### PR TITLE
feat(email): add in-memory send queue with configurable rate limit

### DIFF
--- a/apps/core/src/modules/configs/configs.default.ts
+++ b/apps/core/src/modules/configs/configs.default.ts
@@ -30,6 +30,8 @@ export const generateDefaultConfig: () => IConfig = () => ({
     resend: {
       apiKey: '',
     },
+    rateLimit: 10,
+    retryCount: 3,
   },
   commentOptions: {
     antiSpam: false,

--- a/apps/core/src/modules/configs/configs.schema.ts
+++ b/apps/core/src/modules/configs/configs.schema.ts
@@ -74,6 +74,28 @@ export const MailOptionsSchema = section('邮件通知设置', {
   }),
   smtp: SmtpConfigSchema,
   resend: ResendConfigSchema,
+  rateLimit: field.number(
+    z.preprocess(
+      (val) => (val ? Number(val) : val),
+      z.number().int().min(1).max(1000).optional(),
+    ),
+    '发送速率限制',
+    {
+      description: '每秒最大发送次数，默认 10',
+      'ui:options': { halfGrid: true },
+    },
+  ),
+  retryCount: field.number(
+    z.preprocess(
+      (val) => (val ? Number(val) : val),
+      z.number().int().min(0).max(10).optional(),
+    ),
+    '发送失败重试次数',
+    {
+      description: '发送失败后的最大重试次数，默认 3',
+      'ui:options': { halfGrid: true },
+    },
+  ),
 })
 export class MailOptionsDto extends createZodDto(MailOptionsSchema) {}
 export type MailOptionsConfig = z.infer<typeof MailOptionsSchema>

--- a/apps/core/src/processors/helper/helper.email.service.ts
+++ b/apps/core/src/processors/helper/helper.email.service.ts
@@ -14,6 +14,7 @@ import {
   ConfigVersionScopes,
   ConfigVersionService,
 } from '~/processors/redis/config-version.service'
+import { sleep } from '~/utils/tool.util'
 
 import { AssetService } from './helper.asset.service'
 
@@ -32,6 +33,14 @@ export class EmailService implements OnModuleInit, OnModuleDestroy {
   private refreshPromise?: Promise<void>
   private appliedMailVersion = 0
   private mailConfigSynced = false
+  private pendingQueue: Array<{
+    options: Mail.Options
+    resolve: (value: any) => void
+    reject: (reason: any) => void
+    attempts: number
+  }> = []
+  private isProcessingQueue = false
+  private lastSendTime = 0
   constructor(
     private readonly configsService: ConfigsService,
     private readonly assetService: AssetService,
@@ -244,11 +253,10 @@ export class EmailService implements OnModuleInit, OnModuleDestroy {
   }
 
   async sendTestEmail() {
-    await this.ensureMailTransportFresh()
     const owner = await this.ownerService.getOwner()
     const mailOptions = await this.configsService.get('mailOptions')
     const senderEmail = mailOptions.from || mailOptions.smtp?.user
-    return this.instance?.sendMail({
+    return this.send({
       from: `"Mx Space" <${senderEmail}>`,
       to: owner.mail,
       subject: '测试邮件',
@@ -261,15 +269,59 @@ export class EmailService implements OnModuleInit, OnModuleDestroy {
   }
 
   async send(options: Mail.Options) {
+    return new Promise((resolve, reject) => {
+      this.pendingQueue.push({ options, resolve, reject, attempts: 0 })
+      void this.processQueue()
+    })
+  }
+
+  private async processQueue() {
+    if (this.isProcessingQueue) return
+    this.isProcessingQueue = true
+
     try {
-      await this.ensureMailTransportFresh()
-      if (!this.instance) {
-        throw new Error('邮件服务未初始化')
+      while (this.pendingQueue.length > 0) {
+        const { mailOptions } = await this.configsService.waitForConfigReady()
+        const rateLimit = mailOptions.rateLimit ?? 10
+        const minIntervalMs = 1000 / rateLimit
+
+        const now = Date.now()
+        const waitTime = this.lastSendTime + minIntervalMs - now
+        if (waitTime > 0) {
+          await sleep(waitTime)
+        }
+
+        const item = this.pendingQueue.shift()
+        if (!item) continue
+
+        try {
+          await this.ensureMailTransportFresh()
+          if (!this.instance) {
+            throw new Error('邮件服务未初始化')
+          }
+          const result = await this.instance.sendMail(item.options)
+          this.lastSendTime = Date.now()
+          item.resolve(result)
+        } catch (error) {
+          this.lastSendTime = Date.now()
+          const maxRetry = mailOptions.retryCount ?? 3
+          if (item.attempts < maxRetry) {
+            item.attempts++
+            this.logger.warn(
+              `邮件发送失败，第 ${item.attempts} 次重试: ${error instanceof Error ? error.message : String(error)}`,
+            )
+            await sleep(1000 * item.attempts)
+            this.pendingQueue.push(item)
+            continue
+          }
+          this.logger.warn(
+            error instanceof Error ? error.message : String(error),
+          )
+          item.reject(new BizException('邮件发送失败'))
+        }
       }
-      return await this.instance.sendMail(options)
-    } catch (error) {
-      this.logger.warn(error.message)
-      throw new BizException('邮件发送失败')
+    } finally {
+      this.isProcessingQueue = false
     }
   }
 


### PR DESCRIPTION
## Summary

为邮件服务添加内存发送队列与可配置 rate limit。

- `mailOptions` 新增 `rateLimit` 配置项，默认 10 次/秒，范围 1-1000。
- `EmailService.send()` 改为排队机制：请求入队后按速率限制逐条发送，调用方阻塞等待直至发送完成。
- `sendTestEmail()` 统一走 `send()` 队列，避免绕开限流。

## Changes

- `configs.schema.ts`: `MailOptionsSchema` 增加 `rateLimit` 字段
- `configs.default.ts`: 默认值设为 `10`
- `helper.email.service.ts`: 引入 `pendingQueue` + `processQueue()` 实现 token-bucket-like 限流

## Test Plan

- [x] `pnpm typecheck` 通过
- [x] `pnpm test` 通过（893 tests）