### PR TITLE
chore :  mx user home → host directory

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,7 +9,7 @@ services:
       - TZ=Asia/Shanghai
       - NODE_ENV=production
     volumes:
-      - ./data/mx-space:/root/.mx-space
+      - ./data/mx-space:/home/mx/.mx-space
     ports:
       - '2333:2333'
     depends_on:


### PR DESCRIPTION
注意，这里有一个问题，由于 mx 用户的 uid 比较高，所以默认不能对宿主机映射的文件夹进行写操作，需要手动将映射的目录所有权给 uid 1001 的用户，即：将该文件夹归属于给宿主机 uid 为1001 用户即可，Linux管理的是一套UID/GID，不关心这个 uid 在容器内外对应的用户名是啥；当然， 比较简单的做法就是给 ./data/mx-space 赋予 777 权限