### PR TITLE
fix: address code review findings from PR #2659

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -163,3 +163,4 @@ jobs:
           PG_USER: mx
           PG_PASSWORD: mx
           PG_DATABASE: mx_core
+          MIGRATIONS_DIR: ${{ github.workspace }}/apps/core/src/database/migrations

--- a/apps/core/scripts/migrate-mongo-to-postgres.ts
+++ b/apps/core/scripts/migrate-mongo-to-postgres.ts
@@ -72,7 +72,8 @@ async function main() {
 
   if (mode === 'apply') {
     const migrationsFolder = path.resolve(
-      process.cwd(),
+      import.meta.dirname,
+      '..',
       'src',
       'database',
       'migrations',

--- a/apps/core/src/database/migrations/0000_initial.sql
+++ b/apps/core/src/database/migrations/0000_initial.sql
@@ -416,7 +416,7 @@ CREATE TABLE "file_references" (
 	"uploaded_by" text,
 	"mime_type" text,
 	"byte_size" bigint,
-	"detached_at" timestamp
+	"detached_at" timestamptz
 );
 --> statement-breakpoint
 CREATE TABLE "links" (

--- a/apps/core/src/database/migrations/meta/0000_snapshot.json
+++ b/apps/core/src/database/migrations/meta/0000_snapshot.json
@@ -3701,7 +3701,7 @@
         },
         "detached_at": {
           "name": "detached_at",
-          "type": "timestamp",
+          "type": "timestamptz",
           "primaryKey": false,
           "notNull": false
         }

--- a/apps/core/src/database/schema/ops.ts
+++ b/apps/core/src/database/schema/ops.ts
@@ -7,7 +7,6 @@ import {
   jsonb,
   pgTable,
   text,
-  timestamp,
   uniqueIndex,
 } from 'drizzle-orm/pg-core'
 
@@ -179,7 +178,7 @@ export const fileReferences = pgTable(
     uploadedBy: text('uploaded_by'),
     mimeType: text('mime_type'),
     byteSize: bigint('byte_size', { mode: 'number' }),
-    detachedAt: timestamp('detached_at', { withTimezone: false, mode: 'date' }),
+    detachedAt: tsCol('detached_at'),
   },
   (table) => [
     index('file_references_file_url_idx').on(table.fileUrl),

--- a/apps/core/src/migration/postgres-data-migration/steps.ts
+++ b/apps/core/src/migration/postgres-data-migration/steps.ts
@@ -50,10 +50,16 @@ const upsert = async <T extends Record<string, unknown>>(
 ) => {
   if (ctx.mode !== 'apply' || rows.length === 0) return
   const chunkSize = 200
+  let inserted = 0
   for (let i = 0; i < rows.length; i += chunkSize) {
     const chunk = rows.slice(i, i + chunkSize)
     try {
-      await ctx.pg.insert(table).values(chunk).onConflictDoNothing()
+      const result = await ctx.pg
+        .insert(table)
+        .values(chunk)
+        .onConflictDoNothing()
+        .returning({ id: (table as any).id })
+      inserted += result.length
     } catch (err) {
       ctx.reports.warnings.push({
         collection:
@@ -62,6 +68,16 @@ const upsert = async <T extends Record<string, unknown>>(
         reason: (err as Error).message,
       })
     }
+  }
+  const skipped = rows.length - inserted
+  if (skipped > 0) {
+    const name =
+      table[Symbol.for('drizzle:Name') as any]?.toString() ?? 'unknown'
+    ctx.reports.warnings.push({
+      collection: name,
+      mongoId: `${skipped}/${rows.length} rows`,
+      reason: `skipped (conflict) — re-run detected existing rows`,
+    })
   }
 }
 

--- a/apps/core/src/modules/ai/ai-writer/ai-slug-backfill.service.ts
+++ b/apps/core/src/modules/ai/ai-writer/ai-slug-backfill.service.ts
@@ -52,7 +52,6 @@ export class AiSlugBackfillService implements OnModuleInit {
     const notes = (await this.noteService.findRecent(limit > 0 ? limit : 100))
       .filter((note) => !note.slug)
       .map((note) => ({
-        _id: note.id,
         id: note.id,
         title: note.title,
         nid: note.nid,

--- a/apps/core/src/modules/auth/auth.implement.ts
+++ b/apps/core/src/modules/auth/auth.implement.ts
@@ -168,7 +168,7 @@ export async function CreateAuth(
               and(
                 eq(authSchema.accounts.userId, userId),
                 eq(authSchema.accounts.providerId, 'credential'),
-              )!,
+              ),
             )
             .limit(1)
 

--- a/apps/core/src/utils/check-init.util.ts
+++ b/apps/core/src/utils/check-init.util.ts
@@ -5,18 +5,25 @@ import {
   applyMigrations,
   createDb,
   createPool,
+  disposePool,
 } from '~/processors/database/postgres.provider'
 
 export const checkInit = async () => {
-  const pool = await createPool()
-  const db = createDb(pool)
-  await applyMigrations(db)
-  const [row] = await db
-    .select({ count: sql<number>`count(*)::int` })
-    .from(readers)
-    .where(eq(readers.role, 'owner'))
+  let pool
+  try {
+    pool = await createPool()
+    const db = createDb(pool)
+    await applyMigrations(db)
+    const [row] = await db
+      .select({ count: sql<number>`count(*)::int` })
+      .from(readers)
+      .where(eq(readers.role, 'owner'))
 
-  const isUserExist = Number(row?.count ?? 0) > 0
+    const isUserExist = Number(row?.count ?? 0) > 0
 
-  return isUserExist
+    return isUserExist
+  } catch (err) {
+    await disposePool()
+    throw err
+  }
 }


### PR DESCRIPTION
## Summary

Address review findings from PR #2659 code review.

### Fixes

1. **file_references.detachedAt timezone** — Unified to timestamptz (was bare timestamp), matching all other timestamp columns. Schema, SQL migration, and snapshot all updated.

2. **checkInit half-initialized state** — Added try/catch with disposePool() cleanup on failure.

3. **Migration CLI silent skip on re-run** — upsert() now tracks inserted vs skipped rows via .returning(). When rows are skipped due to onConflictDoNothing, a warning is reported.

4. **Migration CLI path resolution** — Changed from process.cwd() to import.meta.dirname so the script works regardless of the working directory.

5. **CI test job** — Added missing MIGRATIONS_DIR env var, matching the core job config.

6. **Minor cleanup** — Removed _id leftover in ai-slug-backfill, removed unnecessary ! non-null assertion in auth.implement.ts.