### PR TITLE
fix(update): bad credentials when requesting with empty github token

### DIFF
--- a/apps/core/src/modules/update/update.service.ts
+++ b/apps/core/src/modules/update/update.service.ts
@@ -33,7 +33,7 @@ export class UpdateService {
         const result = await this.httpService.axiosRef
           .get(endpoint, {
             headers: {
-              Authorization: githubToken || `Bearer ${githubToken}`,
+              ...(githubToken && { Authorization: `Bearer ${githubToken}` }),
             },
           })
 
@@ -148,7 +148,7 @@ export class UpdateService {
     )
     const res = await this.httpService.axiosRef.get(endpoint, {
       headers: {
-        Authorization: githubToken || `Bearer ${githubToken}`,
+        ...(githubToken && { Authorization: `Bearer ${githubToken}` }),
       },
     })
     return res.data.tag_name.replace(/^v/, '')


### PR DESCRIPTION
<!--

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

当没有配置 GitHub Token 的时候，企图下载 mx-admin 是不可行的

在不配置 Token 的情况下似乎会导致 GitHub Endpoint 返回错误：

<img width="1285" alt="image" src="https://github.com/mx-space/core/assets/62133302/d77cfa01-5e8c-48d4-b947-f995722858c1">

这似乎和 header 中的 Authorization 有关. 在修改逻辑后发现可用了.


### Linked Issues


### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
