### PR TITLE
chore(deps): bump @haklex/rich-headless to 0.0.109

### DIFF
--- a/apps/core/package.json
+++ b/apps/core/package.json
@@ -63,7 +63,7 @@
     "@fastify/cookie": "11.0.2",
     "@fastify/multipart": "10.0.0",
     "@fastify/static": "9.1.1",
-    "@haklex/rich-headless": "0.0.108",
+    "@haklex/rich-headless": "0.0.109",
     "@innei/next-async": "0.4.0",
     "@innei/pretty-logger-nestjs": "0.4.2",
     "@keyv/redis": "5.1.6",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -110,8 +110,8 @@ importers:
         specifier: 9.1.1
         version: 9.1.1
       '@haklex/rich-headless':
-        specifier: 0.0.108
-        version: 0.0.108(lexical@0.43.0)
+        specifier: 0.0.109
+        version: 0.0.109(lexical@0.43.0)
       '@innei/next-async':
         specifier: 0.4.0
         version: 0.4.0
@@ -1188,8 +1188,8 @@ packages:
   '@fastify/static@9.1.1':
     resolution: {integrity: sha512-LHxFea3qdwe0Pbbkh/yux7/k6nFNLGTNcbLKVYgmRDB6LdDE/8TFSO7qWZ0IzM/nF6iwR8W03oFlwe4v79R1Ow==}
 
-  '@haklex/rich-headless@0.0.108':
-    resolution: {integrity: sha512-fNMAFegbd1VFv3KTcrcHpYC/3xUxKlLOuYetQhElsxfDmhobfNabcCWFtv1/Ox7ViF9ERpWQbM1NrXOX2jslGg==}
+  '@haklex/rich-headless@0.0.109':
+    resolution: {integrity: sha512-Pb17+sLf+jziCJmYEfsWK4vMikY4KfwH3EjLBDjXUPc1BQz++H8O/30jXAif1uvlcT2PdmmRP6ueM5QUNw+c/g==}
     peerDependencies:
       lexical: ^0.43.0
 
@@ -8053,7 +8053,7 @@ snapshots:
       fastq: 1.20.1
       glob: 13.0.6
 
-  '@haklex/rich-headless@0.0.108(lexical@0.43.0)':
+  '@haklex/rich-headless@0.0.109(lexical@0.43.0)':
     dependencies:
       '@lexical/code-core': 0.43.0
       '@lexical/extension': 0.43.0


### PR DESCRIPTION
## Summary
Bump @haklex/rich-headless from 0.0.108 → 0.0.109.

## Upstream changes
- fix(agent): compact diff renderer and delete action bar overlay

## Bump level
patch (no public API changes). rich-headless itself had no source changes this cycle; bump is for version alignment across the monorepo.