### PR TITLE
chore(ci): skip postinstall scripts for some testing-only dependencies

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,6 +55,9 @@ jobs:
   core:
     name: Build (Core)
     runs-on: ubuntu-latest
+    env:
+      REDISMS_DISABLE_POSTINSTALL: 1
+      MONGOMS_DISABLE_POSTINSTALL: 1
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,6 +10,9 @@ jobs:
   build:
     name: Main Build
     runs-on: ubuntu-24.04
+    env:
+      REDISMS_DISABLE_POSTINSTALL: 1
+      MONGOMS_DISABLE_POSTINSTALL: 1
     outputs:
       release_url: ${{ steps.create_release.outputs.upload_url }}
     steps:

--- a/dockerfile
+++ b/dockerfile
@@ -1,4 +1,6 @@
 FROM node:22-alpine as builder
+ENV MONGOMS_DISABLE_POSTINSTALL=1
+ENV REDISMS_DISABLE_POSTINSTALL=1
 WORKDIR /app
 COPY . .
 RUN apk add git make g++ alpine-sdk python3 py3-pip unzip


### PR DESCRIPTION
These postinstall scripts is only used in unit tests. By skipping them we can reduce build time.
![不跳过](https://github.com/user-attachments/assets/833b8be7-17e9-4fa7-9ddd-a6d534f6f6d2)
![跳过](https://github.com/user-attachments/assets/cb07d3f3-8f50-455b-896e-1be8845a170b)

