### PR TITLE
fix(ai-summary): allow on-demand generation when auto-generate is disabled

### DIFF
--- a/apps/core/src/modules/ai/ai-summary/ai-summary.service.ts
+++ b/apps/core/src/modules/ai/ai-summary/ai-summary.service.ts
@@ -643,10 +643,8 @@ export class AiSummaryService implements OnModuleInit {
     result: Promise<AISummaryModel>
   }> {
     const aiConfig = await this.configService.get('ai')
-    const shouldGenerate =
-      aiConfig?.enableAutoGenerateSummary && aiConfig.enableSummary
 
-    if (!shouldGenerate) {
+    if (!aiConfig?.enableSummary) {
       throw new BizException(ErrorCodeEnum.AINotEnabled)
     }
 
@@ -687,18 +685,12 @@ export class AiSummaryService implements OnModuleInit {
     }
 
     const aiConfig = await this.configService.get('ai')
-    const shouldGenerate =
-      aiConfig?.enableAutoGenerateSummary && aiConfig.enableSummary
 
-    if (shouldGenerate) {
-      return this.generateSummaryByOpenAI(articleId, lang)
-    }
-
-    if (!aiConfig.enableSummary || !aiConfig.enableAutoGenerateSummary) {
+    if (!aiConfig?.enableSummary) {
       throw new BizException(ErrorCodeEnum.AINotEnabled)
     }
 
-    return null
+    return this.generateSummaryByOpenAI(articleId, lang)
   }
 
   async deleteSummaryByArticleId(articleId: string) {


### PR DESCRIPTION
## Summary

Fixes #2627

按需生成 AI 摘要时不应再受 `enableAutoGenerateSummary` 限制，仅受 `enableSummary` 总开关控制。

## Changes

- `streamSummaryForArticle`（`/article/:id/generate` SSE 流式接口）仅检查 `enableSummary`
- `getOrGenerateSummaryForArticle`（`/article/:id` 公开接口）仅检查 `enableSummary`
- `handleCreateArticle` / `handleUpdateArticle`（文章创建/更新时自动触发）保持原有 `enableAutoGenerateSummary && enableSummary` 双重校验

## Why

`enableAutoGenerateSummary` 应仅控制**自动**行为，不应阻塞用户在前端主动发起的按需生成请求。