### PR TITLE
fix: cleanTempDirectory not remake trash directory

### DIFF
--- a/apps/core/src/processors/helper/helper.cron.service.ts
+++ b/apps/core/src/processors/helper/helper.cron.service.ts
@@ -9,7 +9,7 @@ import { CronExpression } from '@nestjs/schedule'
 import { CronDescription } from '~/common/decorators/cron-description.decorator'
 import { CronOnce } from '~/common/decorators/cron-once.decorator'
 import { RedisKeys } from '~/constants/cache.constant'
-import { LOG_DIR, TEMP_DIR } from '~/constants/path.constant'
+import { LOG_DIR, TEMP_DIR, STATIC_FILE_TRASH_DIR } from '~/constants/path.constant'
 import { AggregateService } from '~/modules/aggregate/aggregate.service'
 import { AnalyzeModel } from '~/modules/analyze/analyze.model'
 import { ConfigsService } from '~/modules/configs/configs.service'
@@ -89,7 +89,7 @@ export class CronService {
   @CronDescription('清理临时文件')
   async cleanTempDirectory() {
     await rm(TEMP_DIR, { recursive: true })
-    mkdirp.sync(TEMP_DIR)
+    mkdirp.sync(STATIC_FILE_TRASH_DIR)
     this.logger.log('--> 清理临时文件成功')
   }
   // “At 00:05.”


### PR DESCRIPTION
<!--

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

清理临时文件任务删除了 `TEMP_DIR`路径，但是只重建了`TEMP_DIR` 并没有同时重建`TEMP_DIR/trash`, 导致在后台无法删除文件

### Linked Issues


### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
