### PR TITLE
chore: ignore all node_modules

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,6 @@
 # compiled output
 /dist
-/node_modules
+node_modules
 
 # Logs
 logs


### PR DESCRIPTION
<!-- DO NOT INGORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/antfu/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

刚刚 clone 下来的仓库 `pnpm install` 之后 Git 马上就扫描出了一下包下的 `node_modules` 

Before
<img width="419" alt="image" src="https://github.com/mx-space/core/assets/33956589/78f715b8-0d7a-48aa-b517-f4cb12e1eb4d">

After
<img width="408" alt="image" src="https://github.com/mx-space/core/assets/33956589/5373e05c-39d5-4647-9ec3-306dd47b3194">


### Linked Issues


### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
