### PR TITLE
fix(ci): docker secret

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,4 +5,5 @@ ALLOWED_ORIGINS=innei.ren,www.innei.ren
 
 # must be 64bit
 ENCRYPT_KEY=593f62860255feb0a914534a43814b9809cc7534da7f5485cd2e3d3c8609acab
-ENCRYPT_ENABLE=false
+# not need
+#ENCRYPT_ENABLE=false

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,7 +3,7 @@ version: '3.8'
 services:
   app:
     container_name: mx-server
-    image: timochan/mx-ccore:latest
+    image: innei/mx-server:latest
     command: node index.js --redis_host=redis --db_host=mongo --allowed_origins=${ALLOWED_ORIGINS} --jwt_secret=${JWT_SECRET} --color --encrypt_key=${ENCRYPT_KEY} --encrypt_enable
     environment:
       - TZ=Asia/Shanghai

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,8 +3,8 @@ version: '3.8'
 services:
   app:
     container_name: mx-server
-    image: innei/mx-server:latest
-    command: node index.js --redis_host=redis --db_host=mongo --allowed_origins=${ALLOWED_ORIGINS} --jwt_secret=${JWT_SECRET} --color --encrypt_key=${ENCRYPT_KEY} --encrypt_enable=${ENCRYPT_ENABLE}
+    image: timochan/mx-ccore:latest
+    command: node index.js --redis_host=redis --db_host=mongo --allowed_origins=${ALLOWED_ORIGINS} --jwt_secret=${JWT_SECRET} --color --encrypt_key=${ENCRYPT_KEY} --encrypt_enable
     environment:
       - TZ=Asia/Shanghai
       - NODE_ENV=production


### PR DESCRIPTION
`--encrypt_enable` 在之前的预设中，只要有这个参数，即认为开启加密，移除参数就是关闭加密。在我本地调试来看，并不能接收参数