### PR TITLE
fix: docker-compose command

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,7 +4,7 @@ services:
   app:
     container_name: mx-server
     image: innei/mx-server:latest
-    command: sh ./docker-run.sh
+    command: bash ./docker-run.sh
     environment:
       - TZ=Asia/Shanghai
       - NODE_ENV=production
@@ -26,7 +26,13 @@ services:
       - app-network
     restart: always
     healthcheck:
-      test: ['CMD', 'curl', '-f', 'http://127.0.0.1:2333/api/v2/ping']
+      test:
+        [
+          'CMD',
+          'curl',
+          '-f',
+          'http://127.0.0.1:2333/api/v2/ping'
+        ]
       interval: 1m30s
       timeout: 30s
       retries: 5


### PR DESCRIPTION
使用了不正确的 SHELL 解释器，导致 SHELL 脚本非预期执行