### PR TITLE
fix: delete file with EXDEV issue

### DIFF
--- a/apps/core/src/modules/file/file.service.ts
+++ b/apps/core/src/modules/file/file.service.ts
@@ -79,8 +79,8 @@ export class FileService {
   async deleteFile(type: FileType, name: string) {
     try {
       const path = this.resolveFilePath(type, name)
-
-      await fs.rename(path, resolve(STATIC_FILE_TRASH_DIR, name))
+      await fs.copyFile(path, resolve(STATIC_FILE_TRASH_DIR, name));
+      await fs.unlink(path);
     } catch (error) {
       this.logger.error('删除文件失败', error)
 


### PR DESCRIPTION
<!--

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

修复由于trash目录和主目录在不同挂在卷下使用fs.rename()导致的EXDEV错误

### Linked Issues
#1761 

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
