### PR TITLE
feat: 为文章、手记、页面添加密码保护和密码提示功能

### DIFF
--- a/apps/core/src/migration/history.ts
+++ b/apps/core/src/migration/history.ts
@@ -34,6 +34,7 @@ import v10_1_0 from './version/v10.1.0'
 import v10_4_1 from './version/v10.4.1'
 import v10_4_2 from './version/v10.4.2'
 import v10_4_3 from './version/v10.4.3'
+import v11_1_0 from './version/v11.1.0'
 
 export default [
   v200Alpha1,
@@ -72,4 +73,5 @@ export default [
   v10_4_1,
   v10_4_2,
   v10_4_3,
+  v11_1_0,
 ]

--- a/apps/core/src/migration/version/v11.1.0.ts
+++ b/apps/core/src/migration/version/v11.1.0.ts
@@ -1,0 +1,36 @@
+import type { Db } from 'mongodb'
+
+import {
+  NOTE_COLLECTION_NAME,
+  PAGE_COLLECTION_NAME,
+  POST_COLLECTION_NAME,
+} from '~/constants/db.constant'
+
+import { defineMigration } from '../helper'
+
+export default defineMigration(
+  'v11.1.0-add-password-and-passwordHint-fields',
+  async (db: Db) => {
+    const CONTENT_COLLECTIONS = [
+      POST_COLLECTION_NAME,
+      NOTE_COLLECTION_NAME,
+      PAGE_COLLECTION_NAME,
+    ]
+
+    for (const collection of CONTENT_COLLECTIONS) {
+      const col = db.collection(collection)
+
+      // Add password field if it doesn't exist
+      await col.updateMany(
+        { password: { $exists: false } },
+        { $set: { password: null } },
+      )
+
+      // Add passwordHint field if it doesn't exist
+      await col.updateMany(
+        { passwordHint: { $exists: false } },
+        { $set: { passwordHint: null } },
+      )
+    }
+  },
+)

--- a/apps/core/src/modules/note/note.controller.ts
+++ b/apps/core/src/modules/note/note.controller.ts
@@ -467,6 +467,44 @@ export class NoteController {
     return { data, size: data.length }
   }
 
+  @Get('/:nid/password-hint')
+  async getPasswordHintByNid(@Param() params: NidType) {
+    const { nid } = params
+    const note = await this.noteService.model
+      .findOne({ nid })
+      .select('+password')
+      .lean()
+
+    if (!note) {
+      throw new CannotFindException()
+    }
+
+    return {
+      hasPassword: !!note.password,
+      passwordHint: note.passwordHint,
+    }
+  }
+
+  @Get('/:year/:month/:day/:slug/password-hint')
+  async getPasswordHintBySlug(@Param() params: NoteSlugDateParamsDto) {
+    const { year, month, day, slug } = params
+    const note = await this.noteService.findOneByDateAndSlug(
+      year,
+      month,
+      day,
+      slug,
+    )
+
+    if (!note) {
+      throw new CannotFindException()
+    }
+
+    return {
+      hasPassword: !!note.password,
+      passwordHint: note.passwordHint,
+    }
+  }
+
   @Post('/')
   @HTTPDecorators.Idempotence()
   @Auth()

--- a/apps/core/src/modules/note/note.model.ts
+++ b/apps/core/src/modules/note/note.model.ts
@@ -1,10 +1,12 @@
 import { AutoIncrementID } from '@typegoose/auto-increment'
-import { index, modelOptions, plugin, prop } from '@typegoose/typegoose'
 import type { Ref } from '@typegoose/typegoose'
+import { index, modelOptions, plugin, prop } from '@typegoose/typegoose'
+import mongooseAutoPopulate from 'mongoose-autopopulate'
+
 import { NOTE_COLLECTION_NAME } from '~/constants/db.constant'
 import { CountModel } from '~/shared/model/count.model'
 import { WriteBaseModel } from '~/shared/model/write-base.model'
-import mongooseAutoPopulate from 'mongoose-autopopulate'
+
 import { TopicModel } from '../topic/topic.model'
 import { Coordinate } from './models/coordinate.model'
 
@@ -41,6 +43,9 @@ export class NoteModel extends WriteBaseModel {
     type: String,
   })
   password: string | null
+
+  @prop()
+  passwordHint?: string | null
 
   @prop({ type: Date })
   publicAt: Date | null

--- a/apps/core/src/modules/note/note.schema.ts
+++ b/apps/core/src/modules/note/note.schema.ts
@@ -40,6 +40,9 @@ export const NoteSchema = WriteBaseSchema.extend({
   }, z.string().optional()),
   isPublished: z.boolean().default(true).optional(),
   password: zTransformEmptyNull(z.string()).optional(),
+  passwordHint: z
+    .preprocess((val) => (val === '' ? null : val), z.string().nullable())
+    .optional(),
   publicAt: z
     .preprocess(
       (val) => (val ? new Date(val as string | number | Date) : null),
@@ -73,6 +76,10 @@ export const PartialNoteSchema = NoteSchema.extend({
     .optional(),
   meta: z.record(z.string(), z.any()).optional().nullable(),
   isPublished: z.boolean().optional(),
+  password: zTransformEmptyNull(z.string()).optional(),
+  passwordHint: z
+    .preprocess((val) => (val === '' ? null : val), z.string().nullable())
+    .optional(),
   bookmark: z.boolean().optional(),
   images: z.array(ImageSchema).optional(),
 }).partial()

--- a/apps/core/src/modules/page/page.controller.ts
+++ b/apps/core/src/modules/page/page.controller.ts
@@ -138,9 +138,15 @@ export class PageController {
       throw new CannotFindException()
     }
 
+    // 检查密码保护
+    if (!this.pageService.checkPasswordToAccess(page, query.password)) {
+      throw new BizException(ErrorCodeEnum.PostNotFound)
+    }
+
     const translationResult = await this.translationService.translateArticle({
       articleId: page._id?.toString?.() ?? page.id ?? String(page._id),
       targetLang: lang,
+      allowHidden: Boolean(page.password),
       originalData: {
         title: page.title,
         text: page.text,
@@ -148,7 +154,7 @@ export class PageController {
       },
     })
 
-    return applyContentPreference(
+    const resultData = applyContentPreference(
       {
         ...page,
         title: translationResult.title,
@@ -164,6 +170,33 @@ export class PageController {
       },
       query.prefer,
     )
+
+    // 如果有密码，将其替换为 '*'
+    if (resultData.password) {
+      resultData.password = '*'
+    }
+
+    return resultData
+  }
+
+  @Get('/slug/:slug/password-hint')
+  async getPasswordHint(@Param('slug') slug: string) {
+    if (typeof slug !== 'string') {
+      throw new BizException(ErrorCodeEnum.InvalidSlug)
+    }
+    const page = await this.pageService.model
+      .findOne({ slug })
+      .lean({ getters: true })
+
+    if (!page) {
+      throw new CannotFindException()
+    }
+
+    // 只返回密码提示，不返回其他内容
+    return {
+      hasPassword: !!page.password,
+      passwordHint: page.passwordHint,
+    }
   }
 
   @Post('/')

--- a/apps/core/src/modules/page/page.model.ts
+++ b/apps/core/src/modules/page/page.model.ts
@@ -1,4 +1,5 @@
 import { modelOptions, prop } from '@typegoose/typegoose'
+
 import { PAGE_COLLECTION_NAME } from '~/constants/db.constant'
 import { WriteBaseModel } from '~/shared/model/write-base.model'
 
@@ -13,6 +14,15 @@ export class PageModel extends WriteBaseModel {
 
   @prop({ trim: true, type: String })
   subtitle?: string | null
+
+  @prop({
+    select: false,
+    type: String,
+  })
+  password: string | null
+
+  @prop()
+  passwordHint?: string | null
 
   @prop({ default: 1 })
   order!: number

--- a/apps/core/src/modules/page/page.schema.ts
+++ b/apps/core/src/modules/page/page.schema.ts
@@ -1,7 +1,13 @@
 import { createZodDto } from 'nestjs-zod'
 import { z } from 'zod'
 
-import { zCoerceInt, zMongoId, zNonEmptyString, zPrefer } from '~/common/zod'
+import {
+  zCoerceInt,
+  zMongoId,
+  zNonEmptyString,
+  zPrefer,
+  zTransformEmptyNull,
+} from '~/common/zod'
 import { WriteBaseSchema } from '~/shared/schema'
 import { ImageSchema } from '~/shared/schema/image.schema'
 import { ContentFormat } from '~/shared/types/content-format.type'
@@ -12,6 +18,10 @@ import { ContentFormat } from '~/shared/types/content-format.type'
 export const PageSchema = WriteBaseSchema.extend({
   slug: zNonEmptyString,
   subtitle: z.string().nullable().optional(),
+  password: zTransformEmptyNull(z.string()).optional(),
+  passwordHint: z
+    .preprocess((val) => (val === '' ? null : val), z.string().nullable())
+    .optional(),
   order: z.preprocess(
     (val) =>
       typeof val === 'string' ? Number.parseInt(val, 10) : (val as number),
@@ -33,6 +43,10 @@ export const PartialPageSchema = PageSchema.extend({
     .enum([ContentFormat.Markdown, ContentFormat.Lexical])
     .optional(),
   meta: z.record(z.string(), z.any()).optional().nullable(),
+  password: zTransformEmptyNull(z.string()).optional(),
+  passwordHint: z
+    .preprocess((val) => (val === '' ? null : val), z.string().nullable())
+    .optional(),
   order: z.preprocess(
     (val) =>
       typeof val === 'string' ? Number.parseInt(val, 10) : (val as number),

--- a/apps/core/src/modules/page/page.schema.ts
+++ b/apps/core/src/modules/page/page.schema.ts
@@ -77,6 +77,7 @@ export class PageReorderDto extends createZodDto(PageReorderSchema) {}
  * Page detail query schema
  */
 export const PageDetailQuerySchema = z.object({
+  password: zNonEmptyString.optional(),
   prefer: zPrefer,
 })
 

--- a/apps/core/src/modules/page/page.service.ts
+++ b/apps/core/src/modules/page/page.service.ts
@@ -104,6 +104,19 @@ export class PageService {
     return res
   }
 
+  checkPasswordToAccess<T extends PageModel>(
+    doc: T,
+    password?: string,
+  ): boolean {
+    if (!doc.password) {
+      return true
+    }
+    if (!password) {
+      return false
+    }
+    return Object.is(password, doc.password)
+  }
+
   public async updateById(
     id: string,
     doc: Partial<PageModel> & { draftId?: string },

--- a/apps/core/src/modules/post/post.controller.ts
+++ b/apps/core/src/modules/post/post.controller.ts
@@ -18,7 +18,9 @@ import { IpLocation } from '~/common/decorators/ip.decorator'
 import { Lang } from '~/common/decorators/lang.decorator'
 import { IsAuthenticated } from '~/common/decorators/role.decorator'
 import { TranslateFields } from '~/common/decorators/translate-fields.decorator'
+import { BizException } from '~/common/exceptions/biz.exception'
 import { CannotFindException } from '~/common/exceptions/cant-find.exception'
+import { ErrorCodeEnum } from '~/constants/error-code.constant'
 import { CountingService } from '~/processors/helper/helper.counting.service'
 import {
   type ArticleTranslationInput,
@@ -311,6 +313,7 @@ export class PostController {
     @Lang() lang?: string,
   ) {
     const { category, slug } = params
+    const { password } = query
     const postDocument = await this.postService.getPostBySlug(
       category,
       slug,
@@ -325,6 +328,14 @@ export class PostController {
       throw new CannotFindException()
     }
 
+    // 检查密码保护
+    if (
+      !this.postService.checkPasswordToAccess(postDocument, password) &&
+      !isAuthenticated
+    ) {
+      throw new BizException(ErrorCodeEnum.PostNotFound)
+    }
+
     const liked = await this.countingService.getThisRecordIsLiked(
       postDocument.id,
       ip,
@@ -334,7 +345,7 @@ export class PostController {
     const translationResult = await this.translationService.translateArticle({
       articleId: postDocument.id,
       targetLang: lang,
-      allowHidden: Boolean(isAuthenticated),
+      allowHidden: Boolean(isAuthenticated || postDocument.password),
       originalData: {
         title: baseData.title,
         text: baseData.text,
@@ -343,7 +354,7 @@ export class PostController {
       },
     })
 
-    return applyContentPreference(
+    const resultData = applyContentPreference(
       {
         ...baseData,
         title: translationResult.title,
@@ -361,6 +372,28 @@ export class PostController {
       },
       query.prefer,
     )
+
+    // 如果有密码，将其替换为 '*'
+    if (resultData.password) {
+      resultData.password = '*'
+    }
+
+    return resultData
+  }
+
+  @Get('/:category/:slug/password-hint')
+  async getPasswordHint(@Param() params: CategoryAndSlugDto) {
+    const { category, slug } = params
+    const postDocument = await this.postService.getPostBySlug(category, slug)
+    if (!postDocument) {
+      throw new CannotFindException()
+    }
+
+    // 只返回密码提示，不返回其他内容
+    return {
+      hasPassword: !!postDocument.password,
+      passwordHint: postDocument.passwordHint,
+    }
   }
 
   @Post('/')

--- a/apps/core/src/modules/post/post.model.ts
+++ b/apps/core/src/modules/post/post.model.ts
@@ -1,3 +1,4 @@
+import type { Ref } from '@typegoose/typegoose'
 import {
   index,
   modelOptions,
@@ -5,14 +6,15 @@ import {
   prop,
   Severity,
 } from '@typegoose/typegoose'
-import type { Ref } from '@typegoose/typegoose'
+import { Types } from 'mongoose'
+import aggregatePaginate from 'mongoose-aggregate-paginate-v2'
+import mongooseAutoPopulate from 'mongoose-autopopulate'
+
 import { POST_COLLECTION_NAME } from '~/constants/db.constant'
 import { Paginator } from '~/shared/interface/paginator.interface'
 import { CountModel as Count } from '~/shared/model/count.model'
 import { WriteBaseModel } from '~/shared/model/write-base.model'
-import { Types } from 'mongoose'
-import aggregatePaginate from 'mongoose-aggregate-paginate-v2'
-import mongooseAutoPopulate from 'mongoose-autopopulate'
+
 import { CategoryModel as Category } from '../category/category.model'
 
 @plugin(aggregatePaginate)
@@ -46,6 +48,15 @@ export class PostModel extends WriteBaseModel {
 
   @prop({ default: true })
   isPublished?: boolean
+
+  @prop({
+    select: false,
+    type: String,
+  })
+  password: string | null
+
+  @prop()
+  passwordHint?: string | null
 
   @prop({ type: String })
   tags?: string[]

--- a/apps/core/src/modules/post/post.schema.ts
+++ b/apps/core/src/modules/post/post.schema.ts
@@ -9,6 +9,7 @@ import {
   zNonEmptyString,
   zPinDate,
   zPrefer,
+  zTransformEmptyNull,
 } from '~/common/zod'
 import { PagerSchema } from '~/shared/dto/pager.dto'
 import { WriteBaseSchema } from '~/shared/schema'
@@ -26,6 +27,10 @@ export const PostSchema = WriteBaseSchema.extend({
   categoryId: zMongoId,
   copyright: z.boolean().default(true).optional(),
   isPublished: z.boolean().default(true).optional(),
+  password: zTransformEmptyNull(z.string()).optional(),
+  passwordHint: z
+    .preprocess((val) => (val === '' ? null : val), z.string().nullable())
+    .optional(),
   tags: zArrayUnique(z.string().min(1)).optional(),
   pin: zPinDate,
   pinOrder: z.preprocess(
@@ -51,6 +56,10 @@ export const PartialPostSchema = PostSchema.extend({
   meta: z.record(z.string(), z.any()).optional().nullable(),
   copyright: z.boolean().optional(),
   isPublished: z.boolean().optional(),
+  password: zTransformEmptyNull(z.string()).optional(),
+  passwordHint: z
+    .preprocess((val) => (val === '' ? null : val), z.string().nullable())
+    .optional(),
 }).partial()
 
 export class PartialPostDto extends createZodDto(PartialPostSchema) {}

--- a/apps/core/src/modules/post/post.schema.ts
+++ b/apps/core/src/modules/post/post.schema.ts
@@ -83,6 +83,7 @@ export class CategoryAndSlugDto extends createZodDto(CategoryAndSlugSchema) {}
  * Post detail query schema
  */
 export const PostDetailQuerySchema = z.object({
+  password: zNonEmptyString.optional(),
   lang: zLang,
   prefer: zPrefer,
 })

--- a/apps/core/src/modules/post/post.service.ts
+++ b/apps/core/src/modules/post/post.service.ts
@@ -152,6 +152,19 @@ export class PostService implements OnApplicationBootstrap {
     return doc
   }
 
+  checkPasswordToAccess<T extends PostModel>(
+    doc: T,
+    password?: string,
+  ): boolean {
+    if (!doc.password) {
+      return true
+    }
+    if (!password) {
+      return false
+    }
+    return Object.is(password, doc.password)
+  }
+
   private async trackSlugChanges(
     oldDocument: PostModel,
     newDocument: Partial<PostModel>,


### PR DESCRIPTION

**描述**：

实现对博客内容的密码保护机制，允许用户对文章（Post）、手记（Note）和页面（Page）设置密码访问控制。

### 主要改动

**数据模型**
- 为 Post、Note、Page 模型添加 `password` 和 `passwordHint` 字段
- password 字段使用 `@select(false)` 隐藏，提高安全性

**API 验证**
- PostSchema、NoteSchema、PageSchema 添加密码字段验证规则
- DetailQuery Schema 支持 password 参数

**业务逻辑**
- PostService、NoteService、PageService 新增 `checkPasswordToAccess()` 方法
- 获取受保护内容时进行密码验证

**API 端点**
- `GET /:category/:slug?password=xxx` - 获取文章（带密码验证）
- `GET /:category/:slug/password-hint` - 获取文章密码提示
- `GET /slug/:slug?password=xxx` - 获取页面（带密码验证）
- `GET /slug/:slug/password-hint` - 获取页面密码提示
- `GET /:nid/password-hint` - 获取手记密码提示（by nid）
- `GET /:year/:month/:day/:slug/password-hint` - 获取手记密码提示（by 日期）

**数据库迁移**
- v11.1.0.ts - 自动为现有文档添加 password 和 passwordHint 字段

### 功能特性

✓ 密码精确匹配验证  
✓ API 返回时密码字段掩码处理（显示为 `*`）  
✓ 支持可选的密码提示文本  
✓ 未认证用户无法访问受保护内容  
✓ 列表查询时自动过滤受保护的内容