### PR TITLE
feat(link): convert external friend avatar links to internal links

### DIFF
--- a/apps/core/src/modules/configs/configs.default.ts
+++ b/apps/core/src/modules/configs/configs.default.ts
@@ -43,7 +43,11 @@ export const generateDefaultConfig: () => IConfig = () => ({
     enableComment: true,
     enableThrottleGuard: false,
   },
-  friendLinkOptions: { allowApply: true, allowSubPath: false },
+  friendLinkOptions: {
+    allowApply: true,
+    allowSubPath: false,
+    enableAvatarInternalization: true,
+  },
   backupOptions: {
     enable: true,
     endpoint: null!,

--- a/apps/core/src/modules/configs/configs.dto.ts
+++ b/apps/core/src/modules/configs/configs.dto.ts
@@ -326,6 +326,14 @@ export class FriendLinkOptionsDto {
   @IsOptional()
   @JSONSchemaToggleField('允许子路径友链', { description: '例如 /blog 子路径' })
   allowSubPath: boolean
+
+  @IsBoolean()
+  @IsOptional()
+  @JSONSchemaToggleField('友联头像转内链', {
+    description:
+      '通过审核后将会下载友链头像并改为内部链接，仅支持常见图片格式，其他格式将不会转换',
+  })
+  enableAvatarInternalization: boolean
 }
 
 @JSONSchema({ title: '文本设定' })

--- a/apps/core/src/modules/configs/configs.dto.ts
+++ b/apps/core/src/modules/configs/configs.dto.ts
@@ -329,7 +329,7 @@ export class FriendLinkOptionsDto {
 
   @IsBoolean()
   @IsOptional()
-  @JSONSchemaToggleField('友联头像转内链', {
+  @JSONSchemaToggleField('友链头像转内链', {
     description:
       '通过审核后将会下载友链头像并改为内部链接，仅支持常见图片格式，其他格式将不会转换',
   })

--- a/apps/core/src/modules/link/link-avatar.service.ts
+++ b/apps/core/src/modules/link/link-avatar.service.ts
@@ -1,0 +1,217 @@
+import { Readable } from 'node:stream'
+import { URL } from 'node:url'
+import { nanoid } from '@mx-space/compiled'
+import {
+  BadRequestException,
+  Injectable,
+  Logger,
+  NotFoundException,
+} from '@nestjs/common'
+import type { DocumentType } from '@typegoose/typegoose'
+import { alphabet } from '~/constants/other.constant'
+import { HttpService } from '~/processors/helper/helper.http.service'
+import { InjectModel } from '~/transformers/model.transformer'
+import { validateImageBuffer } from '~/utils/image.util'
+import { ConfigsService } from '../configs/configs.service'
+import { FileService } from '../file/file.service'
+import type { FileType } from '../file/file.type'
+import { LinkModel, LinkState } from './link.model'
+
+const { customAlphabet } = nanoid
+const AVATAR_TYPE: FileType = 'avatar'
+
+const ALLOWED_IMAGE_MIME_TYPES = new Set([
+  'image/jpeg',
+  'image/jpg',
+  'image/png',
+  'image/webp',
+  'image/gif',
+  'image/x-icon',
+])
+
+const ALLOWED_IMAGE_EXTENSIONS = new Set([
+  '.jpg',
+  '.jpeg',
+  '.png',
+  '.webp',
+  '.gif',
+  '.ico',
+])
+
+@Injectable()
+export class LinkAvatarService {
+  private readonly logger: Logger
+
+  constructor(
+    @InjectModel(LinkModel)
+    private readonly linkModel: MongooseModel<LinkModel>,
+    private readonly configsService: ConfigsService,
+    private readonly fileService: FileService,
+    private readonly http: HttpService,
+  ) {
+    this.logger = new Logger(LinkAvatarService.name)
+  }
+
+  async convertToInternal(
+    link: string | DocumentType<LinkModel>,
+  ): Promise<boolean> {
+    const doc =
+      typeof link === 'string' ? await this.linkModel.findById(link) : link
+    if (!doc) {
+      if (typeof link === 'string') {
+        throw new NotFoundException()
+      }
+      return false
+    }
+
+    const avatar = doc.avatar
+    if (!avatar || !this.isExternalAvatar(avatar)) {
+      return false
+    }
+
+    const { url: configUrl, friendLinkOptions } =
+      await this.configsService.waitForConfigReady()
+
+    if (!friendLinkOptions.enableAvatarInternalization) {
+      return false
+    }
+
+    const { webUrl } = configUrl
+
+    const refererHeader = (() => {
+      try {
+        if (doc.url) {
+          return new URL(doc.url).origin
+        }
+      } catch (error: any) {
+        this.logger.warn(
+          `解析友链 ${doc._id} 的站点地址失败: ${error?.message || String(error)}`,
+        )
+      }
+      return webUrl
+    })()
+
+    const response = await this.http.axiosRef.get<ArrayBuffer>(avatar, {
+      responseType: 'arraybuffer',
+      timeout: 10_000,
+      headers: {
+        'user-agent':
+          'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/142.0.0.0 Safari/537.36',
+        referer: refererHeader,
+      },
+    })
+
+    const buffer = Buffer.from(response.data as any)
+    const contentType = (response.headers['content-type'] ||
+      response.headers['Content-Type']) as string | undefined
+    const normalizedContentType = this.normalizeMimeType(contentType)
+
+    if (
+      !normalizedContentType ||
+      !this.isAllowedMimeType(normalizedContentType)
+    ) {
+      this.logger.warn(
+        `友链 ${doc._id} 头像响应类型 ${contentType || 'unknown'} 不在受支持图片范围，跳过内链转换`,
+      )
+      return false
+    }
+
+    const validation = validateImageBuffer({
+      originUrl: avatar,
+      buffer,
+      allowedExtensions: ALLOWED_IMAGE_EXTENSIONS,
+      allowedMimeTypes: ALLOWED_IMAGE_MIME_TYPES,
+    })
+
+    if (!validation.ok) {
+      throw new BadRequestException(validation.reason)
+    }
+
+    const { ext } = validation
+
+    const filename = customAlphabet(alphabet)(18) + ext.toLowerCase()
+
+    await this.fileService.writeFile(
+      AVATAR_TYPE,
+      filename,
+      Readable.from(buffer),
+    )
+
+    const internalUrl = await this.fileService.resolveFileUrl(
+      AVATAR_TYPE,
+      filename,
+    )
+
+    doc.avatar = internalUrl
+    await doc.save()
+
+    this.logger.log(`友链 ${doc._id} 头像已转换为内部链接`)
+
+    return true
+  }
+
+  async migratePassedLinks(): Promise<{
+    updatedCount: number
+    updatedIds: string[]
+  }> {
+    const { friendLinkOptions } = await this.configsService.waitForConfigReady()
+    if (!friendLinkOptions.enableAvatarInternalization) {
+      return {
+        updatedCount: 0,
+        updatedIds: [],
+      }
+    }
+
+    const links = await this.linkModel
+      .find({
+        state: LinkState.Pass,
+        avatar: { $exists: true, $ne: null },
+      })
+      .lean()
+
+    const updatedIds: string[] = []
+
+    for (const link of links) {
+      try {
+        if (this.isExternalAvatar(link.avatar as string)) {
+          const converted = await this.convertToInternal(String(link._id))
+          if (converted) {
+            updatedIds.push(String(link._id))
+          }
+        }
+      } catch (error: any) {
+        this.logger.error(
+          `迁移友链头像失败: ${link._id} - ${error?.message || String(error)}`,
+        )
+      }
+    }
+
+    return {
+      updatedCount: updatedIds.length,
+      updatedIds,
+    }
+  }
+
+  private isExternalAvatar(avatar: string | undefined | null): boolean {
+    if (!avatar) return false
+    try {
+      new URL(avatar)
+    } catch {
+      return false
+    }
+    if (avatar.includes('/objects/avatar/')) {
+      return false
+    }
+
+    return true
+  }
+
+  private normalizeMimeType(mime?: string): string | undefined {
+    if (!mime) return undefined
+    return mime.split(';')[0].trim().toLowerCase()
+  }
+
+  private isAllowedMimeType(mime: string): boolean {
+    return ALLOWED_IMAGE_MIME_TYPES.has(mime)
+  }
+}

--- a/apps/core/src/modules/link/link.controller.ts
+++ b/apps/core/src/modules/link/link.controller.ts
@@ -109,14 +109,17 @@ export class LinkController {
   @Patch('/audit/:id')
   @Auth()
   async approveLink(@Param('id') id: string) {
-    const doc = await this.linkService.approveLink(id)
+    const { link, convertedAvatar } = await this.linkService.approveLink(id)
 
     scheduleManager.schedule(async () => {
-      if (doc.email) {
-        await this.linkService.sendToCandidate(doc)
+      if (link.email) {
+        await this.linkService.sendToCandidate(link as any)
       }
     })
-    return
+    return {
+      link,
+      convertedAvatar,
+    }
   }
 
   @Post('/audit/reason/:id')
@@ -135,5 +138,12 @@ export class LinkController {
   @Get('/health')
   async checkHealth() {
     return this.linkService.checkLinkHealth()
+  }
+
+  /** 批量迁移已通过友链的外部头像为内部链接 */
+  @Post('/avatar/migrate')
+  @Auth()
+  async migrateExternalAvatars() {
+    return this.linkService.migrateExternalAvatarsForPassedLinks()
   }
 }

--- a/apps/core/src/modules/link/link.module.ts
+++ b/apps/core/src/modules/link/link.module.ts
@@ -1,12 +1,14 @@
 import { Module } from '@nestjs/common'
 import { GatewayModule } from '~/processors/gateway/gateway.module'
+import { FileModule } from '../file/file.module'
+import { LinkAvatarService } from './link-avatar.service'
 import { LinkController, LinkControllerCrud } from './link.controller'
 import { LinkService } from './link.service'
 
 @Module({
   controllers: [LinkController, LinkControllerCrud],
-  providers: [LinkService],
+  providers: [LinkService, LinkAvatarService],
   exports: [LinkService],
-  imports: [GatewayModule],
+  imports: [GatewayModule, FileModule],
 })
 export class LinkModule {}

--- a/apps/core/src/utils/image.util.ts
+++ b/apps/core/src/utils/image.util.ts
@@ -101,10 +101,6 @@ export function validateImageBuffer({
       if (urlExt && allowedExtensions && !allowedExtensions.has(urlExt)) {
         return { ok: false, reason: '头像文件后缀不被支持' }
       }
-
-      if (urlExt && urlExt !== ext) {
-        return { ok: false, reason: '头像文件后缀与实际文件类型不一致' }
-      }
     } catch {
       return { ok: false, reason: '头像地址无法解析' }
     }

--- a/apps/core/src/utils/image.util.ts
+++ b/apps/core/src/utils/image.util.ts
@@ -1,0 +1,118 @@
+import path from 'node:path'
+
+export type ImageTypeDetectionResult = { mime: string; ext: string } | null
+
+export type ImageValidationResult =
+  | ({ ok: true } & Required<{ mime: string; ext: string }>)
+  | { ok: false; reason: string }
+
+export const detectImageType = (buffer: Buffer): ImageTypeDetectionResult => {
+  if (buffer.length < 12) return null
+
+  // JPEG
+  if (buffer[0] === 0xff && buffer[1] === 0xd8 && buffer[2] === 0xff) {
+    return { mime: 'image/jpeg', ext: '.jpg' }
+  }
+
+  // PNG
+  if (
+    buffer[0] === 0x89 &&
+    buffer[1] === 0x50 &&
+    buffer[2] === 0x4e &&
+    buffer[3] === 0x47 &&
+    buffer[4] === 0x0d &&
+    buffer[5] === 0x0a &&
+    buffer[6] === 0x1a &&
+    buffer[7] === 0x0a
+  ) {
+    return { mime: 'image/png', ext: '.png' }
+  }
+
+  // GIF
+  if (
+    buffer[0] === 0x47 && // G
+    buffer[1] === 0x49 && // I
+    buffer[2] === 0x46 && // F
+    buffer[3] === 0x38 && // 8
+    (buffer[4] === 0x39 || buffer[4] === 0x37) && // 9 or 7
+    buffer[5] === 0x61 // a
+  ) {
+    return { mime: 'image/gif', ext: '.gif' }
+  }
+
+  // WEBP: RIFF....WEBP
+  if (
+    buffer[0] === 0x52 && // R
+    buffer[1] === 0x49 && // I
+    buffer[2] === 0x46 && // F
+    buffer[3] === 0x46 && // F
+    buffer[8] === 0x57 && // W
+    buffer[9] === 0x45 && // E
+    buffer[10] === 0x42 && // B
+    buffer[11] === 0x50 // P
+  ) {
+    return { mime: 'image/webp', ext: '.webp' }
+  }
+
+  // ICO: 00 00 01 00
+  if (
+    buffer[0] === 0x00 &&
+    buffer[1] === 0x00 &&
+    buffer[2] === 0x01 &&
+    buffer[3] === 0x00
+  ) {
+    return { mime: 'image/x-icon', ext: '.ico' }
+  }
+
+  return null
+}
+
+export function validateImageBuffer({
+  originUrl,
+  buffer,
+  allowedMimeTypes,
+  allowedExtensions,
+}: {
+  originUrl?: string
+  buffer: Buffer
+  contentType?: string
+  allowedMimeTypes?: Set<string>
+  allowedExtensions?: Set<string>
+}): ImageValidationResult {
+  const detected = detectImageType(buffer)
+  if (!detected) {
+    return { ok: false, reason: '不支持的头像图片格式' }
+  }
+
+  const { mime, ext } = detected
+
+  if (allowedMimeTypes && !allowedMimeTypes.has(mime)) {
+    return { ok: false, reason: '头像仅支持上传常见图片格式' }
+  }
+
+  if (allowedExtensions && !allowedExtensions.has(ext)) {
+    return { ok: false, reason: '头像仅支持上传常见图片格式' }
+  }
+
+  if (originUrl) {
+    try {
+      const urlExt = path.extname(new URL(originUrl).pathname).toLowerCase()
+
+      if (urlExt && allowedExtensions && !allowedExtensions.has(urlExt)) {
+        return { ok: false, reason: '头像文件后缀不被支持' }
+      }
+
+      if (urlExt && urlExt !== ext) {
+        return { ok: false, reason: '头像文件后缀与实际文件类型不一致' }
+      }
+    } catch {
+      return { ok: false, reason: '头像地址无法解析' }
+    }
+  }
+
+  return {
+    ok: true,
+    mime,
+    ext,
+  }
+}

--- a/apps/core/test/src/modules/link/link.controller.e2e-spec.ts
+++ b/apps/core/test/src/modules/link/link.controller.e2e-spec.ts
@@ -4,6 +4,8 @@ import { ExtendedValidationPipe } from '~/common/pipes/validation.pipe'
 import { VALIDATION_PIPE_INJECTION } from '~/constants/system.constant'
 import { OptionModel } from '~/modules/configs/configs.model'
 import { ConfigsService } from '~/modules/configs/configs.service'
+import { FileService } from '~/modules/file/file.service'
+import { LinkAvatarService } from '~/modules/link/link-avatar.service'
 import {
   LinkController,
   LinkControllerCrud,
@@ -24,6 +26,8 @@ describe('Test LinkController(E2E)', async () => {
     providers: [
       ...gatewayProviders,
       LinkService,
+      LinkAvatarService,
+      FileService,
 
       emailProvider,
       HttpService,
@@ -40,7 +44,7 @@ describe('Test LinkController(E2E)', async () => {
     async pourData(modelMap) {
       const linkModel = modelMap.get(LinkModel)
 
-      ;(linkModel.model as ReturnModelType<typeof LinkModel>).create({
+      await (linkModel.model as ReturnModelType<typeof LinkModel>).create({
         url: 'https://innei.in',
         name: 'innei',
         avatar: 'https://innei.in/avatar.png',


### PR DESCRIPTION
Friend link external avatar urls have long been unreliable—they can be hosted anywhere and often become inaccessible. This PR adds an external-to-internal avatar link conversion feature to the Friend Links module, triggered upon approval. It includes necessary file checks and a configuration switch (enableAvatarInternalization) to control the behavior.

Additionally, it provides a batch update API for already-approved entries to convert historical friend avatar links to internal links.

For example: https://www.baidu.com/web.jpg -> https://www.timochan.cn/api/objects/avatar/mfh5w5s1of6uywscbd.jpg