### PR TITLE
feat(enrichment): add screenshot pipeline with browser fetch and storage

### DIFF
--- a/apps/core/src/constants/cache.constant.ts
+++ b/apps/core/src/constants/cache.constant.ts
@@ -32,6 +32,9 @@ export enum RedisKeys {
   AnalyzeAggregate = 'analyze_aggregate',
   AnalyzeTrafficSource = 'analyze_traffic_source',
   AnalyzeDeviceDistribution = 'analyze_device_distribution',
+
+  /** Enrichment 截图 LRU touchAccess 节流 NX 锁 */
+  EnrichmentScreenshotTouch = 'enrichment_screenshot_touch',
 }
 export const API_CACHE_PREFIX = 'mx-api-cache:'
 export enum CacheKeys {

--- a/apps/core/src/database/migrations/0011_enrichment_screenshots.sql
+++ b/apps/core/src/database/migrations/0011_enrichment_screenshots.sql
@@ -1,0 +1,15 @@
+-- migration-lint:allow=no-bare-create-index reason=enrichment_screenshots is a brand-new table, empty at deploy time
+CREATE TABLE IF NOT EXISTS "enrichment_screenshots" (
+	"enrichment_id" text PRIMARY KEY NOT NULL,
+	"object_key" text NOT NULL,
+	"bytes" integer NOT NULL,
+	"width" integer NOT NULL,
+	"height" integer NOT NULL,
+	"blurhash" text,
+	"palette" jsonb,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"last_accessed_at" timestamp with time zone DEFAULT now() NOT NULL,
+	CONSTRAINT "enrichment_screenshots_enrichment_id_enrichment_cache_id_fk" FOREIGN KEY ("enrichment_id") REFERENCES "public"."enrichment_cache"("id") ON DELETE cascade ON UPDATE no action
+);
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "enrichment_screenshots_lru_idx" ON "enrichment_screenshots" USING btree ("last_accessed_at");

--- a/apps/core/src/database/migrations/meta/0011_snapshot.json
+++ b/apps/core/src/database/migrations/meta/0011_snapshot.json
@@ -1,0 +1,5446 @@
+{
+  "id": "0e662dd6-ba86-4161-a21d-e3013f402ac3",
+  "prevId": "2d6c6f3f-bef3-476b-9548-c6bcad13e16f",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.ai_agent_conversations": {
+      "name": "ai_agent_conversations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ref_id": {
+          "name": "ref_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ref_type": {
+          "name": "ref_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "messages": {
+          "name": "messages",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "review_state": {
+          "name": "review_state",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "diff_state": {
+          "name": "diff_state",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "message_count": {
+          "name": "message_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "ai_agent_conversations_ref_idx": {
+          "name": "ai_agent_conversations_ref_idx",
+          "columns": [
+            {
+              "expression": "ref_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "ref_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ai_agent_conversations_updated_at_idx": {
+          "name": "ai_agent_conversations_updated_at_idx",
+          "columns": [
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ai_insights": {
+      "name": "ai_insights",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "ref_id": {
+          "name": "ref_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "lang": {
+          "name": "lang",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "hash": {
+          "name": "hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_translation": {
+          "name": "is_translation",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "source_insights_id": {
+          "name": "source_insights_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_lang": {
+          "name": "source_lang",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "model_info": {
+          "name": "model_info",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "ai_insights_ref_lang_uniq": {
+          "name": "ai_insights_ref_lang_uniq",
+          "columns": [
+            {
+              "expression": "ref_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "lang",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "ai_insights_source_insights_id_ai_insights_id_fk": {
+          "name": "ai_insights_source_insights_id_ai_insights_id_fk",
+          "tableFrom": "ai_insights",
+          "tableTo": "ai_insights",
+          "columnsFrom": [
+            "source_insights_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ai_summaries": {
+      "name": "ai_summaries",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "hash": {
+          "name": "hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "summary": {
+          "name": "summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ref_id": {
+          "name": "ref_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "lang": {
+          "name": "lang",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "ai_summaries_ref_id_idx": {
+          "name": "ai_summaries_ref_id_idx",
+          "columns": [
+            {
+              "expression": "ref_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ai_translations": {
+      "name": "ai_translations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "hash": {
+          "name": "hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ref_id": {
+          "name": "ref_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ref_type": {
+          "name": "ref_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "lang": {
+          "name": "lang",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_lang": {
+          "name": "source_lang",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "text": {
+          "name": "text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subtitle": {
+          "name": "subtitle",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "summary": {
+          "name": "summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tags": {
+          "name": "tags",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::text[]"
+        },
+        "source_modified_at": {
+          "name": "source_modified_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ai_model": {
+          "name": "ai_model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ai_provider": {
+          "name": "ai_provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content_format": {
+          "name": "content_format",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_block_snapshots": {
+          "name": "source_block_snapshots",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_meta_hashes": {
+          "name": "source_meta_hashes",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "ai_translations_ref_lang_uniq": {
+          "name": "ai_translations_ref_lang_uniq",
+          "columns": [
+            {
+              "expression": "ref_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "ref_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "lang",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ai_translations_ref_id_idx": {
+          "name": "ai_translations_ref_id_idx",
+          "columns": [
+            {
+              "expression": "ref_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.translation_entries": {
+      "name": "translation_entries",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "key_path": {
+          "name": "key_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "lang": {
+          "name": "lang",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key_type": {
+          "name": "key_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "lookup_key": {
+          "name": "lookup_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_text": {
+          "name": "source_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "translated_text": {
+          "name": "translated_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_updated_at": {
+          "name": "source_updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "translation_entries_key_uniq": {
+          "name": "translation_entries_key_uniq",
+          "columns": [
+            {
+              "expression": "key_path",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "lang",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "key_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "lookup_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "translation_entries_path_lang_idx": {
+          "name": "translation_entries_path_lang_idx",
+          "columns": [
+            {
+              "expression": "key_path",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "lang",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "translation_entries_lookup_key_idx": {
+          "name": "translation_entries_lookup_key_idx",
+          "columns": [
+            {
+              "expression": "lookup_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.accounts": {
+      "name": "accounts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_account_id": {
+          "name": "provider_account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "raw": {
+          "name": "raw",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "accounts_provider_uniq": {
+          "name": "accounts_provider_uniq",
+          "columns": [
+            {
+              "expression": "provider_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider_account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "accounts_user_id_idx": {
+          "name": "accounts_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "accounts_user_id_readers_id_fk": {
+          "name": "accounts_user_id_readers_id_fk",
+          "tableFrom": "accounts",
+          "tableTo": "readers",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.api_keys": {
+      "name": "api_keys",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reference_id": {
+          "name": "reference_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "config_id": {
+          "name": "config_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "start": {
+          "name": "start",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "prefix": {
+          "name": "prefix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "rate_limit_enabled": {
+          "name": "rate_limit_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "rate_limit_time_window": {
+          "name": "rate_limit_time_window",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rate_limit_max": {
+          "name": "rate_limit_max",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "request_count": {
+          "name": "request_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "remaining": {
+          "name": "remaining",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refill_interval": {
+          "name": "refill_interval",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refill_amount": {
+          "name": "refill_amount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_refill_at": {
+          "name": "last_refill_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_request": {
+          "name": "last_request",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "permissions": {
+          "name": "permissions",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "api_keys_key_uniq": {
+          "name": "api_keys_key_uniq",
+          "columns": [
+            {
+              "expression": "key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "api_keys_user_id_idx": {
+          "name": "api_keys_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "api_keys_user_id_readers_id_fk": {
+          "name": "api_keys_user_id_readers_id_fk",
+          "tableFrom": "api_keys",
+          "tableTo": "readers",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "api_keys_reference_id_readers_id_fk": {
+          "name": "api_keys_reference_id_readers_id_fk",
+          "tableFrom": "api_keys",
+          "tableTo": "readers",
+          "columnsFrom": [
+            "reference_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.owner_profiles": {
+      "name": "owner_profiles",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "reader_id": {
+          "name": "reader_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mail": {
+          "name": "mail",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "introduce": {
+          "name": "introduce",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_login_ip": {
+          "name": "last_login_ip",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_login_time": {
+          "name": "last_login_time",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "social_ids": {
+          "name": "social_ids",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "owner_profiles_reader_id_uniq": {
+          "name": "owner_profiles_reader_id_uniq",
+          "columns": [
+            {
+              "expression": "reader_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "owner_profiles_reader_id_readers_id_fk": {
+          "name": "owner_profiles_reader_id_readers_id_fk",
+          "tableFrom": "owner_profiles",
+          "tableTo": "readers",
+          "columnsFrom": [
+            "reader_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.passkeys": {
+      "name": "passkeys",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "credential_id": {
+          "name": "credential_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "public_key": {
+          "name": "public_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "counter": {
+          "name": "counter",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "device_type": {
+          "name": "device_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "backed_up": {
+          "name": "backed_up",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "transports": {
+          "name": "transports",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "aaguid": {
+          "name": "aaguid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "passkeys_credential_id_uniq": {
+          "name": "passkeys_credential_id_uniq",
+          "columns": [
+            {
+              "expression": "credential_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "passkeys_user_id_idx": {
+          "name": "passkeys_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "passkeys_user_id_readers_id_fk": {
+          "name": "passkeys_user_id_readers_id_fk",
+          "tableFrom": "passkeys",
+          "tableTo": "readers",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.readers": {
+      "name": "readers",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "handle": {
+          "name": "handle",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "username": {
+          "name": "username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "display_username": {
+          "name": "display_username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'reader'"
+        }
+      },
+      "indexes": {
+        "readers_email_uniq": {
+          "name": "readers_email_uniq",
+          "columns": [
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"readers\".\"email\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "readers_username_uniq": {
+          "name": "readers_username_uniq",
+          "columns": [
+            {
+              "expression": "username",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"readers\".\"username\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "readers_role_idx": {
+          "name": "readers_role_idx",
+          "columns": [
+            {
+              "expression": "role",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sessions": {
+      "name": "sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "sessions_token_uniq": {
+          "name": "sessions_token_uniq",
+          "columns": [
+            {
+              "expression": "token",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sessions_user_id_idx": {
+          "name": "sessions_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "sessions_user_id_readers_id_fk": {
+          "name": "sessions_user_id_readers_id_fk",
+          "tableFrom": "sessions",
+          "tableTo": "readers",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verifications": {
+      "name": "verifications",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "verifications_identifier_idx": {
+          "name": "verifications_identifier_idx",
+          "columns": [
+            {
+              "expression": "identifier",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.categories": {
+      "name": "categories",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "categories_name_uniq": {
+          "name": "categories_name_uniq",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "categories_slug_uniq": {
+          "name": "categories_slug_uniq",
+          "columns": [
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.comments": {
+      "name": "comments",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "ref_type": {
+          "name": "ref_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ref_id": {
+          "name": "ref_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "author": {
+          "name": "author",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mail": {
+          "name": "mail",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "text": {
+          "name": "text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "state": {
+          "name": "state",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "parent_comment_id": {
+          "name": "parent_comment_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "root_comment_id": {
+          "name": "root_comment_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reply_count": {
+          "name": "reply_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "latest_reply_at": {
+          "name": "latest_reply_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_deleted": {
+          "name": "is_deleted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ip": {
+          "name": "ip",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "agent": {
+          "name": "agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pin": {
+          "name": "pin",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "location": {
+          "name": "location",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_whispers": {
+          "name": "is_whispers",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "avatar": {
+          "name": "avatar",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "auth_provider": {
+          "name": "auth_provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "meta": {
+          "name": "meta",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reader_id": {
+          "name": "reader_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "edited_at": {
+          "name": "edited_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "anchor": {
+          "name": "anchor",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "comments_thread_idx": {
+          "name": "comments_thread_idx",
+          "columns": [
+            {
+              "expression": "ref_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "ref_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "parent_comment_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "pin",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "comments_root_idx": {
+          "name": "comments_root_idx",
+          "columns": [
+            {
+              "expression": "root_comment_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "comments_reader_idx": {
+          "name": "comments_reader_idx",
+          "columns": [
+            {
+              "expression": "reader_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "comments_parent_comment_id_comments_id_fk": {
+          "name": "comments_parent_comment_id_comments_id_fk",
+          "tableFrom": "comments",
+          "tableTo": "comments",
+          "columnsFrom": [
+            "parent_comment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "comments_root_comment_id_comments_id_fk": {
+          "name": "comments_root_comment_id_comments_id_fk",
+          "tableFrom": "comments",
+          "tableTo": "comments",
+          "columnsFrom": [
+            "root_comment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "comments_reader_id_readers_id_fk": {
+          "name": "comments_reader_id_readers_id_fk",
+          "tableFrom": "comments",
+          "tableTo": "readers",
+          "columnsFrom": [
+            "reader_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.draft_histories": {
+      "name": "draft_histories",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "draft_id": {
+          "name": "draft_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "text": {
+          "name": "text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content_format": {
+          "name": "content_format",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type_specific_data": {
+          "name": "type_specific_data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "saved_at": {
+          "name": "saved_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_full_snapshot": {
+          "name": "is_full_snapshot",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ref_version": {
+          "name": "ref_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "base_version": {
+          "name": "base_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "draft_histories_draft_version_uniq": {
+          "name": "draft_histories_draft_version_uniq",
+          "columns": [
+            {
+              "expression": "draft_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "version",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "draft_histories_draft_id_drafts_id_fk": {
+          "name": "draft_histories_draft_id_drafts_id_fk",
+          "tableFrom": "draft_histories",
+          "tableTo": "drafts",
+          "columnsFrom": [
+            "draft_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.drafts": {
+      "name": "drafts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ref_type": {
+          "name": "ref_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ref_id": {
+          "name": "ref_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "text": {
+          "name": "text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content_format": {
+          "name": "content_format",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "images": {
+          "name": "images",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "meta": {
+          "name": "meta",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type_specific_data": {
+          "name": "type_specific_data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "history": {
+          "name": "history",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "published_version": {
+          "name": "published_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "drafts_ref_idx": {
+          "name": "drafts_ref_idx",
+          "columns": [
+            {
+              "expression": "ref_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "ref_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"drafts\".\"ref_id\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "drafts_updated_at_idx": {
+          "name": "drafts_updated_at_idx",
+          "columns": [
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.notes": {
+      "name": "notes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "nid": {
+          "name": "nid",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "identity": {
+            "type": "byDefault",
+            "name": "notes_nid_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "text": {
+          "name": "text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content_format": {
+          "name": "content_format",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "images": {
+          "name": "images",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "meta": {
+          "name": "meta",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_published": {
+          "name": "is_published",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "public_at": {
+          "name": "public_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mood": {
+          "name": "mood",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "weather": {
+          "name": "weather",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bookmark": {
+          "name": "bookmark",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "coordinates": {
+          "name": "coordinates",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "location": {
+          "name": "location",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "read_count": {
+          "name": "read_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "like_count": {
+          "name": "like_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "topic_id": {
+          "name": "topic_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "modified_at": {
+          "name": "modified_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "notes_nid_uniq": {
+          "name": "notes_nid_uniq",
+          "columns": [
+            {
+              "expression": "nid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "notes_slug_uniq": {
+          "name": "notes_slug_uniq",
+          "columns": [
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"notes\".\"slug\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "notes_nid_desc_idx": {
+          "name": "notes_nid_desc_idx",
+          "columns": [
+            {
+              "expression": "nid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "notes_modified_at_idx": {
+          "name": "notes_modified_at_idx",
+          "columns": [
+            {
+              "expression": "modified_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "notes_created_at_idx": {
+          "name": "notes_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "notes_topic_id_idx": {
+          "name": "notes_topic_id_idx",
+          "columns": [
+            {
+              "expression": "topic_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "notes_topic_id_topics_id_fk": {
+          "name": "notes_topic_id_topics_id_fk",
+          "tableFrom": "notes",
+          "tableTo": "topics",
+          "columnsFrom": [
+            "topic_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pages": {
+      "name": "pages",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subtitle": {
+          "name": "subtitle",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "text": {
+          "name": "text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content_format": {
+          "name": "content_format",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "images": {
+          "name": "images",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "meta": {
+          "name": "meta",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "order": {
+          "name": "order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "modified_at": {
+          "name": "modified_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "pages_slug_uniq": {
+          "name": "pages_slug_uniq",
+          "columns": [
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "pages_order_idx": {
+          "name": "pages_order_idx",
+          "columns": [
+            {
+              "expression": "order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.post_related_posts": {
+      "name": "post_related_posts",
+      "schema": "",
+      "columns": {
+        "post_id": {
+          "name": "post_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "related_post_id": {
+          "name": "related_post_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "post_related_posts_pk": {
+          "name": "post_related_posts_pk",
+          "columns": [
+            {
+              "expression": "post_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "related_post_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "post_related_posts_related_idx": {
+          "name": "post_related_posts_related_idx",
+          "columns": [
+            {
+              "expression": "related_post_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "post_related_posts_post_id_posts_id_fk": {
+          "name": "post_related_posts_post_id_posts_id_fk",
+          "tableFrom": "post_related_posts",
+          "tableTo": "posts",
+          "columnsFrom": [
+            "post_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "post_related_posts_related_post_id_posts_id_fk": {
+          "name": "post_related_posts_related_post_id_posts_id_fk",
+          "tableFrom": "post_related_posts",
+          "tableTo": "posts",
+          "columnsFrom": [
+            "related_post_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.posts": {
+      "name": "posts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "text": {
+          "name": "text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content_format": {
+          "name": "content_format",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "summary": {
+          "name": "summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "images": {
+          "name": "images",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "meta": {
+          "name": "meta",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tags": {
+          "name": "tags",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::text[]"
+        },
+        "modified_at": {
+          "name": "modified_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "category_id": {
+          "name": "category_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "copyright": {
+          "name": "copyright",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "is_published": {
+          "name": "is_published",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "read_count": {
+          "name": "read_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "like_count": {
+          "name": "like_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "pin_at": {
+          "name": "pin_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pin_order": {
+          "name": "pin_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "posts_slug_uniq": {
+          "name": "posts_slug_uniq",
+          "columns": [
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "posts_modified_at_idx": {
+          "name": "posts_modified_at_idx",
+          "columns": [
+            {
+              "expression": "modified_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "posts_created_at_idx": {
+          "name": "posts_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "posts_category_id_idx": {
+          "name": "posts_category_id_idx",
+          "columns": [
+            {
+              "expression": "category_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "posts_category_id_categories_id_fk": {
+          "name": "posts_category_id_categories_id_fk",
+          "tableFrom": "posts",
+          "tableTo": "categories",
+          "columnsFrom": [
+            "category_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.recentlies": {
+      "name": "recentlies",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ref_type": {
+          "name": "ref_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ref_id": {
+          "name": "ref_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "comments_index": {
+          "name": "comments_index",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "allow_comment": {
+          "name": "allow_comment",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "modified_at": {
+          "name": "modified_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "up": {
+          "name": "up",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "down": {
+          "name": "down",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "enrichment_provider": {
+          "name": "enrichment_provider",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "enrichment_external_id": {
+          "name": "enrichment_external_id",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "recentlies_ref_idx": {
+          "name": "recentlies_ref_idx",
+          "columns": [
+            {
+              "expression": "ref_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "ref_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "recentlies_created_at_idx": {
+          "name": "recentlies_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "recentlies_enrichment_idx": {
+          "name": "recentlies_enrichment_idx",
+          "columns": [
+            {
+              "expression": "enrichment_provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "enrichment_external_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.topics": {
+      "name": "topics",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "introduce": {
+          "name": "introduce",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "icon": {
+          "name": "icon",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "topics_name_uniq": {
+          "name": "topics_name_uniq",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "topics_slug_uniq": {
+          "name": "topics_slug_uniq",
+          "columns": [
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.enrichment_cache": {
+      "name": "enrichment_cache",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "external_id": {
+          "name": "external_id",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "locale": {
+          "name": "locale",
+          "type": "varchar(8)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "normalized": {
+          "name": "normalized",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "raw": {
+          "name": "raw",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "fetched_at": {
+          "name": "fetched_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "failure_count": {
+          "name": "failure_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "enrichment_provider_external_id_locale_uniq": {
+          "name": "enrichment_provider_external_id_locale_uniq",
+          "columns": [
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "external_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "locale",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "enrichment_expires_at_idx": {
+          "name": "enrichment_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.enrichment_screenshots": {
+      "name": "enrichment_screenshots",
+      "schema": "",
+      "columns": {
+        "enrichment_id": {
+          "name": "enrichment_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "object_key": {
+          "name": "object_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "bytes": {
+          "name": "bytes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "width": {
+          "name": "width",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "height": {
+          "name": "height",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "blurhash": {
+          "name": "blurhash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "palette": {
+          "name": "palette",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_accessed_at": {
+          "name": "last_accessed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "enrichment_screenshots_lru_idx": {
+          "name": "enrichment_screenshots_lru_idx",
+          "columns": [
+            {
+              "expression": "last_accessed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "enrichment_screenshots_enrichment_id_enrichment_cache_id_fk": {
+          "name": "enrichment_screenshots_enrichment_id_enrichment_cache_id_fk",
+          "tableFrom": "enrichment_screenshots",
+          "tableTo": "enrichment_cache",
+          "columnsFrom": [
+            "enrichment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public._app_migrations": {
+      "name": "_app_migrations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "applied_at": {
+          "name": "applied_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "duration_ms": {
+          "name": "duration_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.auth_id_map": {
+      "name": "auth_id_map",
+      "schema": "",
+      "columns": {
+        "collection": {
+          "name": "collection",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mongo_id": {
+          "name": "mongo_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pg_id": {
+          "name": "pg_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "auth_id_map_collection_mongo_uniq": {
+          "name": "auth_id_map_collection_mongo_uniq",
+          "columns": [
+            {
+              "expression": "collection",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "mongo_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "auth_id_map_collection_pg_uniq": {
+          "name": "auth_id_map_collection_pg_uniq",
+          "columns": [
+            {
+              "expression": "collection",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "pg_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.data_migration_runs": {
+      "name": "data_migration_runs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "finished_at": {
+          "name": "finished_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.mongo_id_map": {
+      "name": "mongo_id_map",
+      "schema": "",
+      "columns": {
+        "collection": {
+          "name": "collection",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mongo_id": {
+          "name": "mongo_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "snowflake_id": {
+          "name": "snowflake_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "mongo_id_map_pk": {
+          "name": "mongo_id_map_pk",
+          "columns": [
+            {
+              "expression": "collection",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "mongo_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "mongo_id_map_snowflake_uniq": {
+          "name": "mongo_id_map_snowflake_uniq",
+          "columns": [
+            {
+              "expression": "snowflake_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.schema_migrations": {
+      "name": "schema_migrations",
+      "schema": "",
+      "columns": {
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "applied_at": {
+          "name": "applied_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.activities": {
+      "name": "activities",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "type": {
+          "name": "type",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "activities_created_at_idx": {
+          "name": "activities_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.analyzes": {
+      "name": "analyzes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ip": {
+          "name": "ip",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ua": {
+          "name": "ua",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "country": {
+          "name": "country",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "path": {
+          "name": "path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "referer": {
+          "name": "referer",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "analyzes_timestamp_idx": {
+          "name": "analyzes_timestamp_idx",
+          "columns": [
+            {
+              "expression": "timestamp",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "analyzes_timestamp_path_idx": {
+          "name": "analyzes_timestamp_path_idx",
+          "columns": [
+            {
+              "expression": "timestamp",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "path",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "analyzes_timestamp_referer_idx": {
+          "name": "analyzes_timestamp_referer_idx",
+          "columns": [
+            {
+              "expression": "timestamp",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "referer",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "analyzes_timestamp_ip_idx": {
+          "name": "analyzes_timestamp_ip_idx",
+          "columns": [
+            {
+              "expression": "timestamp",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "ip",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.file_references": {
+      "name": "file_references",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "file_url": {
+          "name": "file_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "file_name": {
+          "name": "file_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ref_id": {
+          "name": "ref_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ref_type": {
+          "name": "ref_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "s3_object_key": {
+          "name": "s3_object_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reader_id": {
+          "name": "reader_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "uploaded_by": {
+          "name": "uploaded_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mime_type": {
+          "name": "mime_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "byte_size": {
+          "name": "byte_size",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "detached_at": {
+          "name": "detached_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "file_references_file_url_idx": {
+          "name": "file_references_file_url_idx",
+          "columns": [
+            {
+              "expression": "file_url",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "file_references_ref_idx": {
+          "name": "file_references_ref_idx",
+          "columns": [
+            {
+              "expression": "ref_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "ref_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "file_references_status_created_idx": {
+          "name": "file_references_status_created_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "file_references_reader_status_created_idx": {
+          "name": "file_references_reader_status_created_idx",
+          "columns": [
+            {
+              "expression": "reader_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "file_references_status_detached_idx": {
+          "name": "file_references_status_detached_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "detached_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "file_references_reader_id_readers_id_fk": {
+          "name": "file_references_reader_id_readers_id_fk",
+          "tableFrom": "file_references",
+          "tableTo": "readers",
+          "columnsFrom": [
+            "reader_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.links": {
+      "name": "links",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "avatar": {
+          "name": "avatar",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type": {
+          "name": "type",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "state": {
+          "name": "state",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "links_name_uniq": {
+          "name": "links_name_uniq",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "links_url_uniq": {
+          "name": "links_url_uniq",
+          "columns": [
+            {
+              "expression": "url",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.meta_presets": {
+      "name": "meta_presets",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content_type": {
+          "name": "content_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "fields": {
+          "name": "fields",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        }
+      },
+      "indexes": {
+        "meta_presets_name_uniq": {
+          "name": "meta_presets_name_uniq",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.options": {
+      "name": "options",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "options_name_uniq": {
+          "name": "options_name_uniq",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.poll_vote_options": {
+      "name": "poll_vote_options",
+      "schema": "",
+      "columns": {
+        "vote_id": {
+          "name": "vote_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "option_id": {
+          "name": "option_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "poll_vote_options_pk": {
+          "name": "poll_vote_options_pk",
+          "columns": [
+            {
+              "expression": "vote_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "option_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "poll_vote_options_option_idx": {
+          "name": "poll_vote_options_option_idx",
+          "columns": [
+            {
+              "expression": "option_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "poll_vote_options_vote_id_poll_votes_id_fk": {
+          "name": "poll_vote_options_vote_id_poll_votes_id_fk",
+          "tableFrom": "poll_vote_options",
+          "tableTo": "poll_votes",
+          "columnsFrom": [
+            "vote_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.poll_votes": {
+      "name": "poll_votes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "poll_id": {
+          "name": "poll_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "voter_fingerprint": {
+          "name": "voter_fingerprint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "poll_votes_poll_voter_uniq": {
+          "name": "poll_votes_poll_voter_uniq",
+          "columns": [
+            {
+              "expression": "poll_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "voter_fingerprint",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "poll_votes_poll_id_idx": {
+          "name": "poll_votes_poll_id_idx",
+          "columns": [
+            {
+              "expression": "poll_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.projects": {
+      "name": "projects",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "preview_url": {
+          "name": "preview_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "doc_url": {
+          "name": "doc_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "project_url": {
+          "name": "project_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "images": {
+          "name": "images",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "avatar": {
+          "name": "avatar",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "text": {
+          "name": "text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "projects_name_uniq": {
+          "name": "projects_name_uniq",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.says": {
+      "name": "says",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "text": {
+          "name": "text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "author": {
+          "name": "author",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "says_created_at_idx": {
+          "name": "says_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.serverless_logs": {
+      "name": "serverless_logs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "function_id": {
+          "name": "function_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reference": {
+          "name": "reference",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "method": {
+          "name": "method",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ip": {
+          "name": "ip",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "execution_time": {
+          "name": "execution_time",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "logs": {
+          "name": "logs",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error": {
+          "name": "error",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "serverless_logs_created_at_idx": {
+          "name": "serverless_logs_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "serverless_logs_function_idx": {
+          "name": "serverless_logs_function_idx",
+          "columns": [
+            {
+              "expression": "function_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "serverless_logs_reference_idx": {
+          "name": "serverless_logs_reference_idx",
+          "columns": [
+            {
+              "expression": "reference",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.serverless_storages": {
+      "name": "serverless_storages",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "namespace": {
+          "name": "namespace",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "serverless_storages_ns_key_uniq": {
+          "name": "serverless_storages_ns_key_uniq",
+          "columns": [
+            {
+              "expression": "namespace",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.slug_trackers": {
+      "name": "slug_trackers",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_id": {
+          "name": "target_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "slug_trackers_type_target_idx": {
+          "name": "slug_trackers_type_target_idx",
+          "columns": [
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "target_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "slug_trackers_slug_type_idx": {
+          "name": "slug_trackers_slug_type_idx",
+          "columns": [
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.snippets": {
+      "name": "snippets",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "private": {
+          "name": "private",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "raw": {
+          "name": "raw",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reference": {
+          "name": "reference",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'root'"
+        },
+        "comment": {
+          "name": "comment",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metatype": {
+          "name": "metatype",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "schema": {
+          "name": "schema",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "method": {
+          "name": "method",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "custom_path": {
+          "name": "custom_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "secret": {
+          "name": "secret",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "enable": {
+          "name": "enable",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "built_in": {
+          "name": "built_in",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "compiled_code": {
+          "name": "compiled_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "snippets_name_reference_idx": {
+          "name": "snippets_name_reference_idx",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "reference",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "snippets_type_idx": {
+          "name": "snippets_type_idx",
+          "columns": [
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "snippets_custom_path_uniq": {
+          "name": "snippets_custom_path_uniq",
+          "columns": [
+            {
+              "expression": "custom_path",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"snippets\".\"custom_path\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.subscribes": {
+      "name": "subscribes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cancel_token": {
+          "name": "cancel_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subscribe": {
+          "name": "subscribe",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "verified": {
+          "name": "verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {
+        "subscribes_email_uniq": {
+          "name": "subscribes_email_uniq",
+          "columns": [
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "subscribes_cancel_token_uniq": {
+          "name": "subscribes_cancel_token_uniq",
+          "columns": [
+            {
+              "expression": "cancel_token",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.webhook_events": {
+      "name": "webhook_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "headers": {
+          "name": "headers",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "event": {
+          "name": "event",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "response": {
+          "name": "response",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "success": {
+          "name": "success",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hook_id": {
+          "name": "hook_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "webhook_events_hook_id_idx": {
+          "name": "webhook_events_hook_id_idx",
+          "columns": [
+            {
+              "expression": "hook_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "webhook_events_timestamp_idx": {
+          "name": "webhook_events_timestamp_idx",
+          "columns": [
+            {
+              "expression": "timestamp",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "webhook_events_hook_id_webhooks_id_fk": {
+          "name": "webhook_events_hook_id_webhooks_id_fk",
+          "tableFrom": "webhook_events",
+          "tableTo": "webhooks",
+          "columnsFrom": [
+            "hook_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.webhooks": {
+      "name": "webhooks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "payload_url": {
+          "name": "payload_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "events": {
+          "name": "events",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "secret": {
+          "name": "secret",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scope": {
+          "name": "scope",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "webhooks_enabled_idx": {
+          "name": "webhooks_enabled_idx",
+          "columns": [
+            {
+              "expression": "enabled",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.search_documents": {
+      "name": "search_documents",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "ref_type": {
+          "name": "ref_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ref_id": {
+          "name": "ref_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "lang": {
+          "name": "lang",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_hash": {
+          "name": "source_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "search_text": {
+          "name": "search_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "terms": {
+          "name": "terms",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::text[]"
+        },
+        "title_term_freq": {
+          "name": "title_term_freq",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "body_term_freq": {
+          "name": "body_term_freq",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "title_length": {
+          "name": "title_length",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "body_length": {
+          "name": "body_length",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "nid": {
+          "name": "nid",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_published": {
+          "name": "is_published",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "public_at": {
+          "name": "public_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "has_password": {
+          "name": "has_password",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "modified_at": {
+          "name": "modified_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "search_documents_ref_lang_uniq": {
+          "name": "search_documents_ref_lang_uniq",
+          "columns": [
+            {
+              "expression": "ref_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "ref_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "lang",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "search_documents_published_idx": {
+          "name": "search_documents_published_idx",
+          "columns": [
+            {
+              "expression": "is_published",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "public_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "search_documents_lang_idx": {
+          "name": "search_documents_lang_idx",
+          "columns": [
+            {
+              "expression": "lang",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/apps/core/src/database/migrations/meta/_journal.json
+++ b/apps/core/src/database/migrations/meta/_journal.json
@@ -78,6 +78,13 @@
       "when": 1778433600000,
       "tag": "0010_notes_nid_identity",
       "breakpoints": true
+    },
+    {
+      "idx": 11,
+      "version": "7",
+      "when": 1778522427325,
+      "tag": "0011_enrichment_screenshots",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/core/src/modules/configs/configs.default.ts
+++ b/apps/core/src/modules/configs/configs.default.ts
@@ -117,7 +117,19 @@ export const generateDefaultConfig: () => IConfig = () => ({
     leetcode: { enabled: true },
     neteaseMusic: { enabled: true },
     qqMusic: { enabled: true },
-    openGraph: { enabled: true, timeoutMs: 8000, maxBodyBytes: 524_288 },
+    openGraph: {
+      enabled: true,
+      fetchMode: 'fetch',
+      timeoutMs: 8000,
+      maxBodyBytes: 524_288,
+      screenshot: {
+        enabled: false,
+        maxItems: 500,
+        maxTotalBytes: 100 * 1024 * 1024,
+        maxBytesPerImage: 512 * 1024,
+        webpQuality: 75,
+      },
+    },
   },
 
   authSecurity: {

--- a/apps/core/src/modules/configs/configs.schema.ts
+++ b/apps/core/src/modules/configs/configs.schema.ts
@@ -441,14 +441,29 @@ const OpenGraphIntegrationSchema = section('Open Graph / oEmbed 兜底', {
     description:
       '未命中专用 provider 之 URL 抓 Open Graph / oEmbed 元数据作链接卡兜底',
   }),
+  fetchMode: field.select(
+    z.enum(['fetch', 'browser']).optional().default('fetch'),
+    '抓取方式',
+    [
+      { label: 'HTTP 直抓（fetch）', value: 'fetch' },
+      { label: '无头浏览器（agent-browser）', value: 'browser' },
+    ],
+    {
+      description:
+        '默认 HTTP 直抓。遇 Cloudflare / 强反爬站点时切 browser 走 Docker 内置之 chromium 渲染。browser 模式更慢，亦更贵。',
+    },
+  ),
   timeoutMs: field.number(
     z.preprocess(
       (val) =>
         val === '' || val === null || val === undefined ? val : Number(val),
-      z.number().int().min(1000).max(30000).optional(),
+      z.number().int().min(1000).max(60000).optional(),
     ),
     '抓取超时（毫秒）',
-    { description: '默认 8000，区间 1000-30000' },
+    {
+      description:
+        'fetch 模式默认 8000；browser 模式默认 25000。区间 1000-60000',
+    },
   ),
   maxBodyBytes: field.number(
     z.preprocess(
@@ -459,6 +474,57 @@ const OpenGraphIntegrationSchema = section('Open Graph / oEmbed 兜底', {
     '响应大小上限（字节）',
     { description: '默认 524288（512KB），区间 16KB-4MB；仅扫 <head>' },
   ),
+  screenshot: section('截图', {
+    enabled: field.toggle(z.boolean().optional().default(false), '启用截图', {
+      description: 'fetchMode 为 browser 时捕获页面截图。仅 browser 模式生效。',
+    }),
+    maxItems: field.number(
+      z.preprocess(
+        (val) =>
+          val === '' || val === null || val === undefined ? val : Number(val),
+        z.number().int().min(10).max(10_000).optional().default(500),
+      ),
+      '最大缓存数',
+      { description: '默认 500，区间 10-10000' },
+    ),
+    maxTotalBytes: field.number(
+      z.preprocess(
+        (val) =>
+          val === '' || val === null || val === undefined ? val : Number(val),
+        z
+          .number()
+          .int()
+          .min(1024 * 1024)
+          .optional()
+          .default(100 * 1024 * 1024),
+      ),
+      '总存储上限（字节）',
+      { description: '默认 104857600（100MB），下限 1MB' },
+    ),
+    maxBytesPerImage: field.number(
+      z.preprocess(
+        (val) =>
+          val === '' || val === null || val === undefined ? val : Number(val),
+        z
+          .number()
+          .int()
+          .min(1024)
+          .optional()
+          .default(512 * 1024),
+      ),
+      '单图上限（字节）',
+      { description: '默认 524288（512KB），下限 1KB' },
+    ),
+    webpQuality: field.number(
+      z.preprocess(
+        (val) =>
+          val === '' || val === null || val === undefined ? val : Number(val),
+        z.number().int().min(40).max(100).optional().default(75),
+      ),
+      'WebP 质量',
+      { description: '默认 75，区间 40-100' },
+    ),
+  }).optional(),
 })
 
 export const ThirdPartyServiceIntegrationSchema = section('第三方服务集成', {

--- a/apps/core/src/modules/enrichment/enrichment-screenshot.repository.ts
+++ b/apps/core/src/modules/enrichment/enrichment-screenshot.repository.ts
@@ -1,0 +1,143 @@
+import { Inject, Injectable } from '@nestjs/common'
+import { asc, eq, sql } from 'drizzle-orm'
+
+import { PG_DB_TOKEN } from '~/constants/system.constant'
+import {
+  type EnrichmentScreenshotPalette,
+  enrichmentScreenshots,
+} from '~/database/schema'
+import { BaseRepository } from '~/processors/database/base.repository'
+import type { AppDatabase } from '~/processors/database/postgres.provider'
+
+export interface EnrichmentScreenshotRow {
+  enrichmentId: string
+  objectKey: string
+  bytes: number
+  width: number
+  height: number
+  blurhash: string | null
+  palette: EnrichmentScreenshotPalette | null
+  createdAt: Date
+  lastAccessedAt: Date
+}
+
+export interface EnrichmentScreenshotInsert {
+  enrichmentId: string
+  objectKey: string
+  bytes: number
+  width: number
+  height: number
+  blurhash?: string | null
+  palette?: EnrichmentScreenshotPalette | null
+}
+
+@Injectable()
+export class EnrichmentScreenshotRepository extends BaseRepository {
+  constructor(@Inject(PG_DB_TOKEN) db: AppDatabase) {
+    super(db)
+  }
+
+  async findByEnrichmentId(
+    enrichmentId: string,
+  ): Promise<EnrichmentScreenshotRow | null> {
+    const rows = await this.db
+      .select()
+      .from(enrichmentScreenshots)
+      .where(eq(enrichmentScreenshots.enrichmentId, enrichmentId))
+      .limit(1)
+    return rows[0] ? this.mapRow(rows[0]) : null
+  }
+
+  /**
+   * Inserts or replaces the screenshot row for an enrichment.
+   * `last_accessed_at` is set to `now()` on both insert and update — callers
+   * do not need to follow with `touchAccess()`.
+   */
+  async upsert(
+    input: EnrichmentScreenshotInsert,
+  ): Promise<EnrichmentScreenshotRow> {
+    const [row] = await this.db
+      .insert(enrichmentScreenshots)
+      .values({
+        enrichmentId: input.enrichmentId,
+        objectKey: input.objectKey,
+        bytes: input.bytes,
+        width: input.width,
+        height: input.height,
+        blurhash: input.blurhash ?? null,
+        palette: input.palette ?? null,
+      })
+      .onConflictDoUpdate({
+        target: enrichmentScreenshots.enrichmentId,
+        set: {
+          objectKey: sql`excluded.object_key`,
+          bytes: sql`excluded.bytes`,
+          width: sql`excluded.width`,
+          height: sql`excluded.height`,
+          blurhash: sql`excluded.blurhash`,
+          palette: sql`excluded.palette`,
+          lastAccessedAt: sql`now()`,
+        },
+      })
+      .returning()
+    return this.mapRow(row)
+  }
+
+  async deleteByEnrichmentId(enrichmentId: string): Promise<void> {
+    await this.db
+      .delete(enrichmentScreenshots)
+      .where(eq(enrichmentScreenshots.enrichmentId, enrichmentId))
+  }
+
+  /**
+   * Refresh `last_accessed_at` to now. Caller is responsible for throttling
+   * (e.g. Redis NX-EX gate) to avoid write amplification on hot rows.
+   */
+  async touchAccess(enrichmentId: string): Promise<void> {
+    await this.db
+      .update(enrichmentScreenshots)
+      .set({ lastAccessedAt: new Date() })
+      .where(eq(enrichmentScreenshots.enrichmentId, enrichmentId))
+  }
+
+  async getQuotaUsage(): Promise<{ count: number; totalBytes: number }> {
+    const [row] = await this.db
+      .select({
+        count: sql<number>`count(*)`,
+        totalBytes: sql<number>`coalesce(sum(${enrichmentScreenshots.bytes}), 0)`,
+      })
+      .from(enrichmentScreenshots)
+    return {
+      count: Number(row?.count ?? 0),
+      totalBytes: Number(row?.totalBytes ?? 0),
+    }
+  }
+
+  /**
+   * Return the oldest-accessed rows for LRU eviction.
+   */
+  async findOldestByAccess(limit: number): Promise<EnrichmentScreenshotRow[]> {
+    const rows = await this.db
+      .select()
+      .from(enrichmentScreenshots)
+      .orderBy(asc(enrichmentScreenshots.lastAccessedAt))
+      .limit(limit)
+    return rows.map((r) => this.mapRow(r))
+  }
+
+  private mapRow(
+    row: typeof enrichmentScreenshots.$inferSelect,
+  ): EnrichmentScreenshotRow {
+    return {
+      enrichmentId: row.enrichmentId,
+      objectKey: row.objectKey,
+      bytes: row.bytes,
+      width: row.width,
+      height: row.height,
+      blurhash: row.blurhash,
+      palette: row.palette,
+      createdAt: row.createdAt,
+      lastAccessedAt: row.lastAccessedAt,
+    }
+  }
+}

--- a/apps/core/src/modules/enrichment/enrichment.controller.ts
+++ b/apps/core/src/modules/enrichment/enrichment.controller.ts
@@ -21,12 +21,16 @@ import { EnrichmentService } from './enrichment.service'
 import type { EnrichmentResult, ProviderMeta } from './enrichment.types'
 import { ProviderDisabledError, TokenMissingError } from './enrichment.types'
 import { EnrichmentOriginGuard } from './enrichment-origin.guard'
+import { ScreenshotStorageService } from './providers/open-graph/screenshot-storage.service'
 
 const PUBLIC_RESOLVE_THROTTLE = { default: { limit: 30, ttl: 60_000 } }
 
 @ApiController('enrichment')
 export class EnrichmentController {
-  constructor(private readonly enrichmentService: EnrichmentService) {}
+  constructor(
+    private readonly enrichmentService: EnrichmentService,
+    private readonly screenshotStorage: ScreenshotStorageService,
+  ) {}
 
   @Get('resolve')
   @Throttle(PUBLIC_RESOLVE_THROTTLE)
@@ -47,6 +51,7 @@ export class EnrichmentController {
         // `@Res({ passthrough: true })` adapter object.
         res.header('X-Enrichment-Stale', 'true')
       }
+      this.bumpScreenshotAccess(result)
       return result
     } catch (error) {
       // Provider not configured / token missing is a "no data" case, not an
@@ -72,7 +77,21 @@ export class EnrichmentController {
     @Lang() lang: string | undefined,
   ): Promise<EnrichmentResult> {
     const id = decodeURIComponent((req.params as Record<string, string>)['*'])
-    return this.enrichmentService.getOne(provider, id, lang)
+    const result = await this.enrichmentService.getOne(provider, id, lang)
+    this.bumpScreenshotAccess(result)
+    return result
+  }
+
+  /**
+   * Fire-and-forget LRU touch. The throttle (Redis NX-EX 3600s) lives inside
+   * the storage service, so hot URLs do not write per-request. Failure is
+   * swallowed to keep the hot path free of screenshot-storage faults.
+   */
+  private bumpScreenshotAccess(result: EnrichmentResult | undefined): void {
+    if (!result?.screenshot || !result.id) return
+    this.screenshotStorage.touchAccess(result.id).catch(() => {
+      // ignored — storage logs internally
+    })
   }
 
   @Get('admin/list')

--- a/apps/core/src/modules/enrichment/enrichment.module.ts
+++ b/apps/core/src/modules/enrichment/enrichment.module.ts
@@ -6,6 +6,7 @@ import { EnrichmentController } from './enrichment.controller'
 import { EnrichmentRepository } from './enrichment.repository'
 import { EnrichmentService } from './enrichment.service'
 import { EnrichmentOriginGuard } from './enrichment-origin.guard'
+import { EnrichmentScreenshotRepository } from './enrichment-screenshot.repository'
 import { ArxivProvider } from './providers/arxiv/arxiv.provider'
 import { BangumiProvider } from './providers/bangumi/bangumi.provider'
 // Providers
@@ -18,7 +19,10 @@ import { GitHubRepoProvider } from './providers/github/github-repo.provider'
 import { LeetcodeProvider } from './providers/leetcode/leetcode.provider'
 import { NeoDBBookProvider } from './providers/neodb/neodb-book.provider'
 import { NeteaseMusicProvider } from './providers/netease/netease-music.provider'
+import { BrowserFetchService } from './providers/open-graph/browser-fetch.service'
 import { OpenGraphProvider } from './providers/open-graph/open-graph.provider'
+import { ScreenshotPipelineService } from './providers/open-graph/screenshot-pipeline.service'
+import { ScreenshotStorageService } from './providers/open-graph/screenshot-storage.service'
 import type { EnrichmentProvider } from './providers/provider.interface'
 import { ProviderRegistry } from './providers/provider.registry'
 import { QQMusicProvider } from './providers/qq/qq-music.provider'
@@ -55,10 +59,14 @@ const allProviders = [
   controllers: [EnrichmentController],
   providers: [
     EnrichmentRepository,
+    EnrichmentScreenshotRepository,
     EnrichmentService,
     ProviderRegistry,
     UrlExtractorService,
     EnrichmentOriginGuard,
+    BrowserFetchService,
+    ScreenshotPipelineService,
+    ScreenshotStorageService,
     ...allProviders,
   ],
   exports: [EnrichmentService, UrlExtractorService],

--- a/apps/core/src/modules/enrichment/enrichment.module.ts
+++ b/apps/core/src/modules/enrichment/enrichment.module.ts
@@ -20,6 +20,7 @@ import { LeetcodeProvider } from './providers/leetcode/leetcode.provider'
 import { NeoDBBookProvider } from './providers/neodb/neodb-book.provider'
 import { NeteaseMusicProvider } from './providers/netease/netease-music.provider'
 import { BrowserFetchService } from './providers/open-graph/browser-fetch.service'
+import { BrowserSessionPool } from './providers/open-graph/browser-session-pool'
 import { OpenGraphProvider } from './providers/open-graph/open-graph.provider'
 import { ScreenshotPipelineService } from './providers/open-graph/screenshot-pipeline.service'
 import { ScreenshotStorageService } from './providers/open-graph/screenshot-storage.service'
@@ -64,6 +65,7 @@ const allProviders = [
     ProviderRegistry,
     UrlExtractorService,
     EnrichmentOriginGuard,
+    BrowserSessionPool,
     BrowserFetchService,
     ScreenshotPipelineService,
     ScreenshotStorageService,

--- a/apps/core/src/modules/enrichment/enrichment.repository.ts
+++ b/apps/core/src/modules/enrichment/enrichment.repository.ts
@@ -1,4 +1,4 @@
-import { Inject, Injectable } from '@nestjs/common'
+import { Inject, Injectable, Logger } from '@nestjs/common'
 import { and, eq, gt, inArray, or, sql } from 'drizzle-orm'
 
 import { PG_DB_TOKEN } from '~/constants/system.constant'
@@ -7,10 +7,16 @@ import { BaseRepository } from '~/processors/database/base.repository'
 import type { AppDatabase } from '~/processors/database/postgres.provider'
 import { SnowflakeService } from '~/shared/id/snowflake.service'
 
-import type { EnrichmentResult, EnrichmentRow } from './enrichment.types'
+import type {
+  EnrichmentResult,
+  EnrichmentRow,
+  EnrichmentScreenshot,
+} from './enrichment.types'
 
 @Injectable()
 export class EnrichmentRepository extends BaseRepository {
+  private readonly logger = new Logger(EnrichmentRepository.name)
+
   constructor(
     @Inject(PG_DB_TOKEN) db: AppDatabase,
     private readonly snowflake: SnowflakeService,
@@ -140,6 +146,36 @@ export class EnrichmentRepository extends BaseRepository {
       raw: input.raw,
       expiresAt: input.expiresAt,
     })
+  }
+
+  /**
+   * Merge a `screenshot` key into the row's `normalized` JSONB column. Used
+   * by the post-persist screenshot pipeline so an already-inserted row can
+   * pick up the screenshot fields without rewriting the entire normalized
+   * payload (which would race with concurrent writers and revert other
+   * fields). Uses PostgreSQL's `jsonb` `||` operator for an in-place merge.
+   */
+  async updateScreenshot(
+    id: string,
+    screenshot: EnrichmentScreenshot,
+  ): Promise<void> {
+    const patch = JSON.stringify({ screenshot })
+    const updated = await this.db
+      .update(enrichmentCache)
+      .set({
+        normalized: sql`coalesce(${enrichmentCache.normalized}, '{}'::jsonb) || ${patch}::jsonb`,
+      })
+      .where(eq(enrichmentCache.id, id))
+      .returning({ id: enrichmentCache.id })
+
+    if (updated.length === 0) {
+      // Row vanished between persist and screenshot write — most likely an
+      // admin `invalidate` ran concurrently. The S3 object is now orphaned;
+      // the warn log is the ops signal for an eventual reconciliation job.
+      this.logger.warn(
+        `updateScreenshot: row ${id} disappeared between persist and screenshot write; S3 object now orphaned`,
+      )
+    }
   }
 
   async recordFailure(

--- a/apps/core/src/modules/enrichment/enrichment.repository.ts
+++ b/apps/core/src/modules/enrichment/enrichment.repository.ts
@@ -178,6 +178,15 @@ export class EnrichmentRepository extends BaseRepository {
     }
   }
 
+  async clearScreenshot(id: string): Promise<void> {
+    await this.db
+      .update(enrichmentCache)
+      .set({
+        normalized: sql`coalesce(${enrichmentCache.normalized}, '{}'::jsonb) - 'screenshot'`,
+      })
+      .where(eq(enrichmentCache.id, id))
+  }
+
   async recordFailure(
     provider: string,
     externalId: string,

--- a/apps/core/src/modules/enrichment/enrichment.service.ts
+++ b/apps/core/src/modules/enrichment/enrichment.service.ts
@@ -14,6 +14,9 @@ import { scheduleManager } from '~/utils/schedule.util'
 import { EnrichmentRepository } from './enrichment.repository'
 import type { EnrichmentResult, ProviderMeta } from './enrichment.types'
 import { ProviderDisabledError, TokenMissingError } from './enrichment.types'
+import { BrowserFetchService } from './providers/open-graph/browser-fetch.service'
+import { ScreenshotPipelineService } from './providers/open-graph/screenshot-pipeline.service'
+import { ScreenshotStorageService } from './providers/open-graph/screenshot-storage.service'
 import type { EnrichmentProvider } from './providers/provider.interface'
 import { ProviderRegistry } from './providers/provider.registry'
 import type { ContentDoc } from './url-extractor.service'
@@ -51,6 +54,20 @@ export function refKey(provider: string, externalId: string): string {
   return `${provider}\t${externalId}`
 }
 
+/**
+ * Stamp the cache row id onto `normalized` and return it. The argument is
+ * always a freshly-deserialized object (a Drizzle row's JSON column or a
+ * JSON.parse'd Redis payload) so in-place mutation is safe and avoids an
+ * extra allocation per cache hit.
+ */
+function stampRowId(
+  normalized: EnrichmentResult,
+  rowId: string,
+): EnrichmentResult {
+  normalized.id = rowId
+  return normalized
+}
+
 @Injectable()
 export class EnrichmentService implements OnModuleInit {
   private readonly logger = new Logger(EnrichmentService.name)
@@ -64,6 +81,9 @@ export class EnrichmentService implements OnModuleInit {
     private readonly taskQueueService: TaskQueueService,
     private readonly taskQueueProcessor: TaskQueueProcessor,
     private readonly urlExtractor: UrlExtractorService,
+    private readonly browserFetch: BrowserFetchService,
+    private readonly screenshotPipeline: ScreenshotPipelineService,
+    private readonly screenshotStorage: ScreenshotStorageService,
   ) {}
 
   onModuleInit() {
@@ -143,17 +163,18 @@ export class EnrichmentService implements OnModuleInit {
 
     if (dbRow) {
       const isExpired = !!dbRow.expiresAt && dbRow.expiresAt < now
+      const stamped = stampRowId(dbRow.normalized, dbRow.id)
 
       if (isExpired) {
         const inBackoff = this.isInFailureBackoff(dbRow, now)
         if (!inBackoff) {
           this.enqueueRefresh(provider.name, match.id, cacheLocale)
         }
-        return { result: dbRow.normalized, stale: true }
+        return { result: stamped, stale: true }
       }
 
-      await this.setToRedis(url, cacheLocale, dbRow.normalized)
-      return { result: dbRow.normalized }
+      await this.setToRedis(url, cacheLocale, stamped)
+      return { result: stamped }
     }
 
     // Locale-aware miss: try the default ('') row as fallback so the user
@@ -166,7 +187,10 @@ export class EnrichmentService implements OnModuleInit {
       )
       if (fallback) {
         this.enqueueRefresh(provider.name, match.id, cacheLocale)
-        return { result: fallback.normalized, stale: true }
+        return {
+          result: stampRowId(fallback.normalized, fallback.id),
+          stale: true,
+        }
       }
     }
 
@@ -218,7 +242,7 @@ export class EnrichmentService implements OnModuleInit {
       id,
       cacheLocale,
     )
-    if (row) return row.normalized
+    if (row) return stampRowId(row.normalized, row.id)
 
     return this.fetchAndPersist(provider, id, { locale: cacheLocale })
   }
@@ -256,6 +280,14 @@ export class EnrichmentService implements OnModuleInit {
       const rows = await this.repository.findAllLocalesByRef(providerName, id)
       for (const row of rows) {
         await this.deleteFromRedis(row.url, row.locale)
+        // S3 cleanup runs before the cache row is removed — the FK CASCADE
+        // would drop the screenshot row but leave the object behind. Failure
+        // is swallowed (see ScreenshotStorageService.delete contract).
+        await this.screenshotStorage.delete(row.id).catch((error) => {
+          this.logger.warn(
+            `screenshot delete failed for ${row.id}: ${(error as Error).message}`,
+          )
+        })
       }
       await this.repository.deleteByProviderAndExternalId(providerName, id)
       return
@@ -272,6 +304,11 @@ export class EnrichmentService implements OnModuleInit {
     )
     if (row) {
       await this.deleteFromRedis(row.url, cacheLocale)
+      await this.screenshotStorage.delete(row.id).catch((error) => {
+        this.logger.warn(
+          `screenshot delete failed for ${row.id}: ${(error as Error).message}`,
+        )
+      })
       await this.repository.deleteByProviderAndExternalId(
         providerName,
         id,
@@ -594,7 +631,7 @@ export class EnrichmentService implements OnModuleInit {
     await this.enrichWithImageMeta(result)
 
     const expiresAt = new Date(Date.now() + provider.defaultTtl * 1000)
-    await this.repository.upsert(
+    const row = await this.repository.upsert(
       provider.name,
       externalId,
       opts?.url ?? result.url,
@@ -603,7 +640,70 @@ export class EnrichmentService implements OnModuleInit {
       expiresAt,
       locale,
     )
+    result.id = row.id
+
+    await this.processScreenshotIfPresent(row.id, result)
+
     return result
+  }
+
+  /**
+   * Post-persist screenshot pipeline. Runs only when the matched provider has
+   * stashed raw screenshot bytes via `BrowserFetchService.attachScreenshotBytes`
+   * (currently only `OpenGraphProvider` in browser mode). The WeakMap read is
+   * the cheapest gate: it returns `undefined` for any provider that did not
+   * attach, so we can call this unconditionally without branching by provider.
+   *
+   * Any failure — pipeline drop, S3 put, DB merge — is logged at `warn` and
+   * swallowed. The enrichment response is still returned without `screenshot`
+   * and the card degrades gracefully (existing fallback behavior).
+   */
+  private async processScreenshotIfPresent(
+    rowId: string,
+    result: EnrichmentResult,
+  ): Promise<void> {
+    const bytes = this.browserFetch.takeScreenshotBytes(result)
+    if (!bytes) return
+
+    try {
+      const config = await this.configsService.get(
+        'thirdPartyServiceIntegration',
+      )
+      const screenshotConfig = config.openGraph?.screenshot
+      if (!screenshotConfig?.enabled) return
+
+      const webpQuality = Number(screenshotConfig.webpQuality ?? 75)
+      const maxBytesPerImage = Number(
+        screenshotConfig.maxBytesPerImage ?? 512 * 1024,
+      )
+
+      const processed = await this.screenshotPipeline.process(bytes, {
+        webpQuality,
+        maxBytesPerImage,
+      })
+      if (!processed) return
+
+      const stored = await this.screenshotStorage.storeOrEvict({
+        enrichmentId: rowId,
+        processed,
+      })
+
+      const screenshot = {
+        url: stored.url,
+        width: processed.width,
+        height: processed.height,
+        blurhash: processed.blurhash,
+        palette: processed.palette,
+      }
+      result.screenshot = screenshot
+      await this.repository.updateScreenshot(rowId, screenshot)
+    } catch (error) {
+      this.logger.warn(
+        `screenshot post-persist failed for ${result.url} (rowId=${rowId}): ${
+          (error as Error).message
+        }`,
+      )
+    }
   }
 
   /**

--- a/apps/core/src/modules/enrichment/enrichment.types.ts
+++ b/apps/core/src/modules/enrichment/enrichment.types.ts
@@ -13,7 +13,29 @@ export interface EnrichmentAttribute {
   format?: 'number' | 'rating' | 'date' | 'percent' | 'text' | 'duration'
 }
 
+export interface EnrichmentScreenshotPalette {
+  dominant: string
+  swatches?: string[]
+}
+
+export interface EnrichmentScreenshot {
+  url: string
+  width: number
+  height: number
+  blurhash?: string
+  palette?: EnrichmentScreenshotPalette
+}
+
 export interface EnrichmentResult<TRaw = unknown> {
+  /**
+   * Cache row Snowflake id. Populated by `EnrichmentService` on cache hit
+   * and post-persist paths so consumers (notably the screenshot LRU touch
+   * path) can address the underlying row without re-querying. Absent on
+   * raw provider returns and on results fresh out of the cold provider
+   * fetch before persistence.
+   */
+  id?: string
+
   title: string
   description?: string
   image?: EnrichmentImage
@@ -30,6 +52,14 @@ export interface EnrichmentResult<TRaw = unknown> {
   color?: string
 
   links?: Array<{ rel: string; url: string; label?: string }>
+
+  /**
+   * Optional browser-mode page screenshot. Populated by `EnrichmentService`
+   * after the row is persisted (only when `screenshot.enabled` is set and
+   * the provider captured raw bytes via `BrowserFetchService.fetchPage`).
+   * Purely additive — consumers that ignore it see no behavioral change.
+   */
+  screenshot?: EnrichmentScreenshot
 
   raw?: TRaw
 }

--- a/apps/core/src/modules/enrichment/providers/open-graph/browser-fetch.service.ts
+++ b/apps/core/src/modules/enrichment/providers/open-graph/browser-fetch.service.ts
@@ -15,11 +15,13 @@ const execFileAsync = promisify(execFile)
 
 const DEFAULT_EXECUTABLE = process.env.AGENT_BROWSER_BIN || 'agent-browser'
 
-// Quality knob for the CLI's intermediate webp write. The pipeline re-encodes
-// at the configured `webpQuality` (default 75) afterwards, so this only needs
-// to be "high enough to survive the round-trip cleanly". 90 leaves enough
-// detail that the downstream sharp pass can still aggressively reduce size.
+// agent-browser writes jpeg/png natively (no webp). Downstream sharp re-encodes
+// to webp at the configured `webpQuality` (default 75), so this only needs to
+// be "high enough to survive the round-trip cleanly". 90 leaves enough detail
+// that the sharp pass can still aggressively reduce size.
 const SCREENSHOT_CLI_QUALITY = 90
+const SCREENSHOT_CLI_FORMAT = 'jpeg' as const
+const SCREENSHOT_CLI_EXT = '.jpeg'
 
 const SCREENSHOT_VIEWPORT_WIDTH = 1280
 const SCREENSHOT_VIEWPORT_HEIGHT = 720
@@ -120,7 +122,7 @@ export class BrowserFetchService {
           '--json',
           `open ${url.toString()}`,
           'wait 1500',
-          `eval -b ${b64} --json`,
+          `eval -b ${b64}`,
         ],
         {
           signal: ac.signal,
@@ -204,16 +206,40 @@ export class BrowserFetchService {
       const ac = new AbortController()
       const timer = setTimeout(() => ac.abort(), timeoutMs)
       try {
+        // agent-browser 0.26.0's `batch` sub-command parser does not recognize
+        // the screenshot-specific flags (e.g. `--screenshot-format`) — it
+        // treats them as positional [selector] tokens and the command fails
+        // with "Element not found". Run viewport + screenshot as two
+        // standalone invocations against the same `--session` instead.
         await execFileAsync(
           executable,
           [
             '--session',
             sessionName,
-            'batch',
-            '--bail',
-            '--json',
-            `set viewport ${SCREENSHOT_VIEWPORT_WIDTH} ${SCREENSHOT_VIEWPORT_HEIGHT}`,
-            `screenshot --screenshot-format webp --screenshot-quality ${SCREENSHOT_CLI_QUALITY} --screenshot-dir ${dir}`,
+            'set',
+            'viewport',
+            String(SCREENSHOT_VIEWPORT_WIDTH),
+            String(SCREENSHOT_VIEWPORT_HEIGHT),
+          ],
+          {
+            signal: ac.signal,
+            maxBuffer: 1_048_576,
+            windowsHide: true,
+            env: process.env,
+          },
+        )
+        await execFileAsync(
+          executable,
+          [
+            '--session',
+            sessionName,
+            'screenshot',
+            '--screenshot-format',
+            SCREENSHOT_CLI_FORMAT,
+            '--screenshot-quality',
+            String(SCREENSHOT_CLI_QUALITY),
+            '--screenshot-dir',
+            dir,
           ],
           {
             signal: ac.signal,
@@ -226,21 +252,23 @@ export class BrowserFetchService {
         clearTimeout(timer)
       }
 
-      // The CLI's chosen filename is not stable across versions, so discover
-      // it instead of hard-coding. Strict: expect exactly one `.webp` file.
-      // Zero or many is treated as a screenshot failure so a surprising CLI
-      // behavior shift surfaces here instead of silently picking one.
+      // CLI filename is not stable across versions, so discover the output
+      // instead of hard-coding. Strict: expect exactly one matching file; zero
+      // or many is treated as failure so a CLI behavior shift surfaces here
+      // rather than silently picking one.
       const entries = await readdir(dir)
-      const webpFiles = entries.filter((name) =>
-        name.toLowerCase().endsWith('.webp'),
+      const matches = entries.filter(
+        (name) =>
+          name.toLowerCase().endsWith(SCREENSHOT_CLI_EXT) ||
+          name.toLowerCase().endsWith('.jpg'),
       )
-      if (webpFiles.length !== 1) {
+      if (matches.length !== 1) {
         this.logger.debug(
-          `screenshot capture produced ${webpFiles.length} .webp files in ${dir}; expected 1`,
+          `screenshot capture produced ${matches.length} matching files in ${dir}; expected 1`,
         )
         return undefined
       }
-      return await readFile(join(dir, webpFiles[0]))
+      return await readFile(join(dir, matches[0]))
     } finally {
       // Best-effort tempdir cleanup. Failure is non-fatal.
       try {

--- a/apps/core/src/modules/enrichment/providers/open-graph/browser-fetch.service.ts
+++ b/apps/core/src/modules/enrichment/providers/open-graph/browser-fetch.service.ts
@@ -1,0 +1,306 @@
+import { execFile } from 'node:child_process'
+import { randomBytes } from 'node:crypto'
+import { mkdtemp, readdir, readFile, rm } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { promisify } from 'node:util'
+
+import { Injectable, Logger } from '@nestjs/common'
+
+import type { EnrichmentResult } from '../../enrichment.types'
+import type { SafeFetchOptions, SafeFetchResult } from './safe-fetch'
+
+const execFileAsync = promisify(execFile)
+
+const DEFAULT_EXECUTABLE = process.env.AGENT_BROWSER_BIN || 'agent-browser'
+
+// Quality knob for the CLI's intermediate webp write. The pipeline re-encodes
+// at the configured `webpQuality` (default 75) afterwards, so this only needs
+// to be "high enough to survive the round-trip cleanly". 90 leaves enough
+// detail that the downstream sharp pass can still aggressively reduce size.
+const SCREENSHOT_CLI_QUALITY = 90
+
+const SCREENSHOT_VIEWPORT_WIDTH = 1280
+const SCREENSHOT_VIEWPORT_HEIGHT = 720
+
+interface FetchPageResult {
+  html: SafeFetchResult
+  screenshotBytes?: Buffer
+}
+
+/**
+ * Headless-browser fetcher backed by the agent-browser CLI. Used as the
+ * "browser" fetchMode for the Open Graph provider when sites (Cloudflare,
+ * Akamai, JS-rendered SPAs) refuse a plain HTTP request.
+ *
+ * The CLI is invoked via batch mode in a one-shot named session so:
+ *   1. session state is isolated per request (no cookie bleed across URLs);
+ *   2. failures clean up the session even if the batch midway crashes;
+ *   3. we can plumb a hard timeout via AbortController -> SIGKILL.
+ *
+ * Body is captured by evaluating `document.documentElement.outerHTML` after
+ * page load, then truncated to `maxBodyBytes` so we match safeFetch's
+ * post-conditions and feed the existing parseOpenGraph pipeline unchanged.
+ *
+ * `fetchPage` extends that with an optional viewport screenshot, captured in
+ * the SAME named session (no second navigation). The screenshot step is run
+ * as a separate `agent-browser` invocation against the same `--session` after
+ * the HTML batch returns successfully, so a failure to write/read the webp
+ * file cannot mask HTML success or short-circuit the HTML path.
+ */
+@Injectable()
+export class BrowserFetchService {
+  private readonly logger = new Logger(BrowserFetchService.name)
+
+  // Request-scoped channel for raw screenshot bytes. `OpenGraphProvider`
+  // attaches via `attachScreenshotBytes(result, buf)` keyed off the result
+  // instance it is about to return; `EnrichmentService` reads via
+  // `takeScreenshotBytes(result)` after persisting the row (it needs the row
+  // id before it can write the screenshot row). The WeakMap auto-clears
+  // when the result object is garbage-collected, so there is no manual TTL.
+  private readonly bytesByResult = new WeakMap<EnrichmentResult, Buffer>()
+
+  async fetchHtml(
+    rawUrl: string,
+    opts: SafeFetchOptions & { executable?: string },
+  ): Promise<SafeFetchResult> {
+    const { html } = await this.runSession(rawUrl, opts, false)
+    return html
+  }
+
+  async fetchPage(
+    rawUrl: string,
+    opts: SafeFetchOptions & { executable?: string },
+  ): Promise<FetchPageResult> {
+    return this.runSession(rawUrl, opts, true)
+  }
+
+  attachScreenshotBytes(result: EnrichmentResult, bytes: Buffer): void {
+    this.bytesByResult.set(result, bytes)
+  }
+
+  takeScreenshotBytes(result: EnrichmentResult): Buffer | undefined {
+    const buf = this.bytesByResult.get(result)
+    this.bytesByResult.delete(result)
+    return buf
+  }
+
+  private async runSession(
+    rawUrl: string,
+    opts: SafeFetchOptions & { executable?: string },
+    captureScreenshot: boolean,
+  ): Promise<FetchPageResult> {
+    const url = parseHttpUrl(rawUrl)
+
+    const sessionName = `og-${randomBytes(6).toString('hex')}`
+    const executable = opts.executable || DEFAULT_EXECUTABLE
+    const evalScript =
+      '(() => { try { return document.documentElement.outerHTML } catch (_e) { return "" } })()'
+    const b64 = Buffer.from(evalScript, 'utf8').toString('base64')
+
+    // Shared wall budget. HTML batch consumes part of it; the screenshot
+    // step (if any) gets the remainder, so the total time of HTML +
+    // screenshot stays inside `opts.timeoutMs`.
+    const started = Date.now()
+    const ac = new AbortController()
+    const timer = setTimeout(() => ac.abort(), opts.timeoutMs)
+    let html: SafeFetchResult
+    try {
+      const { stdout } = await execFileAsync(
+        executable,
+        [
+          '--session',
+          sessionName,
+          'batch',
+          '--bail',
+          '--json',
+          `open ${url.toString()}`,
+          'wait 1500',
+          `eval -b ${b64} --json`,
+        ],
+        {
+          signal: ac.signal,
+          maxBuffer: Math.max(opts.maxBodyBytes * 2, 4_194_304),
+          windowsHide: true,
+          env: process.env,
+        },
+      )
+      const rawHtml = extractHtmlFromBatchOutput(stdout)
+      const truncated = rawHtml.length > opts.maxBodyBytes
+      const body = truncated ? rawHtml.slice(0, opts.maxBodyBytes) : rawHtml
+      html = {
+        finalUrl: url.toString(),
+        contentType: 'text/html',
+        body,
+        truncated,
+      }
+    } catch (error) {
+      const err = error as NodeJS.ErrnoException & { stderr?: string }
+      if (err.code === 'ENOENT') {
+        throw new Error(
+          `agent-browser executable not found at "${executable}". Install it or set thirdPartyServiceIntegration.openGraph.fetchMode = "fetch".`,
+          { cause: error },
+        )
+      }
+      if (ac.signal.aborted) {
+        throw new Error(
+          `agent-browser timed out after ${opts.timeoutMs}ms for ${url.toString()}`,
+          { cause: error },
+        )
+      }
+      const detail = err.stderr ? `: ${truncate(err.stderr, 400)}` : ''
+      throw new Error(`agent-browser failed for ${url.toString()}${detail}`, {
+        cause: error,
+      })
+    } finally {
+      clearTimeout(timer)
+    }
+
+    // Screenshot step. Runs as a SECOND `agent-browser` invocation against
+    // the same named session so a failure cannot mask HTML success (the
+    // `--bail` batch would have aborted on a sub-step failure and lost the
+    // HTML result). We swallow all errors here and only log at `debug`.
+    let screenshotBytes: Buffer | undefined
+    if (captureScreenshot) {
+      // Floor at 500ms so a near-exhausted budget still gives the CLI a
+      // realistic shot rather than passing 0 (AbortController fires
+      // immediately on a zero timer in some Node versions).
+      const remaining = Math.max(500, opts.timeoutMs - (Date.now() - started))
+      screenshotBytes = await this.captureScreenshot(
+        executable,
+        sessionName,
+        remaining,
+      ).catch((screenshotErr) => {
+        this.logger.debug(
+          `screenshot capture failed for ${url.toString()}: ${(screenshotErr as Error).message}`,
+        )
+        return undefined
+      })
+    }
+
+    // Best-effort cleanup; ignore failures so they cannot mask the primary
+    // error and so the happy path is not blocked on a slow shutdown.
+    try {
+      await execFileAsync(executable, ['--session', sessionName, 'close'], {
+        timeout: 5_000,
+        windowsHide: true,
+        env: process.env,
+      })
+    } catch (cleanupErr) {
+      this.logger.debug(
+        `agent-browser cleanup failed for session ${sessionName}: ${(cleanupErr as Error).message}`,
+      )
+    }
+
+    return { html, screenshotBytes }
+  }
+
+  private async captureScreenshot(
+    executable: string,
+    sessionName: string,
+    timeoutMs: number,
+  ): Promise<Buffer | undefined> {
+    const dir = await mkdtemp(join(tmpdir(), 'mx-og-screenshot-'))
+    try {
+      const ac = new AbortController()
+      const timer = setTimeout(() => ac.abort(), timeoutMs)
+      try {
+        await execFileAsync(
+          executable,
+          [
+            '--session',
+            sessionName,
+            'batch',
+            '--bail',
+            '--json',
+            `set viewport ${SCREENSHOT_VIEWPORT_WIDTH} ${SCREENSHOT_VIEWPORT_HEIGHT}`,
+            `screenshot --screenshot-format webp --screenshot-quality ${SCREENSHOT_CLI_QUALITY} --screenshot-dir ${dir}`,
+          ],
+          {
+            signal: ac.signal,
+            maxBuffer: 8_388_608,
+            windowsHide: true,
+            env: process.env,
+          },
+        )
+      } finally {
+        clearTimeout(timer)
+      }
+
+      // The CLI's chosen filename is not stable across versions, so discover
+      // it instead of hard-coding. Strict: expect exactly one `.webp` file.
+      // Zero or many is treated as a screenshot failure so a surprising CLI
+      // behavior shift surfaces here instead of silently picking one.
+      const entries = await readdir(dir)
+      const webpFiles = entries.filter((name) =>
+        name.toLowerCase().endsWith('.webp'),
+      )
+      if (webpFiles.length !== 1) {
+        this.logger.debug(
+          `screenshot capture produced ${webpFiles.length} .webp files in ${dir}; expected 1`,
+        )
+        return undefined
+      }
+      return await readFile(join(dir, webpFiles[0]))
+    } finally {
+      // Best-effort tempdir cleanup. Failure is non-fatal.
+      try {
+        await rm(dir, { recursive: true, force: true })
+      } catch {
+        // ignore
+      }
+    }
+  }
+}
+
+function parseHttpUrl(raw: string): URL {
+  let url: URL
+  try {
+    url = new URL(raw)
+  } catch {
+    throw new Error(`Invalid URL for browser fetch: ${raw}`)
+  }
+  if (url.protocol !== 'http:' && url.protocol !== 'https:') {
+    throw new Error(`Disallowed protocol for browser fetch: ${url.protocol}`)
+  }
+  return url
+}
+
+/**
+ * agent-browser `batch --json` prints a JSON array — one entry per sub-command.
+ * The last entry corresponds to our `eval` and carries the evaluated value.
+ * Output shape has shifted across versions, so we probe a few keys and fall
+ * back to the raw stdout if nothing parses (defensive — a heavily-shifted
+ * format would just return less useful HTML rather than crash the request).
+ */
+function extractHtmlFromBatchOutput(stdout: string): string {
+  const trimmed = stdout.trim()
+  if (!trimmed) return ''
+  try {
+    const parsed = JSON.parse(trimmed)
+    const last = Array.isArray(parsed) ? parsed.at(-1) : parsed
+    if (last && typeof last === 'object') {
+      const candidate =
+        pickStringField(last, 'value') ??
+        pickStringField(last, 'result') ??
+        pickStringField(last, 'data') ??
+        (typeof (last as { output?: unknown }).output === 'string'
+          ? (last as { output: string }).output
+          : undefined)
+      if (typeof candidate === 'string') return candidate
+    }
+    if (typeof parsed === 'string') return parsed
+  } catch {
+    // Not JSON — could be a heredoc or plain-text mode. Treat as HTML.
+  }
+  return trimmed
+}
+
+function pickStringField(obj: object, key: string): string | undefined {
+  const v = (obj as Record<string, unknown>)[key]
+  return typeof v === 'string' ? v : undefined
+}
+
+function truncate(s: string, n: number): string {
+  return s.length > n ? `${s.slice(0, n)}…` : s
+}

--- a/apps/core/src/modules/enrichment/providers/open-graph/browser-fetch.service.ts
+++ b/apps/core/src/modules/enrichment/providers/open-graph/browser-fetch.service.ts
@@ -1,5 +1,4 @@
 import { execFile } from 'node:child_process'
-import { randomBytes } from 'node:crypto'
 import { mkdtemp, readdir, readFile, rm } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
@@ -8,7 +7,9 @@ import { promisify } from 'node:util'
 import { Injectable, Logger } from '@nestjs/common'
 
 import type { EnrichmentResult } from '../../enrichment.types'
+import { BrowserSessionPool, type PoolSlot } from './browser-session-pool'
 import type { SafeFetchOptions, SafeFetchResult } from './safe-fetch'
+import { assertHostnameSafe, parseAndValidateUrl } from './url-guard'
 
 const execFileAsync = promisify(execFile)
 
@@ -60,6 +61,8 @@ export class BrowserFetchService {
   // when the result object is garbage-collected, so there is no manual TTL.
   private readonly bytesByResult = new WeakMap<EnrichmentResult, Buffer>()
 
+  constructor(private readonly pool: BrowserSessionPool) {}
+
   async fetchHtml(
     rawUrl: string,
     opts: SafeFetchOptions & { executable?: string },
@@ -90,9 +93,10 @@ export class BrowserFetchService {
     opts: SafeFetchOptions & { executable?: string },
     captureScreenshot: boolean,
   ): Promise<FetchPageResult> {
-    const url = parseHttpUrl(rawUrl)
+    const url = parseAndValidateUrl(rawUrl)
+    await assertHostnameSafe(url.hostname)
 
-    const sessionName = `og-${randomBytes(6).toString('hex')}`
+    const slot: PoolSlot = await this.pool.acquire()
     const executable = opts.executable || DEFAULT_EXECUTABLE
     const evalScript =
       '(() => { try { return document.documentElement.outerHTML } catch (_e) { return "" } })()'
@@ -110,7 +114,7 @@ export class BrowserFetchService {
         executable,
         [
           '--session',
-          sessionName,
+          slot.name,
           'batch',
           '--bail',
           '--json',
@@ -125,6 +129,7 @@ export class BrowserFetchService {
           env: process.env,
         },
       )
+      this.pool.markLive(slot)
       const rawHtml = extractHtmlFromBatchOutput(stdout)
       const truncated = rawHtml.length > opts.maxBodyBytes
       const body = truncated ? rawHtml.slice(0, opts.maxBodyBytes) : rawHtml
@@ -136,15 +141,21 @@ export class BrowserFetchService {
       }
     } catch (error) {
       const err = error as NodeJS.ErrnoException & { stderr?: string }
-      if (err.code === 'ENOENT') {
+      if (ac.signal.aborted) {
+        // Timeout: pool keeps the slot — idle eviction will discard it
+        // later if chromium is wedged.
+        this.pool.release(slot)
         throw new Error(
-          `agent-browser executable not found at "${executable}". Install it or set thirdPartyServiceIntegration.openGraph.fetchMode = "fetch".`,
+          `agent-browser timed out after ${opts.timeoutMs}ms for ${url.toString()}`,
           { cause: error },
         )
       }
-      if (ac.signal.aborted) {
+      // Non-timeout: discard the slot so a wedged chromium does not poison
+      // the next caller.
+      this.pool.release(slot, { discard: true })
+      if (err.code === 'ENOENT') {
         throw new Error(
-          `agent-browser timed out after ${opts.timeoutMs}ms for ${url.toString()}`,
+          `agent-browser executable not found at "${executable}". Install it or set thirdPartyServiceIntegration.openGraph.fetchMode = "fetch".`,
           { cause: error },
         )
       }
@@ -160,6 +171,7 @@ export class BrowserFetchService {
     // the same named session so a failure cannot mask HTML success (the
     // `--bail` batch would have aborted on a sub-step failure and lost the
     // HTML result). We swallow all errors here and only log at `debug`.
+    // Reached only on try-block success — `slot` still held, chromium live.
     let screenshotBytes: Buffer | undefined
     if (captureScreenshot) {
       // Floor at 500ms so a near-exhausted budget still gives the CLI a
@@ -168,7 +180,7 @@ export class BrowserFetchService {
       const remaining = Math.max(500, opts.timeoutMs - (Date.now() - started))
       screenshotBytes = await this.captureScreenshot(
         executable,
-        sessionName,
+        slot.name,
         remaining,
       ).catch((screenshotErr) => {
         this.logger.debug(
@@ -178,20 +190,7 @@ export class BrowserFetchService {
       })
     }
 
-    // Best-effort cleanup; ignore failures so they cannot mask the primary
-    // error and so the happy path is not blocked on a slow shutdown.
-    try {
-      await execFileAsync(executable, ['--session', sessionName, 'close'], {
-        timeout: 5_000,
-        windowsHide: true,
-        env: process.env,
-      })
-    } catch (cleanupErr) {
-      this.logger.debug(
-        `agent-browser cleanup failed for session ${sessionName}: ${(cleanupErr as Error).message}`,
-      )
-    }
-
+    this.pool.release(slot)
     return { html, screenshotBytes }
   }
 
@@ -251,19 +250,6 @@ export class BrowserFetchService {
       }
     }
   }
-}
-
-function parseHttpUrl(raw: string): URL {
-  let url: URL
-  try {
-    url = new URL(raw)
-  } catch {
-    throw new Error(`Invalid URL for browser fetch: ${raw}`)
-  }
-  if (url.protocol !== 'http:' && url.protocol !== 'https:') {
-    throw new Error(`Disallowed protocol for browser fetch: ${url.protocol}`)
-  }
-  return url
 }
 
 /**

--- a/apps/core/src/modules/enrichment/providers/open-graph/browser-fetch.service.ts
+++ b/apps/core/src/modules/enrichment/providers/open-graph/browser-fetch.service.ts
@@ -9,7 +9,11 @@ import { Injectable, Logger } from '@nestjs/common'
 import type { EnrichmentResult } from '../../enrichment.types'
 import { BrowserSessionPool, type PoolSlot } from './browser-session-pool'
 import type { SafeFetchOptions, SafeFetchResult } from './safe-fetch'
-import { assertHostnameSafe, parseAndValidateUrl } from './url-guard'
+import {
+  assertHostnameSafe,
+  parseAndValidateUrl,
+  UnsafeUrlError,
+} from './url-guard'
 
 const execFileAsync = promisify(execFile)
 
@@ -31,12 +35,17 @@ interface FetchPageResult {
   screenshotBytes?: Buffer
 }
 
+type BrowserFetchOptions = SafeFetchOptions & {
+  executable?: string
+  captureScreenshot?: boolean
+}
+
 /**
  * Headless-browser fetcher backed by the agent-browser CLI. Used as the
  * "browser" fetchMode for the Open Graph provider when sites (Cloudflare,
  * Akamai, JS-rendered SPAs) refuse a plain HTTP request.
  *
- * The CLI is invoked via batch mode in a one-shot named session so:
+ * The CLI is invoked via batch mode in a named session so:
  *   1. session state is isolated per request (no cookie bleed across URLs);
  *   2. failures clean up the session even if the batch midway crashes;
  *   3. we can plumb a hard timeout via AbortController -> SIGKILL.
@@ -75,9 +84,9 @@ export class BrowserFetchService {
 
   async fetchPage(
     rawUrl: string,
-    opts: SafeFetchOptions & { executable?: string },
+    opts: BrowserFetchOptions,
   ): Promise<FetchPageResult> {
-    return this.runSession(rawUrl, opts, true)
+    return this.runSession(rawUrl, opts, opts.captureScreenshot ?? true)
   }
 
   attachScreenshotBytes(result: EnrichmentResult, bytes: Buffer): void {
@@ -101,12 +110,18 @@ export class BrowserFetchService {
     const slot: PoolSlot = await this.pool.acquire()
     const executable = opts.executable || DEFAULT_EXECUTABLE
     const evalScript =
-      '(() => { try { return document.documentElement.outerHTML } catch (_e) { return "" } })()'
-    const b64 = Buffer.from(evalScript, 'utf8').toString('base64')
+      '(() => { try { return window.location.href } catch (_e) { return "" } })()'
+    const finalUrlB64 = Buffer.from(evalScript, 'utf8').toString('base64')
+    const pageScript = [
+      '(() => { try { return JSON.stringify({ href: window.location.href, ',
+      'html: document.documentElement.outerHTML }) } catch (_e) { ',
+      'return JSON.stringify({ href: window.location.href, html: "" }) } })()',
+    ].join('')
+    const pageB64 = Buffer.from(pageScript, 'utf8').toString('base64')
 
-    // Shared wall budget. HTML batch consumes part of it; the screenshot
-    // step (if any) gets the remainder, so the total time of HTML +
-    // screenshot stays inside `opts.timeoutMs`.
+    // Shared wall budget. Navigation + HTML extraction consume part of it;
+    // the screenshot step (if any) gets the remainder, so the total time stays
+    // inside `opts.timeoutMs`.
     const started = Date.now()
     const ac = new AbortController()
     const timer = setTimeout(() => ac.abort(), opts.timeoutMs)
@@ -122,7 +137,7 @@ export class BrowserFetchService {
           '--json',
           `open ${url.toString()}`,
           'wait 1500',
-          `eval -b ${b64}`,
+          `eval -b ${finalUrlB64}`,
         ],
         {
           signal: ac.signal,
@@ -132,11 +147,21 @@ export class BrowserFetchService {
         },
       )
       this.pool.markLive(slot)
-      const rawHtml = extractHtmlFromBatchOutput(stdout)
-      const truncated = rawHtml.length > opts.maxBodyBytes
-      const body = truncated ? rawHtml.slice(0, opts.maxBodyBytes) : rawHtml
+      await this.assertBrowserFinalUrlSafe(
+        extractStringFromBatchOutput(stdout),
+      )
+
+      const page = await this.extractPage(executable, slot.name, pageB64, {
+        signal: ac.signal,
+        maxBodyBytes: opts.maxBodyBytes,
+      })
+      const pageFinalUrl = await this.assertBrowserFinalUrlSafe(page.href)
+      const truncated = page.html.length > opts.maxBodyBytes
+      const body = truncated
+        ? page.html.slice(0, opts.maxBodyBytes)
+        : page.html
       html = {
-        finalUrl: url.toString(),
+        finalUrl: pageFinalUrl.toString(),
         contentType: 'text/html',
         body,
         truncated,
@@ -155,6 +180,9 @@ export class BrowserFetchService {
       // Non-timeout: discard the slot so a wedged chromium does not poison
       // the next caller.
       this.pool.release(slot, { discard: true })
+      if (error instanceof UnsafeUrlError) {
+        throw error
+      }
       if (err.code === 'ENOENT') {
         throw new Error(
           `agent-browser executable not found at "${executable}". Install it or set thirdPartyServiceIntegration.openGraph.fetchMode = "fetch".`,
@@ -170,9 +198,8 @@ export class BrowserFetchService {
     }
 
     // Screenshot step. Runs as a SECOND `agent-browser` invocation against
-    // the same named session so a failure cannot mask HTML success (the
-    // `--bail` batch would have aborted on a sub-step failure and lost the
-    // HTML result). We swallow all errors here and only log at `debug`.
+    // the same named session so a failure cannot mask HTML success. We swallow
+    // all errors here and only log at `debug`.
     // Reached only on try-block success — `slot` still held, chromium live.
     let screenshotBytes: Buffer | undefined
     if (captureScreenshot) {
@@ -194,6 +221,47 @@ export class BrowserFetchService {
 
     this.pool.release(slot)
     return { html, screenshotBytes }
+  }
+
+  private async extractPage(
+    executable: string,
+    sessionName: string,
+    pageB64: string,
+    opts: { signal: AbortSignal; maxBodyBytes: number },
+  ): Promise<{ href: string; html: string }> {
+    const { stdout } = await execFileAsync(
+      executable,
+      [
+        '--session',
+        sessionName,
+        'batch',
+        '--bail',
+        '--json',
+        `eval -b ${pageB64}`,
+      ],
+      {
+        signal: opts.signal,
+        maxBuffer: Math.max(opts.maxBodyBytes * 2, 4_194_304),
+        windowsHide: true,
+        env: process.env,
+      },
+    )
+    const raw = extractStringFromBatchOutput(stdout)
+    try {
+      const parsed = JSON.parse(raw) as { href?: unknown; html?: unknown }
+      return {
+        href: typeof parsed.href === 'string' ? parsed.href : '',
+        html: typeof parsed.html === 'string' ? parsed.html : '',
+      }
+    } catch {
+      return { href: '', html: raw }
+    }
+  }
+
+  private async assertBrowserFinalUrlSafe(rawUrl: string): Promise<URL> {
+    const url = parseAndValidateUrl(rawUrl)
+    await assertHostnameSafe(url.hostname)
+    return url
   }
 
   private async captureScreenshot(
@@ -287,7 +355,7 @@ export class BrowserFetchService {
  * back to the raw stdout if nothing parses (defensive — a heavily-shifted
  * format would just return less useful HTML rather than crash the request).
  */
-function extractHtmlFromBatchOutput(stdout: string): string {
+function extractStringFromBatchOutput(stdout: string): string {
   const trimmed = stdout.trim()
   if (!trimmed) return ''
   try {

--- a/apps/core/src/modules/enrichment/providers/open-graph/browser-session-pool.ts
+++ b/apps/core/src/modules/enrichment/providers/open-graph/browser-session-pool.ts
@@ -1,0 +1,220 @@
+import { execFile } from 'node:child_process'
+import { promisify } from 'node:util'
+
+import { Injectable, Logger, type OnModuleDestroy } from '@nestjs/common'
+
+const execFileAsync = promisify(execFile)
+
+const DEFAULT_EXECUTABLE = process.env.AGENT_BROWSER_BIN || 'agent-browser'
+const DEFAULT_MAX_SIZE = Number(process.env.AGENT_BROWSER_MAX_CONCURRENT ?? '2')
+const DEFAULT_IDLE_MS = Number(process.env.AGENT_BROWSER_IDLE_MS ?? '60000')
+const CLOSE_TIMEOUT_MS = 5_000
+
+export interface PoolSlot {
+  readonly name: string
+}
+
+export interface AcquireOptions {
+  signal?: AbortSignal
+}
+
+export interface ReleaseOptions {
+  /**
+   * Close the underlying session and discard the slot. Use when the command
+   * that ran on this slot raised a non-timeout error so the next caller does
+   * not reuse a potentially-broken chromium state.
+   */
+  discard?: boolean
+}
+
+interface InternalSlot {
+  index: number
+  name: string
+  inUse: boolean
+  /** chromium has actually been started under this name. */
+  live: boolean
+  idleTimer?: NodeJS.Timeout
+}
+
+interface Waiter {
+  resolve: (slot: PoolSlot) => void
+  reject: (err: Error) => void
+  signal?: AbortSignal
+  onAbort?: () => void
+}
+
+export interface BrowserSessionPoolOptions {
+  maxSize?: number
+  idleMs?: number
+  executable?: string
+}
+
+/**
+ * Bounded pool of long-lived `agent-browser --session` names. Acts as both a
+ * resource cache (avoids per-request chromium spin-up) and a concurrency
+ * semaphore (no more than `maxSize` in-flight captures).
+ *
+ * State note: chromium cookies / localStorage persist across reuses of the
+ * same slot. Open Graph fetches do not send credentials, so cross-origin
+ * leakage is bounded to whatever a previously-visited page chose to set
+ * publicly. Operators wanting stricter isolation should set
+ * `AGENT_BROWSER_MAX_CONCURRENT=1` + `AGENT_BROWSER_IDLE_MS=0` which approximates
+ * the per-request lifecycle the pool replaced.
+ */
+@Injectable()
+export class BrowserSessionPool implements OnModuleDestroy {
+  private readonly logger = new Logger(BrowserSessionPool.name)
+  private readonly maxSize: number
+  private readonly idleMs: number
+  private readonly executable: string
+
+  private readonly slots: InternalSlot[] = []
+  private readonly waiters: Waiter[] = []
+  private shuttingDown = false
+
+  constructor(options?: BrowserSessionPoolOptions) {
+    this.maxSize = Math.max(1, options?.maxSize ?? DEFAULT_MAX_SIZE)
+    this.idleMs = Math.max(0, options?.idleMs ?? DEFAULT_IDLE_MS)
+    this.executable = options?.executable ?? DEFAULT_EXECUTABLE
+  }
+
+  async acquire(options?: AcquireOptions): Promise<PoolSlot> {
+    if (this.shuttingDown) {
+      throw new Error('BrowserSessionPool has been shut down')
+    }
+    const free = this.slots.find((s) => !s.inUse)
+    if (free) {
+      this.cancelIdleTimer(free)
+      free.inUse = true
+      return { name: free.name }
+    }
+    if (this.slots.length < this.maxSize) {
+      const slot: InternalSlot = {
+        index: this.slots.length,
+        name: `og-pool-${this.slots.length}`,
+        inUse: true,
+        live: false,
+      }
+      this.slots.push(slot)
+      return { name: slot.name }
+    }
+    return new Promise<PoolSlot>((resolve, reject) => {
+      const waiter: Waiter = { resolve, reject, signal: options?.signal }
+      if (options?.signal) {
+        if (options.signal.aborted) {
+          reject(new Error('acquire aborted'))
+          return
+        }
+        waiter.onAbort = () => {
+          const i = this.waiters.indexOf(waiter)
+          if (i !== -1) this.waiters.splice(i, 1)
+          reject(new Error('acquire aborted'))
+        }
+        options.signal.addEventListener('abort', waiter.onAbort, { once: true })
+      }
+      this.waiters.push(waiter)
+    })
+  }
+
+  release(slot: PoolSlot, options?: ReleaseOptions): void {
+    const internal = this.slots.find((s) => s.name === slot.name)
+    if (!internal) return
+    internal.inUse = false
+    if (options?.discard) {
+      // Mark live so close is issued even for a slot that never reported a
+      // successful command — caller saw an error and wants chromium torn down.
+      internal.live = true
+      void this.closeSlot(internal)
+    } else {
+      internal.live = true
+      this.scheduleIdleClose(internal)
+    }
+    this.flushWaiter()
+  }
+
+  async onModuleDestroy(): Promise<void> {
+    await this.shutdown()
+  }
+
+  async shutdown(): Promise<void> {
+    if (this.shuttingDown) return
+    this.shuttingDown = true
+    for (const waiter of this.waiters.splice(0)) {
+      if (waiter.signal && waiter.onAbort) {
+        waiter.signal.removeEventListener('abort', waiter.onAbort)
+      }
+      waiter.reject(new Error('BrowserSessionPool has been shut down'))
+    }
+    await Promise.all(this.slots.splice(0).map((s) => this.closeSlot(s, true)))
+  }
+
+  /**
+   * Hook called by `BrowserFetchService` after the first successful command on
+   * a freshly-allocated slot — at that point chromium has truly started, so
+   * subsequent shutdown / discard knows to issue `close`.
+   */
+  markLive(slot: PoolSlot): void {
+    const internal = this.slots.find((s) => s.name === slot.name)
+    if (internal) internal.live = true
+  }
+
+  private flushWaiter(): void {
+    if (this.waiters.length === 0) return
+    const free = this.slots.find((s) => !s.inUse)
+    if (!free) return
+    const waiter = this.waiters.shift()!
+    if (waiter.signal && waiter.onAbort) {
+      waiter.signal.removeEventListener('abort', waiter.onAbort)
+    }
+    this.cancelIdleTimer(free)
+    free.inUse = true
+    waiter.resolve({ name: free.name })
+  }
+
+  private cancelIdleTimer(slot: InternalSlot): void {
+    if (slot.idleTimer) {
+      clearTimeout(slot.idleTimer)
+      slot.idleTimer = undefined
+    }
+  }
+
+  private scheduleIdleClose(slot: InternalSlot): void {
+    this.cancelIdleTimer(slot)
+    if (this.idleMs <= 0) {
+      void this.closeSlot(slot)
+      return
+    }
+    slot.idleTimer = setTimeout(() => {
+      slot.idleTimer = undefined
+      if (!slot.inUse) void this.closeSlot(slot)
+    }, this.idleMs)
+  }
+
+  private async closeSlot(
+    slot: InternalSlot,
+    forceRemoveFromList = false,
+  ): Promise<void> {
+    this.cancelIdleTimer(slot)
+    if (slot.live) {
+      try {
+        await execFileAsync(
+          this.executable,
+          ['--session', slot.name, 'close'],
+          {
+            timeout: CLOSE_TIMEOUT_MS,
+            windowsHide: true,
+            env: process.env,
+          },
+        )
+      } catch (error) {
+        this.logger.debug(
+          `pool close failed for ${slot.name}: ${(error as Error).message}`,
+        )
+      }
+    }
+    slot.live = false
+    if (forceRemoveFromList) return
+    const idx = this.slots.indexOf(slot)
+    if (idx !== -1) this.slots.splice(idx, 1)
+  }
+}

--- a/apps/core/src/modules/enrichment/providers/open-graph/browser-session-pool.ts
+++ b/apps/core/src/modules/enrichment/providers/open-graph/browser-session-pool.ts
@@ -75,6 +75,10 @@ export class BrowserSessionPool implements OnModuleDestroy {
 
   private readonly slots: InternalSlot[] = []
   private readonly waiters: Waiter[] = []
+  // In-flight `closeSlot` promises (from idle close / discard release).
+  // shutdown awaits these so chromium tear-down is fully drained before the
+  // pool is considered destroyed.
+  private readonly inFlightCloses = new Set<Promise<void>>()
   private shuttingDown = false
 
   constructor(@Optional() options?: BrowserSessionPoolOptions) {
@@ -125,13 +129,13 @@ export class BrowserSessionPool implements OnModuleDestroy {
     const internal = this.slots.find((s) => s.name === slot.name)
     if (!internal) return
     internal.inUse = false
+    internal.live = true
     if (options?.discard) {
-      // Mark live so close is issued even for a slot that never reported a
-      // successful command — caller saw an error and wants chromium torn down.
-      internal.live = true
-      void this.closeSlot(internal)
+      // closeSlot synchronously removes the slot from `this.slots` before
+      // awaiting the `close` CLI, so the immediately-following flushWaiter
+      // call cannot hand this same slot to a queued acquire mid-teardown.
+      this.trackClose(this.closeSlot(internal))
     } else {
-      internal.live = true
       this.scheduleIdleClose(internal)
     }
     this.flushWaiter()
@@ -151,6 +155,11 @@ export class BrowserSessionPool implements OnModuleDestroy {
       waiter.reject(new Error('BrowserSessionPool has been shut down'))
     }
     await Promise.all(this.slots.splice(0).map((s) => this.closeSlot(s, true)))
+    // Drain in-flight closes started by release / idle paths so the caller
+    // can rely on shutdown() meaning "all chromium is gone".
+    if (this.inFlightCloses.size > 0) {
+      await Promise.all(this.inFlightCloses)
+    }
   }
 
   /**
@@ -166,14 +175,33 @@ export class BrowserSessionPool implements OnModuleDestroy {
   private flushWaiter(): void {
     if (this.waiters.length === 0) return
     const free = this.slots.find((s) => !s.inUse)
-    if (!free) return
-    const waiter = this.waiters.shift()!
-    if (waiter.signal && waiter.onAbort) {
-      waiter.signal.removeEventListener('abort', waiter.onAbort)
+    if (free) {
+      const waiter = this.waiters.shift()!
+      if (waiter.signal && waiter.onAbort) {
+        waiter.signal.removeEventListener('abort', waiter.onAbort)
+      }
+      this.cancelIdleTimer(free)
+      free.inUse = true
+      waiter.resolve({ name: free.name })
+      return
     }
-    this.cancelIdleTimer(free)
-    free.inUse = true
-    waiter.resolve({ name: free.name })
+    // No reusable slot in pool, but headroom exists — typically after a
+    // discard or idle-close synchronously evicted a slot. Mint a fresh one
+    // so the waiter doesn't sit forever despite available capacity.
+    if (this.slots.length < this.maxSize) {
+      const slot: InternalSlot = {
+        index: this.slots.length,
+        name: `og-pool-${this.slots.length}`,
+        inUse: true,
+        live: false,
+      }
+      this.slots.push(slot)
+      const waiter = this.waiters.shift()!
+      if (waiter.signal && waiter.onAbort) {
+        waiter.signal.removeEventListener('abort', waiter.onAbort)
+      }
+      waiter.resolve({ name: slot.name })
+    }
   }
 
   private cancelIdleTimer(slot: InternalSlot): void {
@@ -186,20 +214,33 @@ export class BrowserSessionPool implements OnModuleDestroy {
   private scheduleIdleClose(slot: InternalSlot): void {
     this.cancelIdleTimer(slot)
     if (this.idleMs <= 0) {
-      void this.closeSlot(slot)
+      this.trackClose(this.closeSlot(slot))
       return
     }
     slot.idleTimer = setTimeout(() => {
       slot.idleTimer = undefined
-      if (!slot.inUse) void this.closeSlot(slot)
+      if (!slot.inUse) this.trackClose(this.closeSlot(slot))
     }, this.idleMs)
+  }
+
+  private trackClose(p: Promise<void>): void {
+    this.inFlightCloses.add(p)
+    p.finally(() => this.inFlightCloses.delete(p))
   }
 
   private async closeSlot(
     slot: InternalSlot,
-    forceRemoveFromList = false,
+    alreadyRemovedFromList = false,
   ): Promise<void> {
     this.cancelIdleTimer(slot)
+    // Remove from the pool SYNCHRONOUSLY before awaiting the CLI close so
+    // any concurrent acquire / flushWaiter sees a shorter pool and creates a
+    // fresh slot instead of handing this one to a new caller while chromium
+    // is being torn down. shutdown() pre-splices and passes the flag.
+    if (!alreadyRemovedFromList) {
+      const idx = this.slots.indexOf(slot)
+      if (idx !== -1) this.slots.splice(idx, 1)
+    }
     if (slot.live) {
       try {
         await execFileAsync(
@@ -218,8 +259,5 @@ export class BrowserSessionPool implements OnModuleDestroy {
       }
     }
     slot.live = false
-    if (forceRemoveFromList) return
-    const idx = this.slots.indexOf(slot)
-    if (idx !== -1) this.slots.splice(idx, 1)
   }
 }

--- a/apps/core/src/modules/enrichment/providers/open-graph/browser-session-pool.ts
+++ b/apps/core/src/modules/enrichment/providers/open-graph/browser-session-pool.ts
@@ -1,7 +1,12 @@
 import { execFile } from 'node:child_process'
 import { promisify } from 'node:util'
 
-import { Injectable, Logger, type OnModuleDestroy } from '@nestjs/common'
+import {
+  Injectable,
+  Logger,
+  type OnModuleDestroy,
+  Optional,
+} from '@nestjs/common'
 
 const execFileAsync = promisify(execFile)
 
@@ -72,7 +77,7 @@ export class BrowserSessionPool implements OnModuleDestroy {
   private readonly waiters: Waiter[] = []
   private shuttingDown = false
 
-  constructor(options?: BrowserSessionPoolOptions) {
+  constructor(@Optional() options?: BrowserSessionPoolOptions) {
     this.maxSize = Math.max(1, options?.maxSize ?? DEFAULT_MAX_SIZE)
     this.idleMs = Math.max(0, options?.idleMs ?? DEFAULT_IDLE_MS)
     this.executable = options?.executable ?? DEFAULT_EXECUTABLE

--- a/apps/core/src/modules/enrichment/providers/open-graph/open-graph.provider.ts
+++ b/apps/core/src/modules/enrichment/providers/open-graph/open-graph.provider.ts
@@ -97,9 +97,11 @@ export class OpenGraphProvider implements EnrichmentProvider {
     let safe: SafeFetchResult
     let screenshotBytes: Buffer | undefined
     if (fetchMode === 'browser') {
+      const captureScreenshot = og.screenshot?.enabled === true
       const fetched = await this.browserFetch.fetchPage(url, {
         timeoutMs,
         maxBodyBytes,
+        captureScreenshot,
       })
       safe = fetched.html
       screenshotBytes = fetched.screenshotBytes

--- a/apps/core/src/modules/enrichment/providers/open-graph/open-graph.provider.ts
+++ b/apps/core/src/modules/enrichment/providers/open-graph/open-graph.provider.ts
@@ -10,11 +10,13 @@ import type {
   EnrichmentFetchContext,
   EnrichmentProvider,
 } from '../provider.interface'
+import { BrowserFetchService } from './browser-fetch.service'
 import { enrichWithOEmbed } from './oembed'
 import { parseOpenGraph } from './og-parser'
-import { safeFetch } from './safe-fetch'
+import { safeFetch, type SafeFetchResult } from './safe-fetch'
 
-const DEFAULT_TIMEOUT_MS = 8_000
+const DEFAULT_FETCH_TIMEOUT_MS = 8_000
+const DEFAULT_BROWSER_TIMEOUT_MS = 25_000
 const DEFAULT_MAX_BODY_BYTES = 524_288
 const ID_HEX_LENGTH = 32
 
@@ -44,7 +46,10 @@ export class OpenGraphProvider implements EnrichmentProvider {
 
   private readonly logger = new Logger(OpenGraphProvider.name)
 
-  constructor(private readonly configsService: ConfigsService) {}
+  constructor(
+    private readonly configsService: ConfigsService,
+    private readonly browserFetch: BrowserFetchService,
+  ) {}
 
   matchUrl(url: URL): UrlMatchResult | null {
     if (url.protocol !== 'http:' && url.protocol !== 'https:') return null
@@ -76,19 +81,42 @@ export class OpenGraphProvider implements EnrichmentProvider {
 
     const config = await this.configsService.get('thirdPartyServiceIntegration')
     const og = config.openGraph ?? {}
-    const timeoutMs = og.timeoutMs ?? DEFAULT_TIMEOUT_MS
+    const fetchMode = og.fetchMode ?? 'fetch'
     const maxBodyBytes = og.maxBodyBytes ?? DEFAULT_MAX_BODY_BYTES
+    const defaultTimeout =
+      fetchMode === 'browser'
+        ? DEFAULT_BROWSER_TIMEOUT_MS
+        : DEFAULT_FETCH_TIMEOUT_MS
+    const timeoutMs = og.timeoutMs ?? defaultTimeout
 
-    const fetched = await safeFetch(url, { timeoutMs, maxBodyBytes })
-    const { result, oembedUrl } = parseOpenGraph(
-      fetched.body,
-      fetched.finalUrl,
-      url,
-    )
+    // Browser mode runs `fetchPage` (HTML + optional screenshot bytes in one
+    // session). HTTP mode stays on `safeFetch` — no Chromium spin-up, and
+    // screenshots are out of scope on that path (see spec Non-Goals). Note
+    // these are NOT fallbacks for each other: a `browser`-mode fetch failure
+    // throws, it does not silently downgrade to HTTP.
+    let safe: SafeFetchResult
+    let screenshotBytes: Buffer | undefined
+    if (fetchMode === 'browser') {
+      const fetched = await this.browserFetch.fetchPage(url, {
+        timeoutMs,
+        maxBodyBytes,
+      })
+      safe = fetched.html
+      screenshotBytes = fetched.screenshotBytes
+    } else {
+      safe = await safeFetch(url, { timeoutMs, maxBodyBytes })
+    }
 
+    const { result, oembedUrl } = parseOpenGraph(safe.body, safe.finalUrl, url)
+
+    // oEmbed alternates are always plain JSON — keep them on the HTTP path
+    // even in browser mode (cheap, no Chromium spin-up).
     if (oembedUrl) {
       try {
-        await enrichWithOEmbed(result, oembedUrl, { timeoutMs, maxBodyBytes })
+        await enrichWithOEmbed(result, oembedUrl, {
+          timeoutMs: DEFAULT_FETCH_TIMEOUT_MS,
+          maxBodyBytes,
+        })
       } catch (error) {
         this.logger.debug(
           `oEmbed enrichment skipped for ${url}: ${(error as Error).message}`,
@@ -98,6 +126,16 @@ export class OpenGraphProvider implements EnrichmentProvider {
 
     // Force category — defensive in case parseOpenGraph drift forgets it.
     result.category = this.category
+
+    // Hand raw screenshot bytes to `EnrichmentService` via the BrowserFetch
+    // WeakMap channel. `EnrichmentService.fetchAndPersist` reads them after
+    // the row is persisted (it needs the row id before writing the
+    // screenshot row). The public return type stays unchanged — `screenshot`
+    // is attached AFTER persistence, not by the provider.
+    if (screenshotBytes) {
+      this.browserFetch.attachScreenshotBytes(result, screenshotBytes)
+    }
+
     return result
   }
 }

--- a/apps/core/src/modules/enrichment/providers/open-graph/safe-fetch.ts
+++ b/apps/core/src/modules/enrichment/providers/open-graph/safe-fetch.ts
@@ -4,8 +4,14 @@ import { isIP } from 'node:net'
 import { isDev } from '~/global/env.global'
 
 const MAX_REDIRECTS = 5
+// Pose as a current Chrome on macOS. Self-identifying "bot" UAs (the previous
+// default) are routinely blocked by Cloudflare/Akamai/Vercel firewall rules,
+// even for unauthenticated metadata reads. Browser-shaped UA + matching
+// Sec-Fetch / sec-ch-ua hints get past the cheapest heuristics.
 const DEFAULT_UA =
-  'Mozilla/5.0 (compatible; mx-space-bot/1.0; +https://github.com/mx-space)'
+  'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/131.0.0.0 Safari/537.36'
+const SEC_CH_UA =
+  '"Google Chrome";v="131", "Chromium";v="131", "Not_A Brand";v="24"'
 
 const BLOCKED_HOSTNAMES = new Set([
   'localhost',
@@ -77,12 +83,7 @@ export async function safeFetch(
         method: 'GET',
         redirect: 'manual',
         signal: ac.signal,
-        headers: {
-          'User-Agent': opts.userAgent ?? DEFAULT_UA,
-          Accept:
-            'text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.5',
-          'Accept-Language': 'en-US,en;q=0.5',
-        },
+        headers: buildRequestHeaders(accept, opts.userAgent ?? DEFAULT_UA, hop),
       })
     } finally {
       clearTimeout(timer)
@@ -130,6 +131,50 @@ export async function safeFetch(
   }
 
   throw new Error(`Too many redirects (>${MAX_REDIRECTS}) for ${rawUrl}`)
+}
+
+/**
+ * Compose request headers shaped like a real Chrome navigation when the caller
+ * expects HTML (Open Graph fallback), and like an XHR JSON request for
+ * everything else (oEmbed). Anti-bot stacks key off the *combination* of UA,
+ * Accept, Sec-Fetch-* and sec-ch-ua, so we keep them consistent rather than
+ * just swapping the UA string.
+ */
+function buildRequestHeaders(
+  accept: readonly string[],
+  userAgent: string,
+  hop: number,
+): Record<string, string> {
+  const isHtml = accept.some((p) => p.startsWith('text/html'))
+  if (isHtml) {
+    return {
+      'User-Agent': userAgent,
+      Accept:
+        'text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,image/apng,*/*;q=0.8',
+      'Accept-Language': 'en-US,en;q=0.9,zh-CN;q=0.8,zh;q=0.7',
+      'Cache-Control': 'no-cache',
+      Pragma: 'no-cache',
+      'Sec-Ch-Ua': SEC_CH_UA,
+      'Sec-Ch-Ua-Mobile': '?0',
+      'Sec-Ch-Ua-Platform': '"macOS"',
+      'Sec-Fetch-Dest': 'document',
+      'Sec-Fetch-Mode': 'navigate',
+      'Sec-Fetch-Site': hop === 0 ? 'none' : 'cross-site',
+      'Sec-Fetch-User': '?1',
+      'Upgrade-Insecure-Requests': '1',
+    }
+  }
+  return {
+    'User-Agent': userAgent,
+    Accept: accept.length ? `${accept.join(', ')}, */*;q=0.1` : '*/*',
+    'Accept-Language': 'en-US,en;q=0.9',
+    'Sec-Ch-Ua': SEC_CH_UA,
+    'Sec-Ch-Ua-Mobile': '?0',
+    'Sec-Ch-Ua-Platform': '"macOS"',
+    'Sec-Fetch-Dest': 'empty',
+    'Sec-Fetch-Mode': 'cors',
+    'Sec-Fetch-Site': 'same-origin',
+  }
 }
 
 function parseAndValidateUrl(raw: string): URL {

--- a/apps/core/src/modules/enrichment/providers/open-graph/safe-fetch.ts
+++ b/apps/core/src/modules/enrichment/providers/open-graph/safe-fetch.ts
@@ -1,7 +1,8 @@
-import { lookup } from 'node:dns/promises'
-import { isIP } from 'node:net'
-
 import { isDev } from '~/global/env.global'
+
+import { assertHostnameSafe, parseAndValidateUrl } from './url-guard'
+
+export { isPrivateIp, UnsafeUrlError } from './url-guard'
 
 const MAX_REDIRECTS = 5
 // Pose as a current Chrome on macOS. Self-identifying "bot" UAs (the previous
@@ -12,16 +13,6 @@ const DEFAULT_UA =
   'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/131.0.0.0 Safari/537.36'
 const SEC_CH_UA =
   '"Google Chrome";v="131", "Chromium";v="131", "Not_A Brand";v="24"'
-
-const BLOCKED_HOSTNAMES = new Set([
-  'localhost',
-  'localhost.localdomain',
-  'broadcasthost',
-  'ip6-localhost',
-  'ip6-loopback',
-])
-
-const BLOCKED_HOSTNAME_SUFFIXES = ['.localhost', '.local', '.internal']
 
 export interface SafeFetchOptions {
   timeoutMs: number
@@ -35,13 +26,6 @@ export interface SafeFetchResult {
   contentType: string
   body: string
   truncated: boolean
-}
-
-export class UnsafeUrlError extends Error {
-  constructor(message: string) {
-    super(message)
-    this.name = 'UnsafeUrlError'
-  }
 }
 
 export class FetchSizeExceededError extends Error {
@@ -177,64 +161,6 @@ function buildRequestHeaders(
   }
 }
 
-function parseAndValidateUrl(raw: string): URL {
-  let url: URL
-  try {
-    url = new URL(raw)
-  } catch {
-    throw new UnsafeUrlError(`Invalid URL: ${raw}`)
-  }
-  if (url.protocol !== 'http:' && url.protocol !== 'https:') {
-    throw new UnsafeUrlError(`Disallowed protocol: ${url.protocol}`)
-  }
-  const host = url.hostname.toLowerCase()
-  if (!host) throw new UnsafeUrlError('Empty hostname')
-  // Dev escape hatch: skip private-network guards so local proxies that
-  // route public domains through fake-IP / RFC2544 ranges (e.g. Surge's
-  // 198.18/15 enhanced-mode pool) can still resolve through this fetcher.
-  if (isDev) return url
-  if (BLOCKED_HOSTNAMES.has(host)) {
-    throw new UnsafeUrlError(`Blocked hostname: ${host}`)
-  }
-  if (BLOCKED_HOSTNAME_SUFFIXES.some((s) => host.endsWith(s))) {
-    throw new UnsafeUrlError(`Blocked hostname suffix: ${host}`)
-  }
-  const ipKind = isIP(stripIpv6Brackets(host))
-  if (ipKind !== 0 && isPrivateIp(stripIpv6Brackets(host), ipKind)) {
-    throw new UnsafeUrlError(`Private IP literal: ${host}`)
-  }
-  return url
-}
-
-async function assertHostnameSafe(hostname: string): Promise<void> {
-  // Skip DNS lookup for IP literals (already validated in parse step).
-  if (isIP(stripIpv6Brackets(hostname)) !== 0) return
-
-  let addrs: { address: string; family: number }[]
-  try {
-    addrs = await lookup(hostname, { all: true })
-  } catch (error) {
-    throw new UnsafeUrlError(
-      `DNS lookup failed for ${hostname}: ${(error as Error).message}`,
-    )
-  }
-  if (addrs.length === 0) {
-    throw new UnsafeUrlError(`No DNS records for ${hostname}`)
-  }
-  for (const a of addrs) {
-    if (isPrivateIp(a.address, a.family === 4 ? 4 : 6)) {
-      throw new UnsafeUrlError(
-        `Hostname ${hostname} resolves to private/internal IP ${a.address}`,
-      )
-    }
-  }
-}
-
-function stripIpv6Brackets(host: string): string {
-  if (host.startsWith('[') && host.endsWith(']')) return host.slice(1, -1)
-  return host
-}
-
 function isRedirect(status: number): boolean {
   return (
     status === 301 ||
@@ -296,54 +222,4 @@ async function readWithLimit(
     }
   }
   return { body: chunks.join(''), truncated }
-}
-
-/**
- * IPv4: blocks loopback (127/8), private (10/8, 172.16/12, 192.168/16),
- * link-local (169.254/16), CGNAT (100.64/10), broadcast (255.255.255.255),
- * "this network" (0/8) and multicast (224/4).
- *
- * IPv6: blocks loopback (::1), unspecified (::), link-local (fe80::/10),
- * unique-local (fc00::/7), IPv4-mapped private equivalents, and multicast.
- */
-export function isPrivateIp(addr: string, family: number): boolean {
-  if (family === 4) return isPrivateIpv4(addr)
-  if (family === 6) return isPrivateIpv6(addr)
-  return true
-}
-
-function isPrivateIpv4(addr: string): boolean {
-  const parts = addr.split('.').map((p) => Number(p))
-  if (
-    parts.length !== 4 ||
-    parts.some((p) => !Number.isInteger(p) || p < 0 || p > 255)
-  ) {
-    return true
-  }
-  const [a, b] = parts
-  if (a === 0) return true
-  if (a === 10) return true
-  if (a === 127) return true
-  if (a === 169 && b === 254) return true
-  if (a === 172 && b >= 16 && b <= 31) return true
-  if (a === 192 && b === 168) return true
-  if (a === 192 && b === 0) return true // 192.0.0.0/24, 192.0.2.0/24 doc range
-  if (a === 198 && (b === 18 || b === 19)) return true // benchmark
-  if (a === 100 && b >= 64 && b <= 127) return true // CGNAT
-  if (a >= 224) return true // multicast + reserved
-  return false
-}
-
-function isPrivateIpv6(addr: string): boolean {
-  const lower = addr.toLowerCase()
-  if (lower === '::' || lower === '::1') return true
-  // IPv4-mapped — re-check as v4.
-  const v4mapped = /^:{2}f{4}:((?:\d+\.){3}\d+)$/i.exec(addr)
-  if (v4mapped) return isPrivateIpv4(v4mapped[1])
-  // fe80::/10 link-local, fc00::/7 unique-local, ff00::/8 multicast.
-  if (lower.startsWith('fe8') || lower.startsWith('fe9')) return true
-  if (lower.startsWith('fea') || lower.startsWith('feb')) return true
-  if (lower.startsWith('fc') || lower.startsWith('fd')) return true
-  if (lower.startsWith('ff')) return true
-  return false
 }

--- a/apps/core/src/modules/enrichment/providers/open-graph/screenshot-pipeline.service.ts
+++ b/apps/core/src/modules/enrichment/providers/open-graph/screenshot-pipeline.service.ts
@@ -1,0 +1,209 @@
+import { Injectable, Logger } from '@nestjs/common'
+import { encode } from 'blurhash'
+import sharp from 'sharp'
+
+export interface ScreenshotPalette {
+  dominant: string // #RRGGBB
+  swatches?: string[] // top distinct, optional, up to 3
+}
+
+export interface ProcessedScreenshot {
+  webp: Buffer
+  width: number
+  height: number
+  blurhash: string
+  palette: ScreenshotPalette
+}
+
+const MAX_WIDTH = 1280
+const MAX_HEIGHT = 720
+
+// Distance-filter swatches in 0-255 RGB space; threshold picked to keep three
+// visibly distinct colors and avoid near-duplicates collapsing the list.
+const SWATCH_DISTINCT_DISTANCE = 32
+
+// Histogram bucket: 5 bits per channel → 32 bins per channel, 32k bins total.
+const SWATCH_BUCKET_BITS = 5
+const SWATCH_BUCKETS_PER_CHANNEL = 1 << SWATCH_BUCKET_BITS // 32
+const SWATCH_BUCKET_SIZE = 256 / SWATCH_BUCKETS_PER_CHANNEL // 8
+const SWATCH_DOWNSCALE = 64
+const SWATCH_TOP_COUNT = 3
+
+// Blurhash sample size mirrors `helper.image.service.ts`.
+const BLURHASH_SIZE = 32
+const BLURHASH_COMP_X = 4
+const BLURHASH_COMP_Y = 4
+
+// Single retry, lower quality, before dropping the screenshot entirely.
+const QUALITY_RETRY_STEP = 15
+
+interface ProcessOptions {
+  webpQuality: number
+  maxBytesPerImage: number
+}
+
+@Injectable()
+export class ScreenshotPipelineService {
+  private readonly logger = new Logger(ScreenshotPipelineService.name)
+
+  async process(
+    input: Buffer,
+    opts: ProcessOptions,
+  ): Promise<ProcessedScreenshot | null> {
+    // Reused sharp instance for everything except the swatch/blurhash clones,
+    // which need their own raw pipelines. Note that `.metadata()` on a
+    // pipeline reflects the SOURCE image, not the resized output — so we
+    // capture the post-resize dimensions from the webp encode's
+    // `resolveWithObject` info instead.
+    const sharped = sharp(input).resize(MAX_WIDTH, MAX_HEIGHT, {
+      fit: 'inside',
+      withoutEnlargement: true,
+    })
+
+    const { dominant } = await sharped.stats()
+    const dominantHex = rgbToHex(dominant.r, dominant.g, dominant.b)
+
+    const swatches = await extractSwatches(sharped)
+    const palette: ScreenshotPalette = swatches.length
+      ? { dominant: dominantHex, swatches }
+      : { dominant: dominantHex }
+
+    const blurhash = await encodeBlurhash(sharped)
+
+    const encoded = await encodeWebpWithRetry(
+      sharped,
+      opts.webpQuality,
+      opts.maxBytesPerImage,
+    )
+    if (!encoded) {
+      this.logger.warn(
+        `screenshot pipeline: bytes exceed cap ${opts.maxBytesPerImage} after retry; dropping screenshot`,
+      )
+      return null
+    }
+
+    const { data: webp, info } = encoded
+    const width = info.width
+    const height = info.height
+    if (!width || !height) {
+      this.logger.debug('screenshot pipeline: missing webp output dimensions')
+      return null
+    }
+
+    return { webp, width, height, blurhash, palette }
+  }
+}
+
+function rgbToHex(r: number, g: number, b: number): string {
+  const h = (n: number) =>
+    Math.max(0, Math.min(255, Math.round(n)))
+      .toString(16)
+      .padStart(2, '0')
+  return `#${h(r)}${h(g)}${h(b)}`
+}
+
+/**
+ * Histogram-bucket a 64x64 downscale into 5-bit-per-channel bins, then pick
+ * the top-3 buckets that survive a Euclidean-distance filter (>=32 in 0-255
+ * space) so swatches do not collapse into near-duplicates.
+ *
+ * If fewer than 3 distinct colors survive, returns whatever exists (callers
+ * MUST tolerate a shorter array). Returns `[]` for fully-degenerate input.
+ */
+async function extractSwatches(source: sharp.Sharp): Promise<string[]> {
+  const { data, info } = await source
+    .clone()
+    .removeAlpha()
+    .resize(SWATCH_DOWNSCALE, SWATCH_DOWNSCALE, { fit: 'inside' })
+    .raw()
+    .toBuffer({ resolveWithObject: true })
+
+  const channels = info.channels // 3 after removeAlpha
+  if (channels !== 3) return []
+
+  const counts = new Map<number, number>()
+  for (let i = 0; i < data.length; i += channels) {
+    const rb = data[i] >> (8 - SWATCH_BUCKET_BITS)
+    const gb = data[i + 1] >> (8 - SWATCH_BUCKET_BITS)
+    const bb = data[i + 2] >> (8 - SWATCH_BUCKET_BITS)
+    const key =
+      (rb << (SWATCH_BUCKET_BITS * 2)) | (gb << SWATCH_BUCKET_BITS) | bb
+    counts.set(key, (counts.get(key) ?? 0) + 1)
+  }
+
+  if (counts.size === 0) return []
+
+  const ranked = Array.from(counts.entries()).sort((a, b) => b[1] - a[1])
+
+  const picked: Array<{ r: number; g: number; b: number }> = []
+  for (const [key] of ranked) {
+    const rb =
+      (key >> (SWATCH_BUCKET_BITS * 2)) & (SWATCH_BUCKETS_PER_CHANNEL - 1)
+    const gb = (key >> SWATCH_BUCKET_BITS) & (SWATCH_BUCKETS_PER_CHANNEL - 1)
+    const bb = key & (SWATCH_BUCKETS_PER_CHANNEL - 1)
+    // Bucket center: shift up + half-bucket bias.
+    const r = rb * SWATCH_BUCKET_SIZE + Math.floor(SWATCH_BUCKET_SIZE / 2)
+    const g = gb * SWATCH_BUCKET_SIZE + Math.floor(SWATCH_BUCKET_SIZE / 2)
+    const b = bb * SWATCH_BUCKET_SIZE + Math.floor(SWATCH_BUCKET_SIZE / 2)
+    const tooClose = picked.some(
+      (p) =>
+        euclideanDistance(p.r, p.g, p.b, r, g, b) < SWATCH_DISTINCT_DISTANCE,
+    )
+    if (tooClose) continue
+    picked.push({ r, g, b })
+    if (picked.length >= SWATCH_TOP_COUNT) break
+  }
+
+  return picked.map((p) => rgbToHex(p.r, p.g, p.b))
+}
+
+function euclideanDistance(
+  r1: number,
+  g1: number,
+  b1: number,
+  r2: number,
+  g2: number,
+  b2: number,
+): number {
+  const dr = r1 - r2
+  const dg = g1 - g2
+  const db = b1 - b2
+  return Math.sqrt(dr * dr + dg * dg + db * db)
+}
+
+async function encodeBlurhash(source: sharp.Sharp): Promise<string> {
+  const { data, info } = await source
+    .clone()
+    .raw()
+    .ensureAlpha()
+    .resize(BLURHASH_SIZE, BLURHASH_SIZE, { fit: 'inside' })
+    .toBuffer({ resolveWithObject: true })
+  return encode(
+    new Uint8ClampedArray(data),
+    info.width,
+    info.height,
+    BLURHASH_COMP_X,
+    BLURHASH_COMP_Y,
+  )
+}
+
+async function encodeWebpWithRetry(
+  source: sharp.Sharp,
+  quality: number,
+  maxBytes: number,
+): Promise<{ data: Buffer; info: sharp.OutputInfo } | null> {
+  const first = await source
+    .clone()
+    .webp({ quality })
+    .toBuffer({ resolveWithObject: true })
+  if (first.data.length <= maxBytes) return first
+
+  const retryQuality = Math.max(1, quality - QUALITY_RETRY_STEP)
+  const second = await source
+    .clone()
+    .webp({ quality: retryQuality })
+    .toBuffer({ resolveWithObject: true })
+  if (second.data.length <= maxBytes) return second
+
+  return null
+}

--- a/apps/core/src/modules/enrichment/providers/open-graph/screenshot-storage.service.ts
+++ b/apps/core/src/modules/enrichment/providers/open-graph/screenshot-storage.service.ts
@@ -6,6 +6,7 @@ import { RedisService } from '~/processors/redis/redis.service'
 import { getRedisKey } from '~/utils/redis.util'
 import { S3Uploader } from '~/utils/s3.util'
 
+import { EnrichmentRepository } from '../../enrichment.repository'
 import { EnrichmentScreenshotRepository } from '../../enrichment-screenshot.repository'
 import type { ProcessedScreenshot } from './screenshot-pipeline.service'
 
@@ -61,6 +62,7 @@ export class ScreenshotStorageService {
 
   constructor(
     private readonly repository: EnrichmentScreenshotRepository,
+    private readonly enrichmentRepository: EnrichmentRepository,
     private readonly configsService: ConfigsService,
     private readonly redisService: RedisService,
   ) {}
@@ -253,6 +255,7 @@ export class ScreenshotStorageService {
         }
 
         try {
+          await this.enrichmentRepository.clearScreenshot(row.enrichmentId)
           await this.repository.deleteByEnrichmentId(row.enrichmentId)
         } catch (error) {
           // Abort: leaving the DB row in place while the S3 object is gone

--- a/apps/core/src/modules/enrichment/providers/open-graph/screenshot-storage.service.ts
+++ b/apps/core/src/modules/enrichment/providers/open-graph/screenshot-storage.service.ts
@@ -49,6 +49,16 @@ export class ScreenshotStorageService {
   private cachedUploader: { signature: string; uploader: S3Uploader } | null =
     null
 
+  // Per-instance serialization of `storeOrEvict`. The quota check
+  // (`getQuotaUsage`) + S3 PUT + DB upsert is not a transaction, so two
+  // concurrent calls inside the same process could each observe headroom
+  // and both write, transiently overshooting `maxItems` / `maxTotalBytes`.
+  // Chaining all calls through one promise makes the critical section
+  // serial within a pod. Cross-pod concurrency (Dokploy runs 2 replicas)
+  // still relies on the next storeOrEvict's LRU pass to converge back to
+  // the cap — quota is a soft target, not a hard invariant.
+  private storeChain: Promise<unknown> = Promise.resolve()
+
   constructor(
     private readonly repository: EnrichmentScreenshotRepository,
     private readonly configsService: ConfigsService,
@@ -56,6 +66,18 @@ export class ScreenshotStorageService {
   ) {}
 
   async storeOrEvict(args: {
+    enrichmentId: string
+    processed: ProcessedScreenshot
+  }): Promise<ScreenshotStoreResult> {
+    const next = this.storeChain.then(() => this.storeOrEvictUnlocked(args))
+    // Swallow rejection on the chain itself so a single failed write does
+    // not poison every subsequent caller; each awaiter still sees the real
+    // error via the returned promise.
+    this.storeChain = next.catch(() => undefined)
+    return next
+  }
+
+  private async storeOrEvictUnlocked(args: {
     enrichmentId: string
     processed: ProcessedScreenshot
   }): Promise<ScreenshotStoreResult> {

--- a/apps/core/src/modules/enrichment/providers/open-graph/screenshot-storage.service.ts
+++ b/apps/core/src/modules/enrichment/providers/open-graph/screenshot-storage.service.ts
@@ -1,0 +1,329 @@
+import { Injectable, Logger } from '@nestjs/common'
+
+import { RedisKeys } from '~/constants/cache.constant'
+import { ConfigsService } from '~/modules/configs/configs.service'
+import { RedisService } from '~/processors/redis/redis.service'
+import { getRedisKey } from '~/utils/redis.util'
+import { S3Uploader } from '~/utils/s3.util'
+
+import { EnrichmentScreenshotRepository } from '../../enrichment-screenshot.repository'
+import type { ProcessedScreenshot } from './screenshot-pipeline.service'
+
+export interface ScreenshotStoreResult {
+  url: string
+  objectKey: string
+  bytes: number
+}
+
+const OBJECT_KEY_PREFIX = 'enrichment-screenshots'
+const EVICTION_BATCH_LIMIT = 50
+const TOUCH_TTL_SECONDS = 3600
+
+const DEFAULT_MAX_ITEMS = 500
+const DEFAULT_MAX_TOTAL_BYTES = 100 * 1024 * 1024
+
+/**
+ * Owns the put / evict / delete lifecycle for browser-mode screenshot blobs.
+ *
+ * S3 is treated as the source of truth: a DB row is only written after a
+ * successful S3 PUT, and on LRU eviction the S3 DELETE runs before the DB
+ * DELETE so the bucket cannot leak rows that point at missing objects.
+ *
+ * **Orphan S3 objects accepted**: in {@link delete}, an S3 deleteObject
+ * failure is logged and swallowed so the DB row is removed regardless.
+ * The admin "purge enrichment" path must never be blocked by a flaky S3
+ * round-trip, and a stale `.webp` object that no longer has a DB row is
+ * harmless (no admin UI references it, LRU never visits it). If/when an
+ * orphan reconciliation job is added, this is the documented entry point;
+ * for now the trade-off is intentional and Task 3 ships without it.
+ *
+ * `EnrichmentModule` wires this service in Task 4 — this file ships the
+ * standalone class only. The S3 client is constructed lazily from
+ * `imageStorageOptions` and cached per-call options signature so live config
+ * edits (custom domain, credentials) are picked up without a restart.
+ */
+@Injectable()
+export class ScreenshotStorageService {
+  private readonly logger = new Logger(ScreenshotStorageService.name)
+
+  private cachedUploader: { signature: string; uploader: S3Uploader } | null =
+    null
+
+  constructor(
+    private readonly repository: EnrichmentScreenshotRepository,
+    private readonly configsService: ConfigsService,
+    private readonly redisService: RedisService,
+  ) {}
+
+  async storeOrEvict(args: {
+    enrichmentId: string
+    processed: ProcessedScreenshot
+  }): Promise<ScreenshotStoreResult> {
+    const { enrichmentId, processed } = args
+    const bytes = processed.webp.length
+    const objectKey = this.objectKeyFor(enrichmentId)
+
+    const { maxItems, maxTotalBytes } = await this.readQuotaConfig()
+    const s3 = await this.getUploader()
+
+    await this.evictUntilFits({
+      newBytes: bytes,
+      maxItems,
+      maxTotalBytes,
+      s3,
+      // Exclude the row we are about to upsert so a re-capture of the same
+      // enrichment never evicts itself out from under the new write.
+      excludeEnrichmentId: enrichmentId,
+    })
+
+    await s3.uploadBuffer(processed.webp, objectKey, 'image/webp')
+
+    await this.repository.upsert({
+      enrichmentId,
+      objectKey,
+      bytes,
+      width: processed.width,
+      height: processed.height,
+      blurhash: processed.blurhash,
+      palette: processed.palette,
+    })
+
+    return {
+      url: s3.getPublicUrl(objectKey),
+      objectKey,
+      bytes,
+    }
+  }
+
+  async delete(enrichmentId: string): Promise<void> {
+    const row = await this.repository.findByEnrichmentId(enrichmentId)
+    if (!row) return
+
+    // S3 errors are logged and swallowed; the DB row is removed regardless
+    // so the entry never appears in admin listings. Orphan S3 objects are
+    // accepted — see the class JSDoc note on reconciliation. The S3Uploader
+    // already maps 404 to a success.
+    try {
+      const s3 = await this.getUploader()
+      await s3.deleteObject(row.objectKey)
+    } catch (error) {
+      this.logger.warn(
+        `screenshot delete: S3 deleteObject failed for ${row.objectKey}: ${(error as Error).message}`,
+      )
+    }
+
+    await this.repository.deleteByEnrichmentId(enrichmentId)
+  }
+
+  async touchAccess(enrichmentId: string): Promise<void> {
+    const key = getRedisKey(RedisKeys.EnrichmentScreenshotTouch, enrichmentId)
+    let acquired: boolean
+    try {
+      const client = this.redisService.getClient()
+      const result = await client.set(key, '1', 'EX', TOUCH_TTL_SECONDS, 'NX')
+      acquired = result === 'OK'
+    } catch (error) {
+      // Best-effort. LRU may drift slightly toward marking active rows as
+      // stale; recoverable on next access.
+      this.logger.debug(
+        `screenshot touch: Redis NX-EX failed for ${enrichmentId}: ${(error as Error).message}`,
+      )
+      return
+    }
+
+    if (!acquired) return
+
+    try {
+      await this.repository.touchAccess(enrichmentId)
+    } catch (error) {
+      this.logger.debug(
+        `screenshot touch: DB update failed for ${enrichmentId}: ${(error as Error).message}`,
+      )
+    }
+  }
+
+  private objectKeyFor(enrichmentId: string): string {
+    return `${OBJECT_KEY_PREFIX}/${enrichmentId}.webp`
+  }
+
+  /**
+   * Evict oldest-by-access rows until the new write fits inside both caps.
+   * If a DB delete fails inside the batch, abort and rethrow — the caller
+   * MUST NOT proceed to S3 PUT, or quota would overrun.
+   */
+  private async evictUntilFits(args: {
+    newBytes: number
+    maxItems: number
+    maxTotalBytes: number
+    s3: S3Uploader
+    excludeEnrichmentId: string
+  }): Promise<void> {
+    const { newBytes, maxItems, maxTotalBytes, s3, excludeEnrichmentId } = args
+
+    // Hard guard: if a single image already exceeds the total cap, eviction
+    // cannot possibly help — bail with a clear error rather than spin.
+    if (newBytes > maxTotalBytes) {
+      throw new Error(
+        `screenshot bytes (${newBytes}) exceed maxTotalBytes (${maxTotalBytes}); refusing to store`,
+      )
+    }
+
+    // The row we're about to overwrite (if any) is invariant across the
+    // eviction loop — same enrichmentId, hoisted so we don't re-query it
+    // every iteration. Subtract its byte count from projected usage so an
+    // upsert that REPLACES an existing screenshot doesn't trigger false-
+    // positive eviction.
+    const existing =
+      await this.repository.findByEnrichmentId(excludeEnrichmentId)
+    const existingBytes = existing?.bytes ?? 0
+    const addedItem = existing ? 0 : 1
+
+    // Cap iterations defensively so a misconfigured repo cannot wedge the
+    // request. Each iteration evicts at most EVICTION_BATCH_LIMIT rows and
+    // rechecks quota; we stop the moment projected usage fits.
+    const MAX_ITERATIONS = 20
+    for (let iteration = 0; iteration < MAX_ITERATIONS; iteration += 1) {
+      const usage = await this.repository.getQuotaUsage()
+
+      let projectedCount = usage.count + addedItem
+      let projectedBytes = usage.totalBytes - existingBytes + newBytes
+
+      if (projectedCount <= maxItems && projectedBytes <= maxTotalBytes) {
+        return
+      }
+
+      const candidates =
+        await this.repository.findOldestByAccess(EVICTION_BATCH_LIMIT)
+      if (candidates.length === 0) {
+        // Nothing to evict but still over quota — this only happens when
+        // the lone existing row IS the one being replaced (handled above)
+        // or maxItems/maxTotalBytes was lowered below the single new row.
+        throw new Error(
+          `screenshot store: cannot fit new bytes (${newBytes}) within quota (items=${projectedCount}/${maxItems}, bytes=${projectedBytes}/${maxTotalBytes}) and no rows are available to evict`,
+        )
+      }
+
+      let evictedAny = false
+      for (const row of candidates) {
+        // Skip the row we're about to overwrite — it gets replaced by upsert
+        // and must not be deleted here (otherwise we evict ourselves).
+        if (row.enrichmentId === excludeEnrichmentId) continue
+
+        // Stop as soon as projected usage fits to avoid over-evicting when
+        // a single removal is already enough.
+        if (projectedCount <= maxItems && projectedBytes <= maxTotalBytes) {
+          break
+        }
+
+        try {
+          await s3.deleteObject(row.objectKey).catch((error: unknown) => {
+            // The S3Uploader already swallows 404 internally. Any other
+            // failure is logged and treated as "skip this row" so a single
+            // dead key cannot block the whole eviction batch.
+            this.logger.warn(
+              `screenshot evict: S3 deleteObject failed for ${row.objectKey}: ${(error as Error).message}; treating as deleted`,
+            )
+          })
+        } catch (error) {
+          this.logger.warn(
+            `screenshot evict: unexpected S3 error for ${row.objectKey}: ${(error as Error).message}`,
+          )
+        }
+
+        try {
+          await this.repository.deleteByEnrichmentId(row.enrichmentId)
+        } catch (error) {
+          // Abort: leaving the DB row in place while the S3 object is gone
+          // is acceptable (frontend tolerates 404), but proceeding to PUT
+          // now would risk overshooting the quota indefinitely.
+          throw new Error(
+            `screenshot evict: aborted batch — DB delete failed for ${row.enrichmentId}: ${(error as Error).message}`,
+            { cause: error },
+          )
+        }
+        evictedAny = true
+        projectedCount -= 1
+        projectedBytes -= row.bytes
+      }
+
+      if (!evictedAny) {
+        // All rows in the batch were the excluded row; we cannot make
+        // progress. Surface a clear error.
+        throw new Error(
+          'screenshot evict: no evictable rows found in batch (all matched the excluded enrichment id)',
+        )
+      }
+
+      if (projectedCount <= maxItems && projectedBytes <= maxTotalBytes) {
+        return
+      }
+    }
+
+    throw new Error(
+      'screenshot evict: exceeded iteration cap without satisfying quota',
+    )
+  }
+
+  private async readQuotaConfig(): Promise<{
+    maxItems: number
+    maxTotalBytes: number
+  }> {
+    const config = await this.configsService.get('thirdPartyServiceIntegration')
+    const screenshot = config.openGraph?.screenshot
+    return {
+      maxItems: Number(screenshot?.maxItems ?? DEFAULT_MAX_ITEMS),
+      maxTotalBytes: Number(
+        screenshot?.maxTotalBytes ?? DEFAULT_MAX_TOTAL_BYTES,
+      ),
+    }
+  }
+
+  /**
+   * Build (or retrieve a cached) `S3Uploader` from `imageStorageOptions`.
+   * Re-built whenever the config signature changes so admin edits to bucket
+   * or credentials are picked up without a process restart.
+   *
+   * `protected` so a subclass / test can swap the uploader by overriding
+   * this method without monkey-patching the full instance.
+   */
+  protected async getUploader(): Promise<S3Uploader> {
+    const config = await this.configsService.get('imageStorageOptions')
+    if (
+      !config.enable ||
+      !config.endpoint ||
+      !config.secretId ||
+      !config.secretKey ||
+      !config.bucket
+    ) {
+      throw new Error(
+        'screenshot storage: imageStorageOptions is not fully configured (need enable=true, endpoint, secretId, secretKey, bucket)',
+      )
+    }
+
+    const signature = [
+      config.endpoint,
+      config.secretId,
+      config.secretKey,
+      config.bucket,
+      config.region ?? 'auto',
+      config.customDomain ?? '',
+    ].join('|')
+
+    if (this.cachedUploader && this.cachedUploader.signature === signature) {
+      return this.cachedUploader.uploader
+    }
+
+    const uploader = new S3Uploader({
+      endpoint: config.endpoint,
+      accessKey: config.secretId,
+      secretKey: config.secretKey,
+      bucket: config.bucket,
+      region: config.region || 'auto',
+    })
+    if (config.customDomain) {
+      uploader.setCustomDomain(config.customDomain)
+    }
+    this.cachedUploader = { signature, uploader }
+    return uploader
+  }
+}

--- a/apps/core/src/modules/enrichment/providers/open-graph/url-guard.ts
+++ b/apps/core/src/modules/enrichment/providers/open-graph/url-guard.ts
@@ -1,0 +1,115 @@
+import { lookup } from 'node:dns/promises'
+import { isIP } from 'node:net'
+
+import { isDev } from '~/global/env.global'
+
+const BLOCKED_HOSTNAMES = new Set([
+  'localhost',
+  'localhost.localdomain',
+  'broadcasthost',
+  'ip6-localhost',
+  'ip6-loopback',
+])
+
+const BLOCKED_HOSTNAME_SUFFIXES = ['.localhost', '.local', '.internal']
+
+export class UnsafeUrlError extends Error {
+  constructor(message: string) {
+    super(message)
+    this.name = 'UnsafeUrlError'
+  }
+}
+
+export function parseAndValidateUrl(raw: string): URL {
+  let url: URL
+  try {
+    url = new URL(raw)
+  } catch {
+    throw new UnsafeUrlError(`Invalid URL: ${raw}`)
+  }
+  if (url.protocol !== 'http:' && url.protocol !== 'https:') {
+    throw new UnsafeUrlError(`Disallowed protocol: ${url.protocol}`)
+  }
+  const host = url.hostname.toLowerCase()
+  if (!host) throw new UnsafeUrlError('Empty hostname')
+  if (isDev) return url
+  if (BLOCKED_HOSTNAMES.has(host)) {
+    throw new UnsafeUrlError(`Blocked hostname: ${host}`)
+  }
+  if (BLOCKED_HOSTNAME_SUFFIXES.some((s) => host.endsWith(s))) {
+    throw new UnsafeUrlError(`Blocked hostname suffix: ${host}`)
+  }
+  const stripped = stripIpv6Brackets(host)
+  const ipKind = isIP(stripped)
+  if (ipKind !== 0 && isPrivateIp(stripped, ipKind)) {
+    throw new UnsafeUrlError(`Private IP literal: ${host}`)
+  }
+  return url
+}
+
+export async function assertHostnameSafe(hostname: string): Promise<void> {
+  if (isIP(stripIpv6Brackets(hostname)) !== 0) return
+  let addrs: { address: string; family: number }[]
+  try {
+    addrs = await lookup(hostname, { all: true })
+  } catch (error) {
+    throw new UnsafeUrlError(
+      `DNS lookup failed for ${hostname}: ${(error as Error).message}`,
+    )
+  }
+  if (addrs.length === 0) {
+    throw new UnsafeUrlError(`No DNS records for ${hostname}`)
+  }
+  for (const a of addrs) {
+    if (isPrivateIp(a.address, a.family === 4 ? 4 : 6)) {
+      throw new UnsafeUrlError(
+        `Hostname ${hostname} resolves to private/internal IP ${a.address}`,
+      )
+    }
+  }
+}
+
+export function stripIpv6Brackets(host: string): string {
+  if (host.startsWith('[') && host.endsWith(']')) return host.slice(1, -1)
+  return host
+}
+
+export function isPrivateIp(addr: string, family: number): boolean {
+  if (family === 4) return isPrivateIpv4(addr)
+  if (family === 6) return isPrivateIpv6(addr)
+  return true
+}
+
+function isPrivateIpv4(addr: string): boolean {
+  const parts = addr.split('.').map((p) => Number(p))
+  if (
+    parts.length !== 4 ||
+    parts.some((p) => !Number.isInteger(p) || p < 0 || p > 255)
+  ) {
+    return true
+  }
+  const [a, b] = parts
+  if (a === 0) return true
+  if (a === 10) return true
+  if (a === 127) return true
+  if (a === 169 && b === 254) return true
+  if (a === 172 && b >= 16 && b <= 31) return true
+  if (a === 192 && b === 168) return true
+  if (a === 192 && b === 0) return true
+  if (a === 198 && (b === 18 || b === 19)) return true
+  if (a === 100 && b >= 64 && b <= 127) return true
+  if (a >= 224) return true
+  return false
+}
+
+function isPrivateIpv6(addr: string): boolean {
+  const lower = addr.toLowerCase()
+  if (lower === '::' || lower === '::1') return true
+  const v4mapped = /^:{2}f{4}:((?:\d+\.){3}\d+)$/i.exec(addr)
+  if (v4mapped) return isPrivateIpv4(v4mapped[1])
+  if (lower.startsWith('fe8') || lower.startsWith('fe9')) return true
+  if (lower.startsWith('fea') || lower.startsWith('feb')) return true
+  if (lower.startsWith('fc') || lower.startsWith('fd')) return true
+  if (lower.startsWith('ff')) return true
+  return false
+}

--- a/apps/core/src/modules/enrichment/providers/open-graph/url-guard.ts
+++ b/apps/core/src/modules/enrichment/providers/open-graph/url-guard.ts
@@ -48,6 +48,7 @@ export function parseAndValidateUrl(raw: string): URL {
 }
 
 export async function assertHostnameSafe(hostname: string): Promise<void> {
+  if (isDev) return
   if (isIP(stripIpv6Brackets(hostname)) !== 0) return
   let addrs: { address: string; family: number }[]
   try {

--- a/apps/core/test/src/database/app-migrations/20260512-enrichment-screenshots.spec.ts
+++ b/apps/core/test/src/database/app-migrations/20260512-enrichment-screenshots.spec.ts
@@ -1,0 +1,166 @@
+import {
+  createPgTestDatabase,
+  type PgTestDatabase,
+} from 'test/helper/pg-verify-url'
+
+import { enrichmentCache, enrichmentScreenshots } from '~/database/schema'
+import { SnowflakeGenerator } from '~/shared/id/snowflake.service'
+
+/**
+ * Schema migration test for 0011_enrichment_screenshots. Verifies the new
+ * table exists with the expected columns/types, the ON DELETE CASCADE link
+ * to enrichment_cache fires, and the LRU index is present.
+ */
+describe('migration 0011 — enrichment_screenshots', () => {
+  let context: PgTestDatabase
+
+  beforeAll(async () => {
+    context = await createPgTestDatabase('mx_enrichment_screenshots')
+  }, 60_000)
+
+  afterAll(async () => {
+    if (context) await context.close()
+  })
+
+  it('creates enrichment_screenshots with the spec column types', async () => {
+    const { rows } = await context.pool.query(
+      `select column_name, data_type, is_nullable, column_default
+         from information_schema.columns
+        where table_schema = 'public'
+          and table_name = 'enrichment_screenshots'
+        order by ordinal_position`,
+    )
+
+    const byName = new Map<
+      string,
+      { type: string; nullable: string; default: string | null }
+    >(
+      rows.map((r: any) => [
+        r.column_name as string,
+        {
+          type: r.data_type as string,
+          nullable: r.is_nullable as string,
+          default: (r.column_default as string | null) ?? null,
+        },
+      ]),
+    )
+
+    expect(byName.get('enrichment_id')).toEqual({
+      type: 'text',
+      nullable: 'NO',
+      default: null,
+    })
+    expect(byName.get('object_key')).toEqual({
+      type: 'text',
+      nullable: 'NO',
+      default: null,
+    })
+    expect(byName.get('bytes')).toEqual({
+      type: 'integer',
+      nullable: 'NO',
+      default: null,
+    })
+    expect(byName.get('width')).toEqual({
+      type: 'integer',
+      nullable: 'NO',
+      default: null,
+    })
+    expect(byName.get('height')).toEqual({
+      type: 'integer',
+      nullable: 'NO',
+      default: null,
+    })
+    expect(byName.get('blurhash')).toEqual({
+      type: 'text',
+      nullable: 'YES',
+      default: null,
+    })
+    expect(byName.get('palette')).toEqual({
+      type: 'jsonb',
+      nullable: 'YES',
+      default: null,
+    })
+    expect(byName.get('created_at')).toEqual({
+      type: 'timestamp with time zone',
+      nullable: 'NO',
+      default: 'now()',
+    })
+    expect(byName.get('last_accessed_at')).toEqual({
+      type: 'timestamp with time zone',
+      nullable: 'NO',
+      default: 'now()',
+    })
+  })
+
+  it('declares enrichment_id as the primary key', async () => {
+    const { rows } = await context.pool.query(
+      `select kcu.column_name
+         from information_schema.table_constraints tc
+         join information_schema.key_column_usage kcu
+           on tc.constraint_name = kcu.constraint_name
+          and tc.table_schema = kcu.table_schema
+        where tc.table_schema = 'public'
+          and tc.table_name = 'enrichment_screenshots'
+          and tc.constraint_type = 'PRIMARY KEY'`,
+    )
+    expect(rows.map((r: any) => r.column_name)).toEqual(['enrichment_id'])
+  })
+
+  it('exposes the LRU index on last_accessed_at', async () => {
+    const { rows } = await context.pool.query(
+      `select indexdef
+         from pg_indexes
+        where schemaname = 'public'
+          and tablename = 'enrichment_screenshots'
+          and indexname = 'enrichment_screenshots_lru_idx'`,
+    )
+    expect(rows).toHaveLength(1)
+    expect(rows[0].indexdef).toMatch(/last_accessed_at/i)
+  })
+
+  it('cascades deletes from enrichment_cache to enrichment_screenshots', async () => {
+    const generator = new SnowflakeGenerator({ workerId: 17 })
+    const enrichmentId = generator.nextId()
+
+    await context.db.insert(enrichmentCache).values({
+      id: enrichmentId,
+      provider: 'open-graph',
+      externalId: `og:test:${enrichmentId}`,
+      url: 'https://example.com/cascade',
+      normalized: { title: 'cascade probe' } as Record<string, unknown>,
+      raw: null,
+    })
+
+    const objectKey = `screenshots/${enrichmentId}.webp`
+    const palette = { dominant: '#112233' }
+    await context.db.insert(enrichmentScreenshots).values({
+      enrichmentId,
+      objectKey,
+      bytes: 12345,
+      width: 1280,
+      height: 720,
+      blurhash: 'LKO2?U%2Tw=w]~RBVZRi};RPxuwH',
+      palette,
+    })
+
+    const beforeRows = await context.pool.query(
+      `select object_key, palette from enrichment_screenshots where enrichment_id = $1`,
+      [enrichmentId],
+    )
+    expect(beforeRows.rowCount).toBe(1)
+    expect(beforeRows.rows[0].object_key).toBe(objectKey)
+    // node-postgres parses jsonb into a JS object, so this asserts the column
+    // is jsonb (or json) and round-trips the structure we inserted.
+    expect(beforeRows.rows[0].palette).toEqual(palette)
+
+    await context.pool.query(`delete from enrichment_cache where id = $1`, [
+      enrichmentId,
+    ])
+
+    const afterCount = await context.pool.query(
+      `select count(*)::int as n from enrichment_screenshots where enrichment_id = $1`,
+      [enrichmentId],
+    )
+    expect(afterCount.rows[0].n).toBe(0)
+  })
+})

--- a/apps/core/test/src/modules/enrichment/browser-fetch.live.spec.ts
+++ b/apps/core/test/src/modules/enrichment/browser-fetch.live.spec.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it } from 'vitest'
+
+import { BrowserFetchService } from '~/modules/enrichment/providers/open-graph/browser-fetch.service'
+import { BrowserSessionPool } from '~/modules/enrichment/providers/open-graph/browser-session-pool'
+
+const LIVE = process.env.LIVE_BROWSER_FETCH === '1'
+const describeLive = LIVE ? describe : describe.skip
+
+describeLive('BrowserFetchService (live agent-browser)', () => {
+  it('fetches HTML via real agent-browser CLI', async () => {
+    const pool = new BrowserSessionPool({ maxSize: 1, idleMs: 0 })
+    const svc = new BrowserFetchService(pool)
+    try {
+      const res = await svc.fetchHtml('https://example.com/', {
+        timeoutMs: 60_000,
+        maxBodyBytes: 1_048_576,
+      })
+      expect(res.contentType).toBe('text/html')
+      expect(res.body.length).toBeGreaterThan(100)
+      expect(res.body.toLowerCase()).toContain('example domain')
+      expect(res.finalUrl).toContain('example.com')
+    } finally {
+      await pool.shutdown()
+    }
+  }, 120_000)
+
+  it('fetches HTML + screenshot from a real site', async () => {
+    const pool = new BrowserSessionPool({ maxSize: 1, idleMs: 0 })
+    const svc = new BrowserFetchService(pool)
+    try {
+      const res = await svc.fetchPage('https://example.com/', {
+        timeoutMs: 60_000,
+        maxBodyBytes: 1_048_576,
+      })
+      expect(res.html.body.toLowerCase()).toContain('example')
+      expect(res.screenshotBytes).toBeDefined()
+      expect(res.screenshotBytes!.length).toBeGreaterThan(1000)
+      expect(res.screenshotBytes![0]).toBe(0xff)
+      expect(res.screenshotBytes![1]).toBe(0xd8)
+      expect(res.screenshotBytes![2]).toBe(0xff)
+    } finally {
+      await pool.shutdown()
+    }
+  }, 120_000)
+
+  it('reuses pooled session across two sequential fetches', async () => {
+    const pool = new BrowserSessionPool({ maxSize: 1, idleMs: 30_000 })
+    const svc = new BrowserFetchService(pool)
+    try {
+      const t1 = Date.now()
+      const r1 = await svc.fetchHtml('https://example.com/', {
+        timeoutMs: 60_000,
+        maxBodyBytes: 1_048_576,
+      })
+      const d1 = Date.now() - t1
+
+      const t2 = Date.now()
+      const r2 = await svc.fetchHtml('https://example.org/', {
+        timeoutMs: 60_000,
+        maxBodyBytes: 1_048_576,
+      })
+      const d2 = Date.now() - t2
+
+      expect(r1.body.length).toBeGreaterThan(0)
+      expect(r2.body.length).toBeGreaterThan(0)
+      console.log(`first fetch ${d1}ms; reused-session fetch ${d2}ms`)
+    } finally {
+      await pool.shutdown()
+    }
+  }, 180_000)
+})

--- a/apps/core/test/src/modules/enrichment/browser-fetch.service.spec.ts
+++ b/apps/core/test/src/modules/enrichment/browser-fetch.service.spec.ts
@@ -92,20 +92,28 @@ function parseBatchArgs(args: string[]): {
   command: string
   subCommands: string[]
   screenshotDir?: string
+  flagValue: (flag: string) => string | undefined
 } {
-  // [--session, <name>, <command>, ...sub commands]
+  // [--session, <name>, <command>, ...rest]
   const sessionName = args[1]
   const command = args[2]
+  const rest = args.slice(3)
   const subCommands: string[] = []
   let screenshotDir: string | undefined
-  for (let i = 3; i < args.length; i++) {
-    const a = args[i]
+  for (let i = 0; i < rest.length; i++) {
+    const a = rest[i]
     if (a.startsWith('--')) continue
     subCommands.push(a)
     const match = /--screenshot-dir\s+(\S+)/.exec(a)
     if (match) screenshotDir = match[1]
   }
-  return { sessionName, command, subCommands, screenshotDir }
+  const flagValue = (flag: string): string | undefined => {
+    const idx = rest.indexOf(flag)
+    if (idx === -1 || idx + 1 >= rest.length) return undefined
+    return rest[idx + 1]
+  }
+  if (!screenshotDir) screenshotDir = flagValue('--screenshot-dir')
+  return { sessionName, command, subCommands, screenshotDir, flagValue }
 }
 
 function buildService() {
@@ -175,24 +183,12 @@ describe('BrowserFetchService', () => {
 
   describe('fetchPage', () => {
     it('returns html + screenshotBytes when CLI succeeds and tempfile exists', async () => {
-      const fakeWebp = Buffer.from([
-        0x52, 0x49, 0x46, 0x46, 0x00, 0x00, 0x00, 0x00, 0x57, 0x45, 0x42, 0x50,
-      ])
+      const fakeJpeg = Buffer.from([0xff, 0xd8, 0xff, 0xe0, 0x00, 0x10])
       const seenScreenshotDirs: string[] = []
 
       setExecFileBehavior(async (call) => {
         const parsed = parseBatchArgs(call.args)
         if (parsed.command === 'batch') {
-          const isScreenshotBatch = parsed.subCommands.some((c) =>
-            c.startsWith('screenshot'),
-          )
-          if (isScreenshotBatch) {
-            // Simulate the CLI writing a webp to the screenshot-dir.
-            const dir = parsed.screenshotDir!
-            seenScreenshotDirs.push(dir)
-            await writeFile(join(dir, 'capture.webp'), fakeWebp)
-            return { stdout: '[]' }
-          }
           return {
             stdout: JSON.stringify([
               {},
@@ -200,6 +196,12 @@ describe('BrowserFetchService', () => {
               { value: '<html><body>ok</body></html>' },
             ]),
           }
+        }
+        if (parsed.command === 'screenshot') {
+          const dir = parsed.screenshotDir!
+          seenScreenshotDirs.push(dir)
+          await writeFile(join(dir, 'capture.jpeg'), fakeJpeg)
+          return { stdout: '' }
         }
         return { stdout: '' }
       })
@@ -213,7 +215,7 @@ describe('BrowserFetchService', () => {
 
       expect(res.html.body).toContain('<body>ok')
       expect(res.screenshotBytes).toBeInstanceOf(Buffer)
-      expect(res.screenshotBytes!.equals(fakeWebp)).toBe(true)
+      expect(res.screenshotBytes!.equals(fakeJpeg)).toBe(true)
 
       // Tempdir cleanup: it must have been removed after the call.
       expect(seenScreenshotDirs).toHaveLength(1)
@@ -227,15 +229,6 @@ describe('BrowserFetchService', () => {
       setExecFileBehavior((call) => {
         const parsed = parseBatchArgs(call.args)
         if (parsed.command === 'batch') {
-          const isScreenshotBatch = parsed.subCommands.some((c) =>
-            c.startsWith('screenshot'),
-          )
-          if (isScreenshotBatch) {
-            if (parsed.screenshotDir)
-              seenScreenshotDirs.push(parsed.screenshotDir)
-            const err = new Error('boom') as NodeJS.ErrnoException
-            return { error: err }
-          }
           return {
             stdout: JSON.stringify([
               {},
@@ -243,6 +236,12 @@ describe('BrowserFetchService', () => {
               { value: '<html><body>still ok</body></html>' },
             ]),
           }
+        }
+        if (parsed.command === 'screenshot') {
+          if (parsed.screenshotDir)
+            seenScreenshotDirs.push(parsed.screenshotDir)
+          const err = new Error('boom') as NodeJS.ErrnoException
+          return { error: err }
         }
         return { stdout: '' }
       })
@@ -263,14 +262,10 @@ describe('BrowserFetchService', () => {
       await pool.shutdown()
     })
 
-    it('returns screenshotBytes undefined when no webp file is written', async () => {
+    it('returns screenshotBytes undefined when no image file is written', async () => {
       setExecFileBehavior((call) => {
         const parsed = parseBatchArgs(call.args)
         if (parsed.command === 'batch') {
-          const isScreenshotBatch = parsed.subCommands.some((c) =>
-            c.startsWith('screenshot'),
-          )
-          if (isScreenshotBatch) return { stdout: '[]' } // no file written
           return {
             stdout: JSON.stringify([
               {},
@@ -279,6 +274,7 @@ describe('BrowserFetchService', () => {
             ]),
           }
         }
+        if (parsed.command === 'screenshot') return { stdout: '' }
         return { stdout: '' }
       })
 
@@ -295,23 +291,20 @@ describe('BrowserFetchService', () => {
       await pool.shutdown()
     })
 
-    it('appends viewport + screenshot sub-commands in the screenshot batch', async () => {
-      const seenSubCommands: string[][] = []
+    it('invokes set-viewport + screenshot as standalone CLI commands with expected flags', async () => {
+      const seenCommands: { command: string; args: string[] }[] = []
       setExecFileBehavior(async (call) => {
         const parsed = parseBatchArgs(call.args)
+        seenCommands.push({ command: parsed.command, args: call.args })
         if (parsed.command === 'batch') {
-          seenSubCommands.push(parsed.subCommands)
-          const isScreenshotBatch = parsed.subCommands.some((c) =>
-            c.startsWith('screenshot'),
-          )
-          if (isScreenshotBatch) {
-            const dir = parsed.screenshotDir!
-            await writeFile(join(dir, 'shot.webp'), Buffer.from([0x00]))
-            return { stdout: '[]' }
-          }
           return {
             stdout: JSON.stringify([{}, {}, { value: '<html></html>' }]),
           }
+        }
+        if (parsed.command === 'screenshot') {
+          const dir = parsed.screenshotDir!
+          await writeFile(join(dir, 'shot.jpeg'), Buffer.from([0xff, 0xd8]))
+          return { stdout: '' }
         }
         return { stdout: '' }
       })
@@ -323,17 +316,20 @@ describe('BrowserFetchService', () => {
         executable: '/usr/local/bin/agent-browser-fake',
       })
 
-      const screenshotBatch = seenSubCommands.find((s) =>
-        s.some((c) => c.startsWith('screenshot')),
-      )
-      expect(screenshotBatch).toBeDefined()
-      expect(screenshotBatch!.includes('set viewport 1280 720')).toBe(true)
-      const screenshotCmd = screenshotBatch!.find((c) =>
-        c.startsWith('screenshot'),
-      )!
-      expect(screenshotCmd).toContain('--screenshot-format webp')
-      expect(screenshotCmd).toContain('--screenshot-quality 90')
-      expect(screenshotCmd).toContain('--screenshot-dir ')
+      const setCall = seenCommands.find((c) => c.command === 'set')
+      expect(setCall).toBeDefined()
+      expect(setCall!.args.slice(2)).toEqual(['set', 'viewport', '1280', '720'])
+
+      const shotCall = seenCommands.find((c) => c.command === 'screenshot')
+      expect(shotCall).toBeDefined()
+      const shotArgs = shotCall!.args
+      const fmtIdx = shotArgs.indexOf('--screenshot-format')
+      expect(fmtIdx).toBeGreaterThan(-1)
+      expect(shotArgs[fmtIdx + 1]).toBe('jpeg')
+      const qIdx = shotArgs.indexOf('--screenshot-quality')
+      expect(qIdx).toBeGreaterThan(-1)
+      expect(shotArgs[qIdx + 1]).toBe('90')
+      expect(shotArgs).toContain('--screenshot-dir')
 
       await pool.shutdown()
     })
@@ -417,18 +413,15 @@ describe('BrowserFetchService', () => {
       setExecFileBehavior(async (call) => {
         const parsed = parseBatchArgs(call.args)
         if (parsed.command === 'batch') {
-          const isScreenshotBatch = parsed.subCommands.some((c) =>
-            c.startsWith('screenshot'),
-          )
-          if (isScreenshotBatch) {
-            const dir = parsed.screenshotDir!
-            seenScreenshotDirs.push(dir)
-            await writeFile(join(dir, 'c.webp'), Buffer.from([0x01]))
-            return { stdout: '[]' }
-          }
           return {
             stdout: JSON.stringify([{}, {}, { value: '<html/>' }]),
           }
+        }
+        if (parsed.command === 'screenshot') {
+          const dir = parsed.screenshotDir!
+          seenScreenshotDirs.push(dir)
+          await writeFile(join(dir, 'c.jpeg'), Buffer.from([0xff, 0xd8]))
+          return { stdout: '' }
         }
         return { stdout: '' }
       })

--- a/apps/core/test/src/modules/enrichment/browser-fetch.service.spec.ts
+++ b/apps/core/test/src/modules/enrichment/browser-fetch.service.spec.ts
@@ -116,6 +116,21 @@ function parseBatchArgs(args: string[]): {
   return { sessionName, command, subCommands, screenshotDir, flagValue }
 }
 
+function batchValue(value: string): string {
+  return JSON.stringify([{}, {}, { value }])
+}
+
+function pageValue(html: string, href = 'https://example.com/'): string {
+  return batchValue(JSON.stringify({ href, html }))
+}
+
+function isNavigationBatch(parsed: ReturnType<typeof parseBatchArgs>): boolean {
+  return (
+    parsed.command === 'batch' &&
+    parsed.subCommands.some((c) => c.startsWith('open '))
+  )
+}
+
 function buildService() {
   const pool = new BrowserSessionPool({ maxSize: 2, idleMs: 60_000 })
   const service = new BrowserFetchService(pool)
@@ -138,14 +153,13 @@ describe('BrowserFetchService', () => {
         calls.push(call)
         const parsed = parseBatchArgs(call.args)
         if (parsed.command === 'batch') {
-          // Single batch is the HTML batch (open/wait/eval).
-          return {
-            stdout: JSON.stringify([
-              {},
-              {},
-              { value: '<html><head><title>x</title></head></html>' },
-            ]),
-          }
+          return isNavigationBatch(parsed)
+            ? { stdout: batchValue('https://example.com/') }
+            : {
+                stdout: pageValue(
+                  '<html><head><title>x</title></head></html>',
+                ),
+              }
         }
         return { stdout: '' }
       })
@@ -163,18 +177,31 @@ describe('BrowserFetchService', () => {
       const batches = calls.filter(
         (c) => parseBatchArgs(c.args).command === 'batch',
       )
-      expect(batches).toHaveLength(1)
-      const htmlBatch = parseBatchArgs(batches[0].args)
-      expect(htmlBatch.sessionName).toMatch(/^og-pool-\d+$/)
-      expect(htmlBatch.subCommands.some((c) => c.startsWith('open '))).toBe(
-        true,
+      expect(batches).toHaveLength(2)
+      expect(parseBatchArgs(batches[0].args).sessionName).toMatch(
+        /^og-pool-\d+$/,
       )
-      expect(htmlBatch.subCommands.some((c) => c.startsWith('eval '))).toBe(
-        true,
+      expect(
+        batches.some((c) =>
+          parseBatchArgs(c.args).subCommands.some((cmd) =>
+            cmd.startsWith('open '),
+          ),
+        ),
+      ).toBe(true)
+      expect(
+        batches.every((c) =>
+          parseBatchArgs(c.args).subCommands.some((cmd) =>
+            cmd.startsWith('eval '),
+          ),
+        ),
       )
       // No screenshot step in fetchHtml.
       expect(
-        htmlBatch.subCommands.some((c) => c.startsWith('screenshot')),
+        batches.some((c) =>
+          parseBatchArgs(c.args).subCommands.some((cmd) =>
+            cmd.startsWith('screenshot'),
+          ),
+        ),
       ).toBe(false)
 
       await pool.shutdown()
@@ -189,13 +216,9 @@ describe('BrowserFetchService', () => {
       setExecFileBehavior(async (call) => {
         const parsed = parseBatchArgs(call.args)
         if (parsed.command === 'batch') {
-          return {
-            stdout: JSON.stringify([
-              {},
-              {},
-              { value: '<html><body>ok</body></html>' },
-            ]),
-          }
+          return isNavigationBatch(parsed)
+            ? { stdout: batchValue('https://example.com/') }
+            : { stdout: pageValue('<html><body>ok</body></html>') }
         }
         if (parsed.command === 'screenshot') {
           const dir = parsed.screenshotDir!
@@ -229,13 +252,9 @@ describe('BrowserFetchService', () => {
       setExecFileBehavior((call) => {
         const parsed = parseBatchArgs(call.args)
         if (parsed.command === 'batch') {
-          return {
-            stdout: JSON.stringify([
-              {},
-              {},
-              { value: '<html><body>still ok</body></html>' },
-            ]),
-          }
+          return isNavigationBatch(parsed)
+            ? { stdout: batchValue('https://example.com/') }
+            : { stdout: pageValue('<html><body>still ok</body></html>') }
         }
         if (parsed.command === 'screenshot') {
           if (parsed.screenshotDir)
@@ -266,13 +285,9 @@ describe('BrowserFetchService', () => {
       setExecFileBehavior((call) => {
         const parsed = parseBatchArgs(call.args)
         if (parsed.command === 'batch') {
-          return {
-            stdout: JSON.stringify([
-              {},
-              {},
-              { value: '<html><body>only html</body></html>' },
-            ]),
-          }
+          return isNavigationBatch(parsed)
+            ? { stdout: batchValue('https://example.com/') }
+            : { stdout: pageValue('<html><body>only html</body></html>') }
         }
         if (parsed.command === 'screenshot') return { stdout: '' }
         return { stdout: '' }
@@ -297,9 +312,9 @@ describe('BrowserFetchService', () => {
         const parsed = parseBatchArgs(call.args)
         seenCommands.push({ command: parsed.command, args: call.args })
         if (parsed.command === 'batch') {
-          return {
-            stdout: JSON.stringify([{}, {}, { value: '<html></html>' }]),
-          }
+          return isNavigationBatch(parsed)
+            ? { stdout: batchValue('https://example.com/') }
+            : { stdout: pageValue('<html></html>') }
         }
         if (parsed.command === 'screenshot') {
           const dir = parsed.screenshotDir!
@@ -331,6 +346,98 @@ describe('BrowserFetchService', () => {
       expect(shotArgs[qIdx + 1]).toBe('90')
       expect(shotArgs).toContain('--screenshot-dir')
 
+      await pool.shutdown()
+    })
+
+    it('reports the browser final URL after redirects', async () => {
+      const finalUrl = 'https://redirected.example/path?q=1'
+      setExecFileBehavior((call) => {
+        const parsed = parseBatchArgs(call.args)
+        if (parsed.command === 'batch') {
+          return isNavigationBatch(parsed)
+            ? { stdout: batchValue(finalUrl) }
+            : {
+                stdout: pageValue(
+                  '<html><body>redirected</body></html>',
+                  finalUrl,
+                ),
+              }
+        }
+        if (parsed.command === 'screenshot') return { stdout: '' }
+        return { stdout: '' }
+      })
+
+      const { pool, service } = buildService()
+      const res = await service.fetchPage('https://example.com/start', {
+        timeoutMs: 5_000,
+        maxBodyBytes: 4_000_000,
+        executable: '/usr/local/bin/agent-browser-fake',
+        captureScreenshot: false,
+      })
+
+      expect(res.html.finalUrl).toBe(finalUrl)
+      expect(res.html.body).toContain('redirected')
+      await pool.shutdown()
+    })
+
+    it('rejects unsafe browser final URLs before HTML extraction and screenshot capture', async () => {
+      const seenCommands: string[] = []
+      setExecFileBehavior((call) => {
+        const parsed = parseBatchArgs(call.args)
+        seenCommands.push(parsed.command)
+        if (parsed.command === 'batch') {
+          return isNavigationBatch(parsed)
+            ? { stdout: batchValue('file:///etc/passwd') }
+            : {
+                stdout: pageValue(
+                  '<html>should not read</html>',
+                  'file:///etc/passwd',
+                ),
+              }
+        }
+        return { stdout: '' }
+      })
+
+      const { pool, service } = buildService()
+      await expect(
+        service.fetchPage('https://example.com/start', {
+          timeoutMs: 5_000,
+          maxBodyBytes: 4_000_000,
+          executable: '/usr/local/bin/agent-browser-fake',
+        }),
+      ).rejects.toThrow(/Disallowed protocol/)
+
+      expect(
+        seenCommands.filter((command) => command === 'batch'),
+      ).toHaveLength(1)
+      expect(seenCommands).not.toContain('screenshot')
+      await pool.shutdown()
+    })
+
+    it('skips viewport and screenshot commands when captureScreenshot is false', async () => {
+      const seenCommands: string[] = []
+      setExecFileBehavior((call) => {
+        const parsed = parseBatchArgs(call.args)
+        seenCommands.push(parsed.command)
+        if (parsed.command === 'batch') {
+          return isNavigationBatch(parsed)
+            ? { stdout: batchValue('https://example.com/') }
+            : { stdout: pageValue('<html><body>metadata only</body></html>') }
+        }
+        return { stdout: '' }
+      })
+
+      const { pool, service } = buildService()
+      const res = await service.fetchPage('https://example.com', {
+        timeoutMs: 5_000,
+        maxBodyBytes: 4_000_000,
+        executable: '/usr/local/bin/agent-browser-fake',
+        captureScreenshot: false,
+      })
+
+      expect(res.html.body).toContain('metadata only')
+      expect(res.screenshotBytes).toBeUndefined()
+      expect(seenCommands).toEqual(['batch', 'batch'])
       await pool.shutdown()
     })
   })
@@ -413,9 +520,9 @@ describe('BrowserFetchService', () => {
       setExecFileBehavior(async (call) => {
         const parsed = parseBatchArgs(call.args)
         if (parsed.command === 'batch') {
-          return {
-            stdout: JSON.stringify([{}, {}, { value: '<html/>' }]),
-          }
+          return isNavigationBatch(parsed)
+            ? { stdout: batchValue('https://example.com/') }
+            : { stdout: pageValue('<html/>') }
         }
         if (parsed.command === 'screenshot') {
           const dir = parsed.screenshotDir!
@@ -460,9 +567,15 @@ describe('BrowserFetchService', () => {
     it('reuses the same session name across two sequential fetches', async () => {
       const pool = new BrowserSessionPool({ maxSize: 1, idleMs: 60_000 })
       const service = new BrowserFetchService(pool)
-      setExecFileBehavior(() => ({
-        stdout: JSON.stringify([{}, {}, { value: '<html></html>' }]),
-      }))
+      setExecFileBehavior((call) => {
+        const parsed = parseBatchArgs(call.args)
+        if (parsed.command !== 'batch') return { stdout: '' }
+        const open = parsed.subCommands.find((c) => c.startsWith('open '))
+        const href = open ? open.slice('open '.length) : 'https://example.com/'
+        return isNavigationBatch(parsed)
+          ? { stdout: batchValue(href) }
+          : { stdout: pageValue('<html></html>', href) }
+      })
       await service.fetchHtml('https://example.com/a', {
         timeoutMs: 5_000,
         maxBodyBytes: 1024,

--- a/apps/core/test/src/modules/enrichment/browser-fetch.service.spec.ts
+++ b/apps/core/test/src/modules/enrichment/browser-fetch.service.spec.ts
@@ -23,11 +23,31 @@ vi.mock('node:child_process', async () => {
   }
 })
 
+// SSRF guard's `assertHostnameSafe` runs a real DNS lookup against the URL
+// hostname. The CI / dev machine may resolve `example.com` through a captive
+// portal or CGNAT-style 198.18.x address, which `isPrivateIp` correctly
+// rejects. We mock the DNS module to a stable public IP so the guard accepts
+// the hostnames used by these tests, and so we don't hit network in unit
+// tests. The `file://` protocol test goes through the protocol check, which
+// runs before DNS, so the mock does not need to special-case it.
+vi.mock('node:dns/promises', async () => {
+  const actual =
+    await vi.importActual<typeof import('node:dns/promises')>(
+      'node:dns/promises',
+    )
+  return {
+    ...actual,
+    lookup: vi.fn(async () => [{ address: '93.184.216.34', family: 4 }]),
+  }
+})
+
 // Import service AFTER the vi.mock setup so `promisify(execFile)` resolves to
 // the mocked execFile. The mocked fn lacks `util.promisify.custom`, so
 // `promisify` wraps it via the standard last-callback contract.
 const { BrowserFetchService } =
   await import('~/modules/enrichment/providers/open-graph/browser-fetch.service')
+const { BrowserSessionPool } =
+  await import('~/modules/enrichment/providers/open-graph/browser-session-pool')
 
 interface ExecFileCall {
   args: string[]
@@ -88,6 +108,12 @@ function parseBatchArgs(args: string[]): {
   return { sessionName, command, subCommands, screenshotDir }
 }
 
+function buildService() {
+  const pool = new BrowserSessionPool({ maxSize: 2, idleMs: 60_000 })
+  const service = new BrowserFetchService(pool)
+  return { pool, service }
+}
+
 describe('BrowserFetchService', () => {
   beforeEach(() => {
     execFileMock.mockReset()
@@ -116,8 +142,8 @@ describe('BrowserFetchService', () => {
         return { stdout: '' }
       })
 
-      const svc = new (BrowserFetchService as any)()
-      const html = await svc.fetchHtml('https://example.com', {
+      const { pool, service } = buildService()
+      const html = await service.fetchHtml('https://example.com', {
         timeoutMs: 5_000,
         maxBodyBytes: 4_000_000,
         executable: '/usr/local/bin/agent-browser-fake',
@@ -126,12 +152,12 @@ describe('BrowserFetchService', () => {
       expect(html.contentType).toBe('text/html')
       expect(html.body).toContain('<title>x</title>')
 
-      // Exactly one `batch` call (the HTML one) + the cleanup `close` call.
       const batches = calls.filter(
         (c) => parseBatchArgs(c.args).command === 'batch',
       )
       expect(batches).toHaveLength(1)
       const htmlBatch = parseBatchArgs(batches[0].args)
+      expect(htmlBatch.sessionName).toMatch(/^og-pool-\d+$/)
       expect(htmlBatch.subCommands.some((c) => c.startsWith('open '))).toBe(
         true,
       )
@@ -142,6 +168,8 @@ describe('BrowserFetchService', () => {
       expect(
         htmlBatch.subCommands.some((c) => c.startsWith('screenshot')),
       ).toBe(false)
+
+      await pool.shutdown()
     })
   })
 
@@ -176,8 +204,8 @@ describe('BrowserFetchService', () => {
         return { stdout: '' }
       })
 
-      const svc = new (BrowserFetchService as any)()
-      const res = await svc.fetchPage('https://example.com', {
+      const { pool, service } = buildService()
+      const res = await service.fetchPage('https://example.com', {
         timeoutMs: 5_000,
         maxBodyBytes: 4_000_000,
         executable: '/usr/local/bin/agent-browser-fake',
@@ -190,6 +218,8 @@ describe('BrowserFetchService', () => {
       // Tempdir cleanup: it must have been removed after the call.
       expect(seenScreenshotDirs).toHaveLength(1)
       expect(existsSync(seenScreenshotDirs[0])).toBe(false)
+
+      await pool.shutdown()
     })
 
     it('returns html with screenshotBytes undefined when screenshot step errors (and cleans tempdir)', async () => {
@@ -217,8 +247,8 @@ describe('BrowserFetchService', () => {
         return { stdout: '' }
       })
 
-      const svc = new (BrowserFetchService as any)()
-      const res = await svc.fetchPage('https://example.com', {
+      const { pool, service } = buildService()
+      const res = await service.fetchPage('https://example.com', {
         timeoutMs: 5_000,
         maxBodyBytes: 4_000_000,
         executable: '/usr/local/bin/agent-browser-fake',
@@ -229,6 +259,8 @@ describe('BrowserFetchService', () => {
 
       expect(seenScreenshotDirs).toHaveLength(1)
       expect(existsSync(seenScreenshotDirs[0])).toBe(false)
+
+      await pool.shutdown()
     })
 
     it('returns screenshotBytes undefined when no webp file is written', async () => {
@@ -250,8 +282,8 @@ describe('BrowserFetchService', () => {
         return { stdout: '' }
       })
 
-      const svc = new (BrowserFetchService as any)()
-      const res = await svc.fetchPage('https://example.com', {
+      const { pool, service } = buildService()
+      const res = await service.fetchPage('https://example.com', {
         timeoutMs: 5_000,
         maxBodyBytes: 4_000_000,
         executable: '/usr/local/bin/agent-browser-fake',
@@ -259,6 +291,8 @@ describe('BrowserFetchService', () => {
 
       expect(res.screenshotBytes).toBeUndefined()
       expect(res.html.body).toContain('only html')
+
+      await pool.shutdown()
     })
 
     it('appends viewport + screenshot sub-commands in the screenshot batch', async () => {
@@ -282,8 +316,8 @@ describe('BrowserFetchService', () => {
         return { stdout: '' }
       })
 
-      const svc = new (BrowserFetchService as any)()
-      await svc.fetchPage('https://example.com', {
+      const { pool, service } = buildService()
+      await service.fetchPage('https://example.com', {
         timeoutMs: 5_000,
         maxBodyBytes: 4_000_000,
         executable: '/usr/local/bin/agent-browser-fake',
@@ -300,31 +334,35 @@ describe('BrowserFetchService', () => {
       expect(screenshotCmd).toContain('--screenshot-format webp')
       expect(screenshotCmd).toContain('--screenshot-quality 90')
       expect(screenshotCmd).toContain('--screenshot-dir ')
+
+      await pool.shutdown()
     })
   })
 
   describe('WeakMap screenshot channel', () => {
     it('attach + take returns the buffer once, undefined on second read', () => {
-      const svc = new (BrowserFetchService as any)()
+      const { pool, service } = buildService()
       const result = {
         title: 'x',
         url: 'https://x',
         category: 'web',
       } as EnrichmentResult
       const buf = Buffer.from('payload')
-      svc.attachScreenshotBytes(result, buf)
-      expect(svc.takeScreenshotBytes(result)).toBe(buf)
-      expect(svc.takeScreenshotBytes(result)).toBeUndefined()
+      service.attachScreenshotBytes(result, buf)
+      expect(service.takeScreenshotBytes(result)).toBe(buf)
+      expect(service.takeScreenshotBytes(result)).toBeUndefined()
+      void pool.shutdown()
     })
 
     it('returns undefined for a result that was never attached', () => {
-      const svc = new (BrowserFetchService as any)()
+      const { pool, service } = buildService()
       const result = {
         title: 'x',
         url: 'https://x',
         category: 'web',
       } as EnrichmentResult
-      expect(svc.takeScreenshotBytes(result)).toBeUndefined()
+      expect(service.takeScreenshotBytes(result)).toBeUndefined()
+      void pool.shutdown()
     })
   })
 
@@ -334,11 +372,20 @@ describe('BrowserFetchService', () => {
       // callback only after the AbortController has aborted, with an
       // ECONNABORTED-ish error so the service sees `ac.signal.aborted = true`.
       execFileMock.mockImplementation((...invocationArgs: unknown[]) => {
+        const args = invocationArgs[1] as string[]
         const options = invocationArgs[2] as { signal?: AbortSignal }
         const callback = invocationArgs.at(-1) as (
           err: NodeJS.ErrnoException | null,
           result?: { stdout: string; stderr: string },
         ) => void
+        // pool.shutdown issues `--session <name> close` against the slot once
+        // the timeout path runs through `release` (no discard). That call has
+        // no AbortSignal, so we resolve it synchronously instead of leaving
+        // the test hanging on a never-resolving promise.
+        if (args.includes('close')) {
+          queueMicrotask(() => callback(null, { stdout: '', stderr: '' }))
+          return undefined
+        }
         options.signal?.addEventListener('abort', () => {
           const err = new Error('aborted') as NodeJS.ErrnoException
           err.code = 'ABORT_ERR'
@@ -347,14 +394,16 @@ describe('BrowserFetchService', () => {
         return undefined
       })
 
-      const svc = new (BrowserFetchService as any)()
+      const { pool, service } = buildService()
       await expect(
-        svc.fetchHtml('https://example.com', {
+        service.fetchHtml('https://example.com', {
           timeoutMs: 10,
           maxBodyBytes: 4_000_000,
           executable: '/usr/local/bin/agent-browser-fake',
         }),
       ).rejects.toThrow(/timed out after 10ms/)
+
+      await pool.shutdown()
     })
   })
 
@@ -384,8 +433,8 @@ describe('BrowserFetchService', () => {
         return { stdout: '' }
       })
 
-      const svc = new (BrowserFetchService as any)()
-      await svc.fetchPage('https://example.com', {
+      const { pool, service } = buildService()
+      await service.fetchPage('https://example.com', {
         timeoutMs: 5_000,
         maxBodyBytes: 4_000_000,
         executable: '/usr/local/bin/agent-browser-fake',
@@ -393,6 +442,55 @@ describe('BrowserFetchService', () => {
 
       expect(seenScreenshotDirs).toHaveLength(1)
       expect(existsSync(seenScreenshotDirs[0])).toBe(false)
+
+      await pool.shutdown()
+    })
+  })
+
+  describe('SSRF guard + pool reuse', () => {
+    it('rejects file:// URLs before invoking chromium', async () => {
+      // In test/dev mode (__DEV__=true) `parseAndValidateUrl` skips the
+      // hostname/IP block-list but still rejects unsupported protocols, so we
+      // exercise the protocol guard rather than the localhost block-list.
+      const pool = new BrowserSessionPool({ maxSize: 1, idleMs: 60_000 })
+      const service = new BrowserFetchService(pool)
+      await expect(
+        service.fetchPage('file:///etc/passwd', {
+          timeoutMs: 5_000,
+          maxBodyBytes: 1024,
+        }),
+      ).rejects.toThrow(/Disallowed protocol/)
+      expect(execFileMock).not.toHaveBeenCalled()
+      await pool.shutdown()
+    })
+
+    it('reuses the same session name across two sequential fetches', async () => {
+      const pool = new BrowserSessionPool({ maxSize: 1, idleMs: 60_000 })
+      const service = new BrowserFetchService(pool)
+      setExecFileBehavior(() => ({
+        stdout: JSON.stringify([{}, {}, { value: '<html></html>' }]),
+      }))
+      await service.fetchHtml('https://example.com/a', {
+        timeoutMs: 5_000,
+        maxBodyBytes: 1024,
+      })
+      await service.fetchHtml('https://example.com/b', {
+        timeoutMs: 5_000,
+        maxBodyBytes: 1024,
+      })
+      const openCalls = execFileMock.mock.calls.filter((call) => {
+        const args = call[1] as string[]
+        return (
+          args.includes('batch') &&
+          args.some((a: string) => a.startsWith('open '))
+        )
+      })
+      expect(openCalls.length).toBe(2)
+      const sessionNames = new Set(
+        openCalls.map((call) => (call[1] as string[])[1]),
+      )
+      expect(sessionNames.size).toBe(1)
+      await pool.shutdown()
     })
   })
 })

--- a/apps/core/test/src/modules/enrichment/browser-fetch.service.spec.ts
+++ b/apps/core/test/src/modules/enrichment/browser-fetch.service.spec.ts
@@ -1,0 +1,398 @@
+import { existsSync } from 'node:fs'
+import { writeFile } from 'node:fs/promises'
+import { join } from 'node:path'
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import type { EnrichmentResult } from '~/modules/enrichment/enrichment.types'
+
+// Hoisted so the vi.mock factory below can see the same mock instance the
+// test bodies reach via `execFileMock`.
+const { execFileMock } = vi.hoisted(() => ({
+  execFileMock: vi.fn(),
+}))
+
+vi.mock('node:child_process', async () => {
+  const actual =
+    await vi.importActual<typeof import('node:child_process')>(
+      'node:child_process',
+    )
+  return {
+    ...actual,
+    execFile: execFileMock,
+  }
+})
+
+// Import service AFTER the vi.mock setup so `promisify(execFile)` resolves to
+// the mocked execFile. The mocked fn lacks `util.promisify.custom`, so
+// `promisify` wraps it via the standard last-callback contract.
+const { BrowserFetchService } =
+  await import('~/modules/enrichment/providers/open-graph/browser-fetch.service')
+
+interface ExecFileCall {
+  args: string[]
+  options: Record<string, unknown>
+}
+
+function setExecFileBehavior(
+  cb: (call: ExecFileCall) =>
+    | {
+        stdout?: string
+        stderr?: string
+        error?: NodeJS.ErrnoException
+      }
+    | Promise<{
+        stdout?: string
+        stderr?: string
+        error?: NodeJS.ErrnoException
+      }>,
+): void {
+  execFileMock.mockImplementation((...invocationArgs: unknown[]) => {
+    const args = invocationArgs[1] as string[]
+    const options = (invocationArgs[2] as Record<string, unknown>) ?? {}
+    const callback = invocationArgs.at(-1) as (
+      err: NodeJS.ErrnoException | null,
+      result?: { stdout: string; stderr: string },
+    ) => void
+    Promise.resolve(cb({ args, options }))
+      .then((res) => {
+        if (res.error) {
+          callback(res.error)
+          return
+        }
+        callback(null, { stdout: res.stdout ?? '', stderr: res.stderr ?? '' })
+      })
+      .catch((err) => callback(err as NodeJS.ErrnoException))
+    return undefined
+  })
+}
+
+function parseBatchArgs(args: string[]): {
+  sessionName: string
+  command: string
+  subCommands: string[]
+  screenshotDir?: string
+} {
+  // [--session, <name>, <command>, ...sub commands]
+  const sessionName = args[1]
+  const command = args[2]
+  const subCommands: string[] = []
+  let screenshotDir: string | undefined
+  for (let i = 3; i < args.length; i++) {
+    const a = args[i]
+    if (a.startsWith('--')) continue
+    subCommands.push(a)
+    const match = /--screenshot-dir\s+(\S+)/.exec(a)
+    if (match) screenshotDir = match[1]
+  }
+  return { sessionName, command, subCommands, screenshotDir }
+}
+
+describe('BrowserFetchService', () => {
+  beforeEach(() => {
+    execFileMock.mockReset()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  describe('fetchHtml (backward compat)', () => {
+    it('returns html-only and never invokes the screenshot step', async () => {
+      const calls: ExecFileCall[] = []
+      setExecFileBehavior((call) => {
+        calls.push(call)
+        const parsed = parseBatchArgs(call.args)
+        if (parsed.command === 'batch') {
+          // Single batch is the HTML batch (open/wait/eval).
+          return {
+            stdout: JSON.stringify([
+              {},
+              {},
+              { value: '<html><head><title>x</title></head></html>' },
+            ]),
+          }
+        }
+        return { stdout: '' }
+      })
+
+      const svc = new (BrowserFetchService as any)()
+      const html = await svc.fetchHtml('https://example.com', {
+        timeoutMs: 5_000,
+        maxBodyBytes: 4_000_000,
+        executable: '/usr/local/bin/agent-browser-fake',
+      })
+
+      expect(html.contentType).toBe('text/html')
+      expect(html.body).toContain('<title>x</title>')
+
+      // Exactly one `batch` call (the HTML one) + the cleanup `close` call.
+      const batches = calls.filter(
+        (c) => parseBatchArgs(c.args).command === 'batch',
+      )
+      expect(batches).toHaveLength(1)
+      const htmlBatch = parseBatchArgs(batches[0].args)
+      expect(htmlBatch.subCommands.some((c) => c.startsWith('open '))).toBe(
+        true,
+      )
+      expect(htmlBatch.subCommands.some((c) => c.startsWith('eval '))).toBe(
+        true,
+      )
+      // No screenshot step in fetchHtml.
+      expect(
+        htmlBatch.subCommands.some((c) => c.startsWith('screenshot')),
+      ).toBe(false)
+    })
+  })
+
+  describe('fetchPage', () => {
+    it('returns html + screenshotBytes when CLI succeeds and tempfile exists', async () => {
+      const fakeWebp = Buffer.from([
+        0x52, 0x49, 0x46, 0x46, 0x00, 0x00, 0x00, 0x00, 0x57, 0x45, 0x42, 0x50,
+      ])
+      const seenScreenshotDirs: string[] = []
+
+      setExecFileBehavior(async (call) => {
+        const parsed = parseBatchArgs(call.args)
+        if (parsed.command === 'batch') {
+          const isScreenshotBatch = parsed.subCommands.some((c) =>
+            c.startsWith('screenshot'),
+          )
+          if (isScreenshotBatch) {
+            // Simulate the CLI writing a webp to the screenshot-dir.
+            const dir = parsed.screenshotDir!
+            seenScreenshotDirs.push(dir)
+            await writeFile(join(dir, 'capture.webp'), fakeWebp)
+            return { stdout: '[]' }
+          }
+          return {
+            stdout: JSON.stringify([
+              {},
+              {},
+              { value: '<html><body>ok</body></html>' },
+            ]),
+          }
+        }
+        return { stdout: '' }
+      })
+
+      const svc = new (BrowserFetchService as any)()
+      const res = await svc.fetchPage('https://example.com', {
+        timeoutMs: 5_000,
+        maxBodyBytes: 4_000_000,
+        executable: '/usr/local/bin/agent-browser-fake',
+      })
+
+      expect(res.html.body).toContain('<body>ok')
+      expect(res.screenshotBytes).toBeInstanceOf(Buffer)
+      expect(res.screenshotBytes!.equals(fakeWebp)).toBe(true)
+
+      // Tempdir cleanup: it must have been removed after the call.
+      expect(seenScreenshotDirs).toHaveLength(1)
+      expect(existsSync(seenScreenshotDirs[0])).toBe(false)
+    })
+
+    it('returns html with screenshotBytes undefined when screenshot step errors (and cleans tempdir)', async () => {
+      const seenScreenshotDirs: string[] = []
+      setExecFileBehavior((call) => {
+        const parsed = parseBatchArgs(call.args)
+        if (parsed.command === 'batch') {
+          const isScreenshotBatch = parsed.subCommands.some((c) =>
+            c.startsWith('screenshot'),
+          )
+          if (isScreenshotBatch) {
+            if (parsed.screenshotDir)
+              seenScreenshotDirs.push(parsed.screenshotDir)
+            const err = new Error('boom') as NodeJS.ErrnoException
+            return { error: err }
+          }
+          return {
+            stdout: JSON.stringify([
+              {},
+              {},
+              { value: '<html><body>still ok</body></html>' },
+            ]),
+          }
+        }
+        return { stdout: '' }
+      })
+
+      const svc = new (BrowserFetchService as any)()
+      const res = await svc.fetchPage('https://example.com', {
+        timeoutMs: 5_000,
+        maxBodyBytes: 4_000_000,
+        executable: '/usr/local/bin/agent-browser-fake',
+      })
+
+      expect(res.html.body).toContain('<body>still ok')
+      expect(res.screenshotBytes).toBeUndefined()
+
+      expect(seenScreenshotDirs).toHaveLength(1)
+      expect(existsSync(seenScreenshotDirs[0])).toBe(false)
+    })
+
+    it('returns screenshotBytes undefined when no webp file is written', async () => {
+      setExecFileBehavior((call) => {
+        const parsed = parseBatchArgs(call.args)
+        if (parsed.command === 'batch') {
+          const isScreenshotBatch = parsed.subCommands.some((c) =>
+            c.startsWith('screenshot'),
+          )
+          if (isScreenshotBatch) return { stdout: '[]' } // no file written
+          return {
+            stdout: JSON.stringify([
+              {},
+              {},
+              { value: '<html><body>only html</body></html>' },
+            ]),
+          }
+        }
+        return { stdout: '' }
+      })
+
+      const svc = new (BrowserFetchService as any)()
+      const res = await svc.fetchPage('https://example.com', {
+        timeoutMs: 5_000,
+        maxBodyBytes: 4_000_000,
+        executable: '/usr/local/bin/agent-browser-fake',
+      })
+
+      expect(res.screenshotBytes).toBeUndefined()
+      expect(res.html.body).toContain('only html')
+    })
+
+    it('appends viewport + screenshot sub-commands in the screenshot batch', async () => {
+      const seenSubCommands: string[][] = []
+      setExecFileBehavior(async (call) => {
+        const parsed = parseBatchArgs(call.args)
+        if (parsed.command === 'batch') {
+          seenSubCommands.push(parsed.subCommands)
+          const isScreenshotBatch = parsed.subCommands.some((c) =>
+            c.startsWith('screenshot'),
+          )
+          if (isScreenshotBatch) {
+            const dir = parsed.screenshotDir!
+            await writeFile(join(dir, 'shot.webp'), Buffer.from([0x00]))
+            return { stdout: '[]' }
+          }
+          return {
+            stdout: JSON.stringify([{}, {}, { value: '<html></html>' }]),
+          }
+        }
+        return { stdout: '' }
+      })
+
+      const svc = new (BrowserFetchService as any)()
+      await svc.fetchPage('https://example.com', {
+        timeoutMs: 5_000,
+        maxBodyBytes: 4_000_000,
+        executable: '/usr/local/bin/agent-browser-fake',
+      })
+
+      const screenshotBatch = seenSubCommands.find((s) =>
+        s.some((c) => c.startsWith('screenshot')),
+      )
+      expect(screenshotBatch).toBeDefined()
+      expect(screenshotBatch!.includes('set viewport 1280 720')).toBe(true)
+      const screenshotCmd = screenshotBatch!.find((c) =>
+        c.startsWith('screenshot'),
+      )!
+      expect(screenshotCmd).toContain('--screenshot-format webp')
+      expect(screenshotCmd).toContain('--screenshot-quality 90')
+      expect(screenshotCmd).toContain('--screenshot-dir ')
+    })
+  })
+
+  describe('WeakMap screenshot channel', () => {
+    it('attach + take returns the buffer once, undefined on second read', () => {
+      const svc = new (BrowserFetchService as any)()
+      const result = {
+        title: 'x',
+        url: 'https://x',
+        category: 'web',
+      } as EnrichmentResult
+      const buf = Buffer.from('payload')
+      svc.attachScreenshotBytes(result, buf)
+      expect(svc.takeScreenshotBytes(result)).toBe(buf)
+      expect(svc.takeScreenshotBytes(result)).toBeUndefined()
+    })
+
+    it('returns undefined for a result that was never attached', () => {
+      const svc = new (BrowserFetchService as any)()
+      const result = {
+        title: 'x',
+        url: 'https://x',
+        category: 'web',
+      } as EnrichmentResult
+      expect(svc.takeScreenshotBytes(result)).toBeUndefined()
+    })
+  })
+
+  describe('timeout path', () => {
+    it('aborts the HTML batch and throws a timeout error', async () => {
+      // Simulate the CLI never returning within the timeout. We invoke the
+      // callback only after the AbortController has aborted, with an
+      // ECONNABORTED-ish error so the service sees `ac.signal.aborted = true`.
+      execFileMock.mockImplementation((...invocationArgs: unknown[]) => {
+        const options = invocationArgs[2] as { signal?: AbortSignal }
+        const callback = invocationArgs.at(-1) as (
+          err: NodeJS.ErrnoException | null,
+          result?: { stdout: string; stderr: string },
+        ) => void
+        options.signal?.addEventListener('abort', () => {
+          const err = new Error('aborted') as NodeJS.ErrnoException
+          err.code = 'ABORT_ERR'
+          callback(err)
+        })
+        return undefined
+      })
+
+      const svc = new (BrowserFetchService as any)()
+      await expect(
+        svc.fetchHtml('https://example.com', {
+          timeoutMs: 10,
+          maxBodyBytes: 4_000_000,
+          executable: '/usr/local/bin/agent-browser-fake',
+        }),
+      ).rejects.toThrow(/timed out after 10ms/)
+    })
+  })
+
+  describe('tempdir cleanup edge case', () => {
+    it('removes the screenshot tempdir it created after a successful run', async () => {
+      // Race-safe: snapshot exactly the tempdir the service mkdtemp'd via
+      // the CLI's --screenshot-dir argument, then assert it is gone after
+      // the call. We don't enumerate sibling entries in os.tmpdir(), so
+      // parallel test files don't perturb the assertion.
+      const seenScreenshotDirs: string[] = []
+      setExecFileBehavior(async (call) => {
+        const parsed = parseBatchArgs(call.args)
+        if (parsed.command === 'batch') {
+          const isScreenshotBatch = parsed.subCommands.some((c) =>
+            c.startsWith('screenshot'),
+          )
+          if (isScreenshotBatch) {
+            const dir = parsed.screenshotDir!
+            seenScreenshotDirs.push(dir)
+            await writeFile(join(dir, 'c.webp'), Buffer.from([0x01]))
+            return { stdout: '[]' }
+          }
+          return {
+            stdout: JSON.stringify([{}, {}, { value: '<html/>' }]),
+          }
+        }
+        return { stdout: '' }
+      })
+
+      const svc = new (BrowserFetchService as any)()
+      await svc.fetchPage('https://example.com', {
+        timeoutMs: 5_000,
+        maxBodyBytes: 4_000_000,
+        executable: '/usr/local/bin/agent-browser-fake',
+      })
+
+      expect(seenScreenshotDirs).toHaveLength(1)
+      expect(existsSync(seenScreenshotDirs[0])).toBe(false)
+    })
+  })
+})

--- a/apps/core/test/src/modules/enrichment/browser-session-pool.spec.ts
+++ b/apps/core/test/src/modules/enrichment/browser-session-pool.spec.ts
@@ -125,6 +125,28 @@ describe('BrowserSessionPool', () => {
     await expect(pool.acquire()).rejects.toThrow(/shut down/i)
   })
 
+  it('discard release with a queued waiter does NOT hand the discarded slot to the waiter', async () => {
+    // Regression: discard fires close asynchronously; flushWaiter must not
+    // see the slot being torn down, or the waiter ends up sharing a session
+    // name with an in-flight `agent-browser ... close`.
+    const pool = new BrowserSessionPool({ maxSize: 1, idleMs: 60_000 })
+    const a = await pool.acquire()
+    const waiterPromise = pool.acquire()
+    pool.release(a, { discard: true })
+    const b = await waiterPromise
+    // Slot index reused (pool was emptied), so name collides — but the
+    // important invariant is that the slot object now in the pool is a
+    // fresh one, observable via the close-call count: discard issues one
+    // close, the waiter's slot has not been closed yet.
+    const closeCalls = execFileMock.mock.calls.filter(
+      (call) => (call[1] as string[]).at(-1) === 'close',
+    )
+    expect(closeCalls.length).toBe(1)
+    expect(b.name).toBe('og-pool-0')
+    pool.release(b)
+    await pool.shutdown()
+  })
+
   it('acquire waiter cancelled by aborted signal rejects without consuming a slot', async () => {
     const pool = new BrowserSessionPool({ maxSize: 1, idleMs: 60_000 })
     const a = await pool.acquire()

--- a/apps/core/test/src/modules/enrichment/browser-session-pool.spec.ts
+++ b/apps/core/test/src/modules/enrichment/browser-session-pool.spec.ts
@@ -1,0 +1,142 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const { execFileMock } = vi.hoisted(() => ({
+  execFileMock: vi.fn(),
+}))
+
+vi.mock('node:child_process', async () => {
+  const actual =
+    await vi.importActual<typeof import('node:child_process')>(
+      'node:child_process',
+    )
+  return { ...actual, execFile: execFileMock }
+})
+
+const { BrowserSessionPool } =
+  await import('~/modules/enrichment/providers/open-graph/browser-session-pool')
+
+function mockExecFileSuccess(): void {
+  execFileMock.mockImplementation((...args: unknown[]) => {
+    const cb = args.at(-1) as (
+      err: NodeJS.ErrnoException | null,
+      r?: { stdout: string; stderr: string },
+    ) => void
+    // sync callback so awaits resolve under fake timers without needing
+    // setImmediate / microtask flushing
+    cb(null, { stdout: '[]', stderr: '' })
+    return undefined
+  })
+}
+
+beforeEach(() => {
+  execFileMock.mockReset()
+  mockExecFileSuccess()
+  vi.useFakeTimers()
+})
+
+afterEach(() => {
+  vi.useRealTimers()
+})
+
+describe('BrowserSessionPool', () => {
+  it('acquire returns a slot named og-pool-0 on first use', async () => {
+    const pool = new BrowserSessionPool({ maxSize: 2, idleMs: 60_000 })
+    const slot = await pool.acquire()
+    expect(slot.name).toBe('og-pool-0')
+    pool.release(slot)
+    await pool.shutdown()
+  })
+
+  it('two concurrent acquires up to cap return distinct slots without queueing', async () => {
+    const pool = new BrowserSessionPool({ maxSize: 2, idleMs: 60_000 })
+    const a = await pool.acquire()
+    const b = await pool.acquire()
+    expect([a.name, b.name].sort()).toEqual(['og-pool-0', 'og-pool-1'])
+    pool.release(a)
+    pool.release(b)
+    await pool.shutdown()
+  })
+
+  it('third acquire at cap blocks until a slot is released', async () => {
+    const pool = new BrowserSessionPool({ maxSize: 2, idleMs: 60_000 })
+    const a = await pool.acquire()
+    const b = await pool.acquire()
+    const cPromise = pool.acquire()
+    let resolved = false
+    cPromise.then(() => {
+      resolved = true
+    })
+    await Promise.resolve()
+    expect(resolved).toBe(false)
+    pool.release(a)
+    const c = await cPromise
+    expect(c.name).toBe(a.name)
+    pool.release(b)
+    pool.release(c)
+    await pool.shutdown()
+  })
+
+  it('release with discard:true closes the session and frees the slot', async () => {
+    const pool = new BrowserSessionPool({ maxSize: 1, idleMs: 60_000 })
+    const a = await pool.acquire()
+    pool.release(a, { discard: true })
+    // discard issues a close; next acquire creates a fresh session with the
+    // same name (slot index reused).
+    const b = await pool.acquire()
+    expect(b.name).toBe(a.name)
+    const closedCall = execFileMock.mock.calls.find(
+      (call) => (call[1] as string[]).at(-1) === 'close',
+    )
+    expect(closedCall).toBeDefined()
+    pool.release(b)
+    await pool.shutdown()
+  })
+
+  it('idle slot is closed after idleMs and the slot index is recyclable', async () => {
+    const pool = new BrowserSessionPool({ maxSize: 1, idleMs: 1_000 })
+    const a = await pool.acquire()
+    pool.release(a)
+    expect(execFileMock).not.toHaveBeenCalled()
+    vi.advanceTimersByTime(1_000)
+    await vi.runAllTicks()
+    const closedCall = execFileMock.mock.calls.find(
+      (call) => (call[1] as string[]).at(-1) === 'close',
+    )
+    expect(closedCall).toBeDefined()
+    await pool.shutdown()
+  })
+
+  it('shutdown closes every live slot', async () => {
+    const pool = new BrowserSessionPool({ maxSize: 2, idleMs: 60_000 })
+    const a = await pool.acquire()
+    const b = await pool.acquire()
+    pool.release(a)
+    pool.release(b)
+    await pool.shutdown()
+    const closeCalls = execFileMock.mock.calls.filter(
+      (call) => (call[1] as string[]).at(-1) === 'close',
+    )
+    expect(closeCalls.length).toBe(2)
+  })
+
+  it('acquire after shutdown rejects', async () => {
+    const pool = new BrowserSessionPool({ maxSize: 1, idleMs: 60_000 })
+    await pool.shutdown()
+    await expect(pool.acquire()).rejects.toThrow(/shut down/i)
+  })
+
+  it('acquire waiter cancelled by aborted signal rejects without consuming a slot', async () => {
+    const pool = new BrowserSessionPool({ maxSize: 1, idleMs: 60_000 })
+    const a = await pool.acquire()
+    const ac = new AbortController()
+    const waiter = pool.acquire({ signal: ac.signal })
+    ac.abort()
+    await expect(waiter).rejects.toThrow(/aborted/i)
+    pool.release(a)
+    // ensure no leftover waiter consumed the freed slot
+    const b = await pool.acquire()
+    expect(b.name).toBe(a.name)
+    pool.release(b)
+    await pool.shutdown()
+  })
+})

--- a/apps/core/test/src/modules/enrichment/enrichment.service.spec.ts
+++ b/apps/core/test/src/modules/enrichment/enrichment.service.spec.ts
@@ -115,6 +115,25 @@ function makeService(stubs: ServiceStubs = {}) {
     registerHandler: vi.fn(),
   }
 
+  const browserFetch = {
+    // Default: no screenshot bytes attached → post-persist screenshot block
+    // short-circuits before touching pipeline/storage/config.
+    takeScreenshotBytes: vi.fn(() => undefined),
+    attachScreenshotBytes: vi.fn(),
+  }
+  const screenshotPipeline = {
+    process: vi.fn(async () => null),
+  }
+  const screenshotStorage = {
+    storeOrEvict: vi.fn(async () => ({
+      url: 'https://example.test/screenshot.webp',
+      objectKey: 'enrichment-screenshots/x.webp',
+      bytes: 1024,
+    })),
+    delete: vi.fn(async () => undefined),
+    touchAccess: vi.fn(async () => undefined),
+  }
+
   const service = Object.create(EnrichmentService.prototype) as any
   service.repository = repository
   service.providerRegistry = providerRegistry
@@ -123,6 +142,9 @@ function makeService(stubs: ServiceStubs = {}) {
   service.imageService = imageService
   service.taskQueueService = taskQueueService
   service.taskQueueProcessor = taskQueueProcessor
+  service.browserFetch = browserFetch
+  service.screenshotPipeline = screenshotPipeline
+  service.screenshotStorage = screenshotStorage
   service.logger = { warn: vi.fn(), log: vi.fn() }
 
   return {

--- a/apps/core/test/src/modules/enrichment/open-graph-screenshot.integration.spec.ts
+++ b/apps/core/test/src/modules/enrichment/open-graph-screenshot.integration.spec.ts
@@ -230,25 +230,32 @@ describe('OpenGraph screenshot integration (Task 4)', () => {
     const browserFetch = new BrowserFetchService(browserFetchPool)
     const png = await makePngBytes()
     // Stub network step but keep the real WeakMap / attach contract intact.
-    vi.spyOn(browserFetch, 'fetchPage').mockImplementation(async (url) => ({
-      html: {
-        finalUrl: url,
-        contentType: 'text/html',
-        body: makeHtmlBody(url),
-        truncated: false,
-      },
-      screenshotBytes: opts.withoutScreenshotBytes ? undefined : png,
-    }))
+    const fetchPageSpy = vi
+      .spyOn(browserFetch, 'fetchPage')
+      .mockImplementation(async (url, fetchOpts) => ({
+        html: {
+          finalUrl: url,
+          contentType: 'text/html',
+          body: makeHtmlBody(url),
+          truncated: false,
+        },
+        screenshotBytes:
+          opts.withoutScreenshotBytes || fetchOpts.captureScreenshot === false
+            ? undefined
+            : png,
+      }))
 
     const pipeline = new ScreenshotPipelineService()
+    const processSpy = vi.spyOn(pipeline, 'process')
     if (opts.pipelineOverride === null) {
-      vi.spyOn(pipeline, 'process').mockResolvedValue(null)
+      processSpy.mockResolvedValue(null)
     } else if (opts.pipelineOverride) {
-      vi.spyOn(pipeline, 'process').mockResolvedValue(opts.pipelineOverride)
+      processSpy.mockResolvedValue(opts.pipelineOverride)
     }
 
     const storage = new TestScreenshotStorageService(
       screenshotRepository,
+      repository,
       configsService,
       redisService,
     )
@@ -284,7 +291,9 @@ describe('OpenGraph screenshot integration (Task 4)', () => {
       service,
       storage,
       pipeline,
+      processSpy,
       browserFetch,
+      fetchPageSpy,
       repository,
       screenshotRepository,
       touchSpy,
@@ -314,13 +323,18 @@ describe('OpenGraph screenshot integration (Task 4)', () => {
     expect(fakeS3.putCalls).toHaveLength(1)
   })
 
-  it('screenshot disabled: bytes captured but never stored', async () => {
-    const { service, fakeS3 } = await buildHarness({
+  it('screenshot disabled: browser metadata fetch does not capture or store bytes', async () => {
+    const { service, fakeS3, fetchPageSpy, processSpy } = await buildHarness({
       screenshot: { enabled: false },
     })
 
     const { result } = await service.resolve(RESOLVE_URL)
     expect(result.screenshot).toBeUndefined()
+    expect(fetchPageSpy).toHaveBeenCalledWith(
+      RESOLVE_URL,
+      expect.objectContaining({ captureScreenshot: false }),
+    )
+    expect(processSpy).not.toHaveBeenCalled()
     expect(fakeS3.putCalls).toHaveLength(0)
   })
 

--- a/apps/core/test/src/modules/enrichment/open-graph-screenshot.integration.spec.ts
+++ b/apps/core/test/src/modules/enrichment/open-graph-screenshot.integration.spec.ts
@@ -1,0 +1,358 @@
+import sharp from 'sharp'
+import {
+  createPgTestDatabase,
+  type PgTestDatabase,
+} from 'test/helper/pg-verify-url'
+import {
+  afterAll,
+  afterEach,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+} from 'vitest'
+
+import { EnrichmentRepository } from '~/modules/enrichment/enrichment.repository'
+import { EnrichmentService } from '~/modules/enrichment/enrichment.service'
+import { EnrichmentScreenshotRepository } from '~/modules/enrichment/enrichment-screenshot.repository'
+import { BrowserFetchService } from '~/modules/enrichment/providers/open-graph/browser-fetch.service'
+import { OpenGraphProvider } from '~/modules/enrichment/providers/open-graph/open-graph.provider'
+import {
+  type ProcessedScreenshot,
+  ScreenshotPipelineService,
+} from '~/modules/enrichment/providers/open-graph/screenshot-pipeline.service'
+import { ScreenshotStorageService } from '~/modules/enrichment/providers/open-graph/screenshot-storage.service'
+import { ProviderRegistry } from '~/modules/enrichment/providers/provider.registry'
+import { SnowflakeService } from '~/shared/id/snowflake.service'
+import type { S3Uploader } from '~/utils/s3.util'
+
+/**
+ * Integration coverage for Task 4: the post-persist screenshot pipeline.
+ *
+ * Wires real {@link EnrichmentService} + repositories against a Postgres
+ * testcontainer, with three controllable seams:
+ *
+ *  - `BrowserFetchService.fetchPage` → returns synthesized HTML + a tiny PNG
+ *    (the open-graph provider feeds the PNG into the WeakMap channel).
+ *  - `ScreenshotStorageService.getUploader` → returns an in-memory fake S3
+ *    that records put/delete calls and can be made to throw on demand.
+ *  - `ScreenshotPipelineService.process` → swapped per test so we can force
+ *    a `null` (oversize) return without re-engineering image fixtures.
+ *
+ * Covers the happy path, screenshot-disabled, pipeline-null, storage-throws,
+ * and the controller-style touchAccess fire-and-forget on a cache hit.
+ */
+
+class FakeS3Uploader {
+  public objects = new Map<string, Buffer>()
+  public putCalls: Array<{ key: string; bytes: number }> = []
+  public deleteCalls: string[] = []
+  public nextUploadError: Error | null = null
+
+  async uploadBuffer(
+    buffer: Buffer,
+    objectKey: string,
+    _contentType: string,
+  ): Promise<string> {
+    this.putCalls.push({ key: objectKey, bytes: buffer.length })
+    if (this.nextUploadError) {
+      const err = this.nextUploadError
+      this.nextUploadError = null
+      throw err
+    }
+    this.objects.set(objectKey, buffer)
+    return this.getPublicUrl(objectKey)
+  }
+
+  async deleteObject(objectKey: string): Promise<void> {
+    this.deleteCalls.push(objectKey)
+    this.objects.delete(objectKey)
+  }
+
+  getPublicUrl(objectKey: string): string {
+    return `https://cdn.example.test/${objectKey}`
+  }
+}
+
+class TestScreenshotStorageService extends ScreenshotStorageService {
+  public readonly fakeS3 = new FakeS3Uploader()
+  protected override async getUploader(): Promise<S3Uploader> {
+    return this.fakeS3 as unknown as S3Uploader
+  }
+}
+
+async function makePngBytes(): Promise<Buffer> {
+  return sharp({
+    create: {
+      width: 320,
+      height: 180,
+      channels: 4,
+      background: { r: 30, g: 120, b: 220, alpha: 1 },
+    },
+  })
+    .png()
+    .toBuffer()
+}
+
+function makeHtmlBody(url: string, title = 'integration title'): string {
+  return `<!DOCTYPE html><html><head>
+    <title>${title}</title>
+    <meta property="og:title" content="${title}">
+    <meta property="og:description" content="integration description">
+    <link rel="canonical" href="${url}">
+  </head><body></body></html>`
+}
+
+interface BuildOptions {
+  /**
+   * Override `thirdPartyServiceIntegration.openGraph.screenshot`. When omitted,
+   * defaults to `{ enabled: true, ...sane caps }`.
+   */
+  screenshot?: Partial<{
+    enabled: boolean
+    maxItems: number
+    maxTotalBytes: number
+    maxBytesPerImage: number
+    webpQuality: number
+  }>
+  /**
+   * Override the pipeline result. When set to `null`, the pipeline's
+   * `process` returns `null` (oversize / drop). When set to a Buffer, the
+   * underlying real pipeline runs against those bytes.
+   */
+  pipelineOverride?: ProcessedScreenshot | null
+  /**
+   * Force `storeOrEvict` to throw the given error.
+   */
+  storageError?: Error
+  /**
+   * Force `BrowserFetchService.fetchPage` to omit screenshotBytes (HTTP-like
+   * shape but in browser mode — exercises the "no bytes attached" branch).
+   */
+  withoutScreenshotBytes?: boolean
+}
+
+describe('OpenGraph screenshot integration (Task 4)', () => {
+  let context: PgTestDatabase
+  let snowflake: SnowflakeService
+  const RESOLVE_URL = 'https://integration.example.test/post/1'
+
+  beforeAll(async () => {
+    context = await createPgTestDatabase('mx_og_screenshot')
+    snowflake = new SnowflakeService()
+  }, 60_000)
+
+  afterAll(async () => {
+    if (context) await context.close()
+  })
+
+  beforeEach(async () => {
+    await context.pool.query('TRUNCATE enrichment_cache CASCADE')
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  async function buildHarness(opts: BuildOptions = {}) {
+    const repository = new EnrichmentRepository(context.db as any, snowflake)
+    const screenshotRepository = new EnrichmentScreenshotRepository(
+      context.db as any,
+    )
+
+    const screenshot = {
+      enabled: true,
+      maxItems: 500,
+      maxTotalBytes: 100 * 1024 * 1024,
+      maxBytesPerImage: 1024 * 1024,
+      webpQuality: 75,
+      ...opts.screenshot,
+    }
+
+    const configsService = {
+      get: vi.fn(async (key: string) => {
+        if (key === 'thirdPartyServiceIntegration') {
+          return {
+            openGraph: { enabled: true, fetchMode: 'browser', screenshot },
+          }
+        }
+        if (key === 'imageStorageOptions') {
+          return {
+            enable: true,
+            endpoint: 'https://s3.example.test',
+            secretId: 'AKIATEST',
+            secretKey: 'SECRET',
+            bucket: 'mx-test',
+            region: 'auto',
+            customDomain: '',
+          }
+        }
+        return {}
+      }),
+    } as any
+
+    const redisClient = {
+      get: vi.fn(async () => null),
+      set: vi.fn(async () => 'OK'),
+      del: vi.fn(async () => 1),
+    }
+    const redisService = {
+      getClient: () => redisClient,
+    } as any
+
+    const imageService = {
+      getOnlineImageSizeAndMeta: vi.fn(async () => ({
+        size: { width: 0, height: 0 },
+        accent: '#000000',
+        blurHash: '',
+      })),
+    } as any
+
+    const taskQueueService = {
+      createTask: vi.fn(async () => ({ taskId: 't', created: true })),
+    } as any
+    const taskQueueProcessor = {
+      registerHandler: vi.fn(),
+    } as any
+    const urlExtractor = {
+      extractFromDoc: vi.fn(() => []),
+    } as any
+
+    const browserFetch = new BrowserFetchService()
+    const png = await makePngBytes()
+    // Stub network step but keep the real WeakMap / attach contract intact.
+    vi.spyOn(browserFetch, 'fetchPage').mockImplementation(async (url) => ({
+      html: {
+        finalUrl: url,
+        contentType: 'text/html',
+        body: makeHtmlBody(url),
+        truncated: false,
+      },
+      screenshotBytes: opts.withoutScreenshotBytes ? undefined : png,
+    }))
+
+    const pipeline = new ScreenshotPipelineService()
+    if (opts.pipelineOverride === null) {
+      vi.spyOn(pipeline, 'process').mockResolvedValue(null)
+    } else if (opts.pipelineOverride) {
+      vi.spyOn(pipeline, 'process').mockResolvedValue(opts.pipelineOverride)
+    }
+
+    const storage = new TestScreenshotStorageService(
+      screenshotRepository,
+      configsService,
+      redisService,
+    )
+    if (opts.storageError) {
+      vi.spyOn(storage, 'storeOrEvict').mockRejectedValue(opts.storageError)
+    }
+    const touchSpy = vi.spyOn(storage, 'touchAccess')
+
+    const openGraphProvider = new OpenGraphProvider(
+      configsService,
+      browserFetch,
+    )
+    const providerRegistry = new ProviderRegistry()
+    providerRegistry.register(openGraphProvider)
+
+    const service = new EnrichmentService(
+      providerRegistry,
+      repository,
+      configsService,
+      redisService,
+      imageService,
+      taskQueueService,
+      taskQueueProcessor,
+      urlExtractor,
+      browserFetch,
+      pipeline,
+      storage,
+    )
+
+    return {
+      service,
+      storage,
+      pipeline,
+      browserFetch,
+      repository,
+      screenshotRepository,
+      touchSpy,
+      fakeS3: storage.fakeS3,
+    }
+  }
+
+  it('happy path: persists row, runs pipeline, attaches screenshot to response', async () => {
+    const { service, fakeS3 } = await buildHarness()
+
+    const { result } = await service.resolve(RESOLVE_URL)
+
+    expect(result.screenshot).toBeDefined()
+    expect(result.screenshot?.url).toMatch(/^https:\/\/cdn\.example\.test\//)
+    expect(result.screenshot?.width).toBeGreaterThan(0)
+    expect(result.screenshot?.height).toBeGreaterThan(0)
+    expect(result.screenshot?.palette?.dominant).toMatch(/^#[\da-f]{6}$/i)
+    expect(fakeS3.putCalls).toHaveLength(1)
+    expect(fakeS3.putCalls[0].key).toMatch(
+      /^enrichment-screenshots\/\d+\.webp$/,
+    )
+
+    // The row's normalized JSON must include the screenshot key — second
+    // resolve (cache hit) should see it without re-running the pipeline.
+    const second = await service.resolve(RESOLVE_URL)
+    expect(second.result.screenshot?.url).toBe(result.screenshot?.url)
+    expect(fakeS3.putCalls).toHaveLength(1)
+  })
+
+  it('screenshot disabled: bytes captured but never stored', async () => {
+    const { service, fakeS3 } = await buildHarness({
+      screenshot: { enabled: false },
+    })
+
+    const { result } = await service.resolve(RESOLVE_URL)
+    expect(result.screenshot).toBeUndefined()
+    expect(fakeS3.putCalls).toHaveLength(0)
+  })
+
+  it('pipeline returns null (oversize): response has no screenshot field', async () => {
+    const { service, fakeS3 } = await buildHarness({
+      pipelineOverride: null,
+    })
+
+    const { result } = await service.resolve(RESOLVE_URL)
+    expect(result.screenshot).toBeUndefined()
+    expect(fakeS3.putCalls).toHaveLength(0)
+  })
+
+  it('storage throws: response is still returned without screenshot', async () => {
+    const { service, fakeS3 } = await buildHarness({
+      storageError: new Error('simulated S3 failure'),
+    })
+
+    const { result } = await service.resolve(RESOLVE_URL)
+    expect(result.screenshot).toBeUndefined()
+    // Storage stub throws synchronously before S3 PUT, so the fake never sees
+    // the put call.
+    expect(fakeS3.putCalls).toHaveLength(0)
+  })
+
+  it('cache hit: touchAccess fires for results that carry a screenshot', async () => {
+    const { service, storage, touchSpy } = await buildHarness()
+
+    // Cold path warms the row.
+    const cold = await service.resolve(RESOLVE_URL)
+    expect(cold.result.screenshot).toBeDefined()
+    expect(cold.result.id).toBeDefined()
+
+    // Simulate the controller's fire-and-forget call on a cache-hit response.
+    // We do not import the controller here to keep this test scoped to the
+    // service-level integration; the controller code path is mechanically the
+    // same: `if (result.screenshot && result.id) storage.touchAccess(result.id)`.
+    if (cold.result.screenshot && cold.result.id) {
+      await storage.touchAccess(cold.result.id)
+    }
+
+    expect(touchSpy).toHaveBeenCalledWith(cold.result.id)
+  })
+})

--- a/apps/core/test/src/modules/enrichment/open-graph-screenshot.integration.spec.ts
+++ b/apps/core/test/src/modules/enrichment/open-graph-screenshot.integration.spec.ts
@@ -18,6 +18,7 @@ import { EnrichmentRepository } from '~/modules/enrichment/enrichment.repository
 import { EnrichmentService } from '~/modules/enrichment/enrichment.service'
 import { EnrichmentScreenshotRepository } from '~/modules/enrichment/enrichment-screenshot.repository'
 import { BrowserFetchService } from '~/modules/enrichment/providers/open-graph/browser-fetch.service'
+import { BrowserSessionPool } from '~/modules/enrichment/providers/open-graph/browser-session-pool'
 import { OpenGraphProvider } from '~/modules/enrichment/providers/open-graph/open-graph.provider'
 import {
   type ProcessedScreenshot,
@@ -138,6 +139,7 @@ describe('OpenGraph screenshot integration (Task 4)', () => {
   let context: PgTestDatabase
   let snowflake: SnowflakeService
   const RESOLVE_URL = 'https://integration.example.test/post/1'
+  const activePools: BrowserSessionPool[] = []
 
   beforeAll(async () => {
     context = await createPgTestDatabase('mx_og_screenshot')
@@ -152,8 +154,9 @@ describe('OpenGraph screenshot integration (Task 4)', () => {
     await context.pool.query('TRUNCATE enrichment_cache CASCADE')
   })
 
-  afterEach(() => {
+  afterEach(async () => {
     vi.restoreAllMocks()
+    await Promise.all(activePools.splice(0).map((p) => p.shutdown()))
   })
 
   async function buildHarness(opts: BuildOptions = {}) {
@@ -220,7 +223,11 @@ describe('OpenGraph screenshot integration (Task 4)', () => {
       extractFromDoc: vi.fn(() => []),
     } as any
 
-    const browserFetch = new BrowserFetchService()
+    const browserFetchPool = new BrowserSessionPool({
+      maxSize: 1,
+      idleMs: 60_000,
+    })
+    const browserFetch = new BrowserFetchService(browserFetchPool)
     const png = await makePngBytes()
     // Stub network step but keep the real WeakMap / attach contract intact.
     vi.spyOn(browserFetch, 'fetchPage').mockImplementation(async (url) => ({
@@ -270,6 +277,8 @@ describe('OpenGraph screenshot integration (Task 4)', () => {
       pipeline,
       storage,
     )
+
+    activePools.push(browserFetchPool)
 
     return {
       service,

--- a/apps/core/test/src/modules/enrichment/screenshot-pipeline.service.spec.ts
+++ b/apps/core/test/src/modules/enrichment/screenshot-pipeline.service.spec.ts
@@ -1,0 +1,159 @@
+import { decode } from 'blurhash'
+import sharp from 'sharp'
+import { beforeAll, describe, expect, it } from 'vitest'
+
+import { ScreenshotPipelineService } from '~/modules/enrichment/providers/open-graph/screenshot-pipeline.service'
+
+// Fixture images are synthesized at test setup with `sharp` so no binary
+// asset needs to live in the repo. The shapes are picked to exercise:
+//   - the normal happy path (mixed colors with a clear dominant)
+//   - the clamp branch (input larger than 1280x720)
+//   - the size-cap branch (a noisy/large image at high quality)
+
+const HEX_RE = /^#[\da-f]{6}$/i
+
+async function makePngBuffer(opts: {
+  width: number
+  height: number
+  background: { r: number; g: number; b: number; alpha: number }
+}): Promise<Buffer> {
+  return sharp({
+    create: {
+      width: opts.width,
+      height: opts.height,
+      channels: 4,
+      background: opts.background,
+    },
+  })
+    .png()
+    .toBuffer()
+}
+
+async function makeMultiColorPng(
+  width: number,
+  height: number,
+): Promise<Buffer> {
+  const base = await makePngBuffer({
+    width,
+    height,
+    background: { r: 20, g: 30, b: 200, alpha: 1 },
+  })
+  // Composite two distinct color stripes so the swatch extractor sees more
+  // than one bucket. Stripes occupy ~30% + ~20% of the image.
+  const stripeOne = await makePngBuffer({
+    width: Math.round(width * 0.3),
+    height,
+    background: { r: 220, g: 40, b: 40, alpha: 1 },
+  })
+  const stripeTwo = await makePngBuffer({
+    width: Math.round(width * 0.2),
+    height,
+    background: { r: 40, g: 200, b: 60, alpha: 1 },
+  })
+  return sharp(base)
+    .composite([
+      { input: stripeOne, top: 0, left: 0 },
+      { input: stripeTwo, top: 0, left: Math.round(width * 0.7) },
+    ])
+    .png()
+    .toBuffer()
+}
+
+/**
+ * High-entropy per-pixel noise: a seeded LCG drives independent R/G/B bytes
+ * so the resulting image has no spatial structure for webp to exploit. Even
+ * at q=80 the encoded byte count for 1280x720 sits well above 100, which is
+ * what the size-cap test relies on.
+ */
+async function makeRandomNoisePng(
+  width: number,
+  height: number,
+): Promise<Buffer> {
+  const channels = 3
+  const data = Buffer.alloc(width * height * channels)
+  // Linear congruential generator (Numerical Recipes constants); fast,
+  // deterministic, fine for "looks random" image data.
+  let state = 0x12345678
+  for (let i = 0; i < data.length; i++) {
+    state = (Math.imul(state, 1664525) + 1013904223) | 0
+    data[i] = (state >>> 16) & 0xff
+  }
+  return sharp(data, { raw: { width, height, channels } }).png().toBuffer()
+}
+
+describe('ScreenshotPipelineService', () => {
+  let service: ScreenshotPipelineService
+  let multiColor1280: Buffer
+  let multiColorLarge: Buffer
+  let noisyLarge: Buffer
+
+  beforeAll(async () => {
+    service = new ScreenshotPipelineService()
+    multiColor1280 = await makeMultiColorPng(1280, 720)
+    multiColorLarge = await makeMultiColorPng(2560, 1440)
+    noisyLarge = await makeRandomNoisePng(1280, 720)
+  })
+
+  it('returns processed screenshot for a normal image', async () => {
+    const result = await service.process(multiColor1280, {
+      webpQuality: 75,
+      maxBytesPerImage: 1024 * 1024,
+    })
+
+    expect(result).not.toBeNull()
+    expect(result!.webp.length).toBeGreaterThan(0)
+    expect(result!.width).toBe(1280)
+    expect(result!.height).toBe(720)
+    expect(result!.palette.dominant).toMatch(HEX_RE)
+    expect(result!.blurhash).toBeTypeOf('string')
+    expect(result!.blurhash.length).toBeGreaterThan(0)
+  })
+
+  it('clamps oversized input to <=1280 / <=720', async () => {
+    const result = await service.process(multiColorLarge, {
+      webpQuality: 75,
+      maxBytesPerImage: 2 * 1024 * 1024,
+    })
+    expect(result).not.toBeNull()
+    expect(result!.width).toBeLessThanOrEqual(1280)
+    expect(result!.height).toBeLessThanOrEqual(720)
+  })
+
+  it('extracts swatches as #RRGGBB strings', async () => {
+    const result = await service.process(multiColor1280, {
+      webpQuality: 75,
+      maxBytesPerImage: 1024 * 1024,
+    })
+    expect(result).not.toBeNull()
+    const swatches = result!.palette.swatches ?? []
+    expect(swatches.length).toBeGreaterThan(0)
+    for (const s of swatches) {
+      expect(s).toMatch(HEX_RE)
+    }
+  })
+
+  it('produces a blurhash that decodes to a non-trivial canvas', async () => {
+    const result = await service.process(multiColor1280, {
+      webpQuality: 75,
+      maxBytesPerImage: 1024 * 1024,
+    })
+    expect(result).not.toBeNull()
+    const decoded = decode(result!.blurhash, 32, 32)
+    // 32 * 32 RGBA = 4096 bytes
+    expect(decoded).toBeInstanceOf(Uint8ClampedArray)
+    expect(decoded.length).toBe(32 * 32 * 4)
+    const nonZero = decoded.some((v) => v !== 0)
+    expect(nonZero).toBe(true)
+  })
+
+  it('returns null when even the retry-quality webp exceeds the byte cap', async () => {
+    // 1280x720 of LCG noise will not compress under 100 bytes at q=95 nor
+    // at the retry q=80, so the pipeline must drop the screenshot. This
+    // is the deterministic null branch and the warn log path.
+    const result = await service.process(noisyLarge, {
+      webpQuality: 95,
+      maxBytesPerImage: 100,
+    })
+    expect(result).toBeNull()
+  })
+})

--- a/apps/core/test/src/modules/enrichment/screenshot-storage.service.spec.ts
+++ b/apps/core/test/src/modules/enrichment/screenshot-storage.service.spec.ts
@@ -517,4 +517,79 @@ describe('ScreenshotStorageService', () => {
     expect(touchSpy).not.toHaveBeenCalled()
     touchSpy.mockRestore()
   })
+
+  it('serializes concurrent storeOrEvict so quota check + write never interleave', async () => {
+    // Regression for the codex P2 race: getQuotaUsage → S3 PUT → DB upsert
+    // is not transactional. Two concurrent storeOrEvict calls inside the
+    // same process must run sequentially or both observe headroom and
+    // overshoot maxItems / maxTotalBytes.
+    const id1 = generator.nextId()
+    const id2 = generator.nextId()
+    await seedEnrichment(context, id1)
+    await seedEnrichment(context, id2)
+    const { redisService } = makeRedisService()
+    const service = new TestScreenshotStorageService(
+      repository,
+      makeConfigsService(),
+      redisService,
+    )
+
+    const events: Array<'start' | 'end'> = []
+    const originalUpload = service.fakeS3.uploadBuffer.bind(service.fakeS3)
+    service.fakeS3.uploadBuffer = (async (
+      buf: Buffer,
+      key: string,
+      contentType: string,
+    ) => {
+      events.push('start')
+      // Hold the critical section briefly so any interleaving from the
+      // second concurrent call has a chance to surface.
+      await new Promise((r) => setTimeout(r, 20))
+      const url = await originalUpload(buf, key, contentType)
+      events.push('end')
+      return url
+    }) as typeof service.fakeS3.uploadBuffer
+
+    await Promise.all([
+      service.storeOrEvict({
+        enrichmentId: id1,
+        processed: makeProcessed({ webp: Buffer.alloc(1024, 1) }),
+      }),
+      service.storeOrEvict({
+        enrichmentId: id2,
+        processed: makeProcessed({ webp: Buffer.alloc(1024, 2) }),
+      }),
+    ])
+
+    expect(events).toEqual(['start', 'end', 'start', 'end'])
+    expect(service.fakeS3.putCalls).toHaveLength(2)
+  })
+
+  it('a rejected storeOrEvict does not poison subsequent calls', async () => {
+    const id1 = generator.nextId()
+    const id2 = generator.nextId()
+    await seedEnrichment(context, id1)
+    await seedEnrichment(context, id2)
+    const { redisService } = makeRedisService()
+    const service = new TestScreenshotStorageService(
+      repository,
+      makeConfigsService(),
+      redisService,
+    )
+
+    service.fakeS3.nextUploadError = new Error('boom')
+    await expect(
+      service.storeOrEvict({
+        enrichmentId: id1,
+        processed: makeProcessed(),
+      }),
+    ).rejects.toThrow(/boom/)
+
+    // Second call must proceed despite the first chain link rejecting.
+    const result = await service.storeOrEvict({
+      enrichmentId: id2,
+      processed: makeProcessed(),
+    })
+    expect(result.objectKey).toBe(`enrichment-screenshots/${id2}.webp`)
+  })
 })

--- a/apps/core/test/src/modules/enrichment/screenshot-storage.service.spec.ts
+++ b/apps/core/test/src/modules/enrichment/screenshot-storage.service.spec.ts
@@ -5,6 +5,7 @@ import {
 } from 'test/helper/pg-verify-url'
 
 import { enrichmentCache, enrichmentScreenshots } from '~/database/schema'
+import { EnrichmentRepository } from '~/modules/enrichment/enrichment.repository'
 import { EnrichmentScreenshotRepository } from '~/modules/enrichment/enrichment-screenshot.repository'
 import type { ProcessedScreenshot } from '~/modules/enrichment/providers/open-graph/screenshot-pipeline.service'
 import { ScreenshotStorageService } from '~/modules/enrichment/providers/open-graph/screenshot-storage.service'
@@ -155,6 +156,28 @@ async function seedEnrichment(
   })
 }
 
+async function setCachedScreenshot(ctx: PgTestDatabase, id: string) {
+  await ctx.pool.query(
+    `update enrichment_cache set normalized = jsonb_set(normalized, '{screenshot}', $1::jsonb) where id = $2`,
+    [
+      JSON.stringify({
+        url: `https://cdn.example.test/enrichment-screenshots/${id}.webp`,
+        width: 1280,
+        height: 720,
+      }),
+      id,
+    ],
+  )
+}
+
+async function readCachedNormalized(ctx: PgTestDatabase, id: string) {
+  const result = await ctx.pool.query(
+    `select normalized from enrichment_cache where id = $1`,
+    [id],
+  )
+  return result.rows[0]?.normalized as Record<string, unknown> | undefined
+}
+
 /**
  * Stamp a deterministic `last_accessed_at` on an existing screenshot row.
  * Avoids `setTimeout`-based ordering, which is fragile under CI load.
@@ -173,10 +196,14 @@ async function stampAccessTime(
 describe('ScreenshotStorageService', () => {
   let context: PgTestDatabase
   let repository: EnrichmentScreenshotRepository
+  let cacheRepository: EnrichmentRepository
 
   beforeAll(async () => {
     context = await createPgTestDatabase('mx_screenshot_storage')
     repository = new EnrichmentScreenshotRepository(context.db as any)
+    cacheRepository = new EnrichmentRepository(context.db as any, {
+      nextId: async () => generator.nextId(),
+    } as any)
   }, 60_000)
 
   afterAll(async () => {
@@ -202,6 +229,7 @@ describe('ScreenshotStorageService', () => {
     const { redisService } = makeRedisService()
     const service = new TestScreenshotStorageService(
       repository,
+      cacheRepository,
       makeConfigsService(),
       redisService,
     )
@@ -235,6 +263,7 @@ describe('ScreenshotStorageService', () => {
     const { redisService } = makeRedisService()
     const service = new TestScreenshotStorageService(
       repository,
+      cacheRepository,
       makeConfigsService(),
       redisService,
     )
@@ -276,6 +305,7 @@ describe('ScreenshotStorageService', () => {
     const { redisService } = makeRedisService()
     const service = new TestScreenshotStorageService(
       repository,
+      cacheRepository,
       makeConfigsService({ maxItems: 2 }),
       redisService,
     )
@@ -286,6 +316,7 @@ describe('ScreenshotStorageService', () => {
       enrichmentId: ids[0],
       processed: makeProcessed({ webp: Buffer.alloc(1024, 1) }),
     })
+    await setCachedScreenshot(context, ids[0])
     await stampAccessTime(context, ids[0], '2020-01-01T00:00:00Z')
     await service.storeOrEvict({
       enrichmentId: ids[1],
@@ -305,6 +336,9 @@ describe('ScreenshotStorageService', () => {
       `enrichment-screenshots/${ids[0]}.webp`,
     ])
     expect(await repository.findByEnrichmentId(ids[0])).toBeNull()
+    expect(await readCachedNormalized(context, ids[0])).toEqual({
+      title: 'probe',
+    })
     expect(await repository.findByEnrichmentId(ids[1])).not.toBeNull()
     expect(await repository.findByEnrichmentId(ids[2])).not.toBeNull()
   })
@@ -318,6 +352,7 @@ describe('ScreenshotStorageService', () => {
     // each row is 1500 bytes, so the third write needs eviction.
     const service = new TestScreenshotStorageService(
       repository,
+      cacheRepository,
       makeConfigsService({ maxItems: 100, maxTotalBytes: 3000 }),
       redisService,
     )
@@ -352,6 +387,7 @@ describe('ScreenshotStorageService', () => {
     const { redisService } = makeRedisService()
     const service = new TestScreenshotStorageService(
       repository,
+      cacheRepository,
       makeConfigsService({ maxItems: 1 }),
       redisService,
     )
@@ -395,6 +431,7 @@ describe('ScreenshotStorageService', () => {
     const { redisService } = makeRedisService()
     const service = new TestScreenshotStorageService(
       repository,
+      cacheRepository,
       makeConfigsService(),
       redisService,
     )
@@ -417,6 +454,7 @@ describe('ScreenshotStorageService', () => {
     const { redisService } = makeRedisService()
     const service = new TestScreenshotStorageService(
       repository,
+      cacheRepository,
       makeConfigsService(),
       redisService,
     )
@@ -431,6 +469,7 @@ describe('ScreenshotStorageService', () => {
     const { redisService } = makeRedisService()
     const service = new TestScreenshotStorageService(
       repository,
+      cacheRepository,
       makeConfigsService(),
       redisService,
     )
@@ -478,6 +517,7 @@ describe('ScreenshotStorageService', () => {
     const touchSpy = vi.spyOn(repository, 'touchAccess')
     const service = new TestScreenshotStorageService(
       repository,
+      cacheRepository,
       makeConfigsService(),
       redisService,
     )
@@ -508,6 +548,7 @@ describe('ScreenshotStorageService', () => {
     const touchSpy = vi.spyOn(repository, 'touchAccess')
     const service = new TestScreenshotStorageService(
       repository,
+      cacheRepository,
       makeConfigsService(),
       redisService,
     )
@@ -530,6 +571,7 @@ describe('ScreenshotStorageService', () => {
     const { redisService } = makeRedisService()
     const service = new TestScreenshotStorageService(
       repository,
+      cacheRepository,
       makeConfigsService(),
       redisService,
     )
@@ -573,6 +615,7 @@ describe('ScreenshotStorageService', () => {
     const { redisService } = makeRedisService()
     const service = new TestScreenshotStorageService(
       repository,
+      cacheRepository,
       makeConfigsService(),
       redisService,
     )

--- a/apps/core/test/src/modules/enrichment/screenshot-storage.service.spec.ts
+++ b/apps/core/test/src/modules/enrichment/screenshot-storage.service.spec.ts
@@ -1,0 +1,520 @@
+import { Logger } from '@nestjs/common'
+import {
+  createPgTestDatabase,
+  type PgTestDatabase,
+} from 'test/helper/pg-verify-url'
+
+import { enrichmentCache, enrichmentScreenshots } from '~/database/schema'
+import { EnrichmentScreenshotRepository } from '~/modules/enrichment/enrichment-screenshot.repository'
+import type { ProcessedScreenshot } from '~/modules/enrichment/providers/open-graph/screenshot-pipeline.service'
+import { ScreenshotStorageService } from '~/modules/enrichment/providers/open-graph/screenshot-storage.service'
+import { SnowflakeGenerator } from '~/shared/id/snowflake.service'
+import type { S3Uploader } from '~/utils/s3.util'
+
+/**
+ * In-memory fake of {@link S3Uploader} sufficient to exercise the storage
+ * service. We type-assert via `as unknown as S3Uploader` so the service can
+ * accept the fake without needing to implement every method on the real class.
+ */
+class FakeS3Uploader {
+  public objects = new Map<string, Buffer>()
+  public putCalls: Array<{ key: string; contentType: string; bytes: number }> =
+    []
+  public deleteCalls: string[] = []
+  /** When set, the next `uploadBuffer` throws this error then clears it. */
+  public nextUploadError: Error | null = null
+  /** When set, every `deleteObject` for matching key throws. */
+  public deleteFailKeys = new Set<string>()
+
+  async uploadBuffer(
+    buffer: Buffer,
+    objectKey: string,
+    contentType: string,
+  ): Promise<string> {
+    this.putCalls.push({
+      key: objectKey,
+      contentType,
+      bytes: buffer.length,
+    })
+    if (this.nextUploadError) {
+      const err = this.nextUploadError
+      this.nextUploadError = null
+      throw err
+    }
+    this.objects.set(objectKey, buffer)
+    return this.getPublicUrl(objectKey)
+  }
+
+  async deleteObject(objectKey: string): Promise<void> {
+    this.deleteCalls.push(objectKey)
+    if (this.deleteFailKeys.has(objectKey)) {
+      throw new Error(`fake S3: delete failure for ${objectKey}`)
+    }
+    this.objects.delete(objectKey)
+  }
+
+  getPublicUrl(objectKey: string): string {
+    return `https://cdn.example.test/${objectKey}`
+  }
+}
+
+/**
+ * Subclass that injects a controllable fake S3 client and lets us swap the
+ * Redis facade per-test without spinning up a real client.
+ */
+class TestScreenshotStorageService extends ScreenshotStorageService {
+  public readonly fakeS3 = new FakeS3Uploader()
+
+  protected override async getUploader(): Promise<S3Uploader> {
+    return this.fakeS3 as unknown as S3Uploader
+  }
+}
+
+function makeProcessed(
+  overrides: Partial<ProcessedScreenshot> = {},
+): ProcessedScreenshot {
+  return {
+    webp: Buffer.alloc(1024, 0xab),
+    width: 1280,
+    height: 720,
+    blurhash: 'LKO2?U%2Tw=w]~RBVZRi};RPxuwH',
+    palette: { dominant: '#112233' },
+    ...overrides,
+  }
+}
+
+interface RedisFakeOptions {
+  setResults?: Array<'OK' | null>
+  setThrows?: boolean
+}
+
+function makeRedisService(opts: RedisFakeOptions = {}) {
+  const setResults = [...(opts.setResults ?? ['OK'])]
+  const setMock = vi.fn(async () => {
+    if (opts.setThrows) throw new Error('fake redis: SET failure')
+    // Default to 'OK' (first NX-acquire wins) when the queue is exhausted.
+    if (setResults.length === 0) return 'OK'
+    return setResults.shift() as 'OK' | null
+  })
+  const client = { set: setMock }
+  return {
+    setMock,
+    redisService: { getClient: () => client } as any,
+  }
+}
+
+function makeConfigsService(overrides?: {
+  maxItems?: number
+  maxTotalBytes?: number
+  maxBytesPerImage?: number
+  webpQuality?: number
+  imageStorage?: Record<string, unknown>
+}) {
+  const screenshot = {
+    enabled: true,
+    maxItems: overrides?.maxItems ?? 500,
+    maxTotalBytes: overrides?.maxTotalBytes ?? 100 * 1024 * 1024,
+    maxBytesPerImage: overrides?.maxBytesPerImage ?? 512 * 1024,
+    webpQuality: overrides?.webpQuality ?? 75,
+  }
+  const get = vi.fn(async (key: string) => {
+    if (key === 'thirdPartyServiceIntegration') {
+      return { openGraph: { screenshot } }
+    }
+    if (key === 'imageStorageOptions') {
+      return {
+        enable: true,
+        endpoint: 'https://s3.example.test',
+        secretId: 'AKIATESTKEY',
+        secretKey: 'TESTSECRET',
+        bucket: 'mx-test',
+        region: 'auto',
+        customDomain: '',
+        ...overrides?.imageStorage,
+      }
+    }
+    return {}
+  })
+  return { get } as any
+}
+
+const generator = new SnowflakeGenerator({ workerId: 23 })
+
+async function seedEnrichment(
+  ctx: PgTestDatabase,
+  id: string,
+  url = `https://example.test/${id}`,
+) {
+  await ctx.db.insert(enrichmentCache).values({
+    id,
+    provider: 'open-graph',
+    externalId: `og:test:${id}`,
+    url,
+    normalized: { title: 'probe' } as Record<string, unknown>,
+    raw: null,
+  })
+}
+
+/**
+ * Stamp a deterministic `last_accessed_at` on an existing screenshot row.
+ * Avoids `setTimeout`-based ordering, which is fragile under CI load.
+ */
+async function stampAccessTime(
+  ctx: PgTestDatabase,
+  enrichmentId: string,
+  iso: string,
+) {
+  await ctx.pool.query(
+    `update enrichment_screenshots set last_accessed_at = $1 where enrichment_id = $2`,
+    [iso, enrichmentId],
+  )
+}
+
+describe('ScreenshotStorageService', () => {
+  let context: PgTestDatabase
+  let repository: EnrichmentScreenshotRepository
+
+  beforeAll(async () => {
+    context = await createPgTestDatabase('mx_screenshot_storage')
+    repository = new EnrichmentScreenshotRepository(context.db as any)
+  }, 60_000)
+
+  afterAll(async () => {
+    if (context) await context.close()
+  })
+
+  beforeEach(async () => {
+    // Truncate both tables so each test starts on a clean slate (CASCADE
+    // removes screenshots first via the FK).
+    await context.pool.query('TRUNCATE enrichment_cache CASCADE')
+  })
+
+  afterEach(() => {
+    // Restore any vi.spyOn applied to the shared repository so the next
+    // test starts from a clean prototype.
+    vi.restoreAllMocks()
+  })
+
+  it('uploads to S3 and inserts a row on happy path', async () => {
+    const id = generator.nextId()
+    await seedEnrichment(context, id)
+    const processed = makeProcessed({ webp: Buffer.alloc(2048, 1) })
+    const { redisService } = makeRedisService()
+    const service = new TestScreenshotStorageService(
+      repository,
+      makeConfigsService(),
+      redisService,
+    )
+
+    const result = await service.storeOrEvict({
+      enrichmentId: id,
+      processed,
+    })
+
+    expect(result.objectKey).toBe(`enrichment-screenshots/${id}.webp`)
+    expect(result.bytes).toBe(2048)
+    expect(result.url).toBe(
+      `https://cdn.example.test/enrichment-screenshots/${id}.webp`,
+    )
+    expect(service.fakeS3.putCalls).toHaveLength(1)
+    expect(service.fakeS3.putCalls[0]).toMatchObject({
+      key: `enrichment-screenshots/${id}.webp`,
+      contentType: 'image/webp',
+      bytes: 2048,
+    })
+
+    const row = await repository.findByEnrichmentId(id)
+    expect(row).not.toBeNull()
+    expect(row?.bytes).toBe(2048)
+    expect(row?.palette).toEqual({ dominant: '#112233' })
+  })
+
+  it('overwrites the existing row on re-capture (upsert)', async () => {
+    const id = generator.nextId()
+    await seedEnrichment(context, id)
+    const { redisService } = makeRedisService()
+    const service = new TestScreenshotStorageService(
+      repository,
+      makeConfigsService(),
+      redisService,
+    )
+
+    await service.storeOrEvict({
+      enrichmentId: id,
+      processed: makeProcessed({
+        webp: Buffer.alloc(1024, 1),
+        palette: { dominant: '#aabbcc' },
+      }),
+    })
+    await service.storeOrEvict({
+      enrichmentId: id,
+      processed: makeProcessed({
+        webp: Buffer.alloc(3072, 2),
+        palette: { dominant: '#001122', swatches: ['#334455'] },
+      }),
+    })
+
+    // Both writes target the same object key — S3 overwrites, no delete.
+    expect(service.fakeS3.deleteCalls).toEqual([])
+    expect(service.fakeS3.putCalls).toHaveLength(2)
+    expect(
+      service.fakeS3.objects.get(`enrichment-screenshots/${id}.webp`)?.length,
+    ).toBe(3072)
+
+    const row = await repository.findByEnrichmentId(id)
+    expect(row?.bytes).toBe(3072)
+    expect(row?.palette).toEqual({
+      dominant: '#001122',
+      swatches: ['#334455'],
+    })
+  })
+
+  it('evicts oldest by item-cap before storing a new screenshot', async () => {
+    const ids = [generator.nextId(), generator.nextId(), generator.nextId()]
+    for (const id of ids) await seedEnrichment(context, id)
+
+    const { redisService } = makeRedisService()
+    const service = new TestScreenshotStorageService(
+      repository,
+      makeConfigsService({ maxItems: 2 }),
+      redisService,
+    )
+
+    // Seed the first two with deterministic `last_accessed_at` so the
+    // eviction order is well-defined: ids[0] is the oldest.
+    await service.storeOrEvict({
+      enrichmentId: ids[0],
+      processed: makeProcessed({ webp: Buffer.alloc(1024, 1) }),
+    })
+    await stampAccessTime(context, ids[0], '2020-01-01T00:00:00Z')
+    await service.storeOrEvict({
+      enrichmentId: ids[1],
+      processed: makeProcessed({ webp: Buffer.alloc(1024, 2) }),
+    })
+    await stampAccessTime(context, ids[1], '2020-01-02T00:00:00Z')
+
+    expect(service.fakeS3.deleteCalls).toEqual([])
+
+    // Third write must evict ids[0] (the oldest).
+    await service.storeOrEvict({
+      enrichmentId: ids[2],
+      processed: makeProcessed({ webp: Buffer.alloc(1024, 3) }),
+    })
+
+    expect(service.fakeS3.deleteCalls).toEqual([
+      `enrichment-screenshots/${ids[0]}.webp`,
+    ])
+    expect(await repository.findByEnrichmentId(ids[0])).toBeNull()
+    expect(await repository.findByEnrichmentId(ids[1])).not.toBeNull()
+    expect(await repository.findByEnrichmentId(ids[2])).not.toBeNull()
+  })
+
+  it('evicts oldest by byte-cap when count is under the item limit', async () => {
+    const ids = [generator.nextId(), generator.nextId(), generator.nextId()]
+    for (const id of ids) await seedEnrichment(context, id)
+
+    const { redisService } = makeRedisService()
+    // maxItems plenty large, but bytes cap tight — 3000 bytes total,
+    // each row is 1500 bytes, so the third write needs eviction.
+    const service = new TestScreenshotStorageService(
+      repository,
+      makeConfigsService({ maxItems: 100, maxTotalBytes: 3000 }),
+      redisService,
+    )
+
+    await service.storeOrEvict({
+      enrichmentId: ids[0],
+      processed: makeProcessed({ webp: Buffer.alloc(1500, 1) }),
+    })
+    await stampAccessTime(context, ids[0], '2020-01-01T00:00:00Z')
+    await service.storeOrEvict({
+      enrichmentId: ids[1],
+      processed: makeProcessed({ webp: Buffer.alloc(1500, 2) }),
+    })
+    await stampAccessTime(context, ids[1], '2020-01-02T00:00:00Z')
+    await service.storeOrEvict({
+      enrichmentId: ids[2],
+      processed: makeProcessed({ webp: Buffer.alloc(1500, 3) }),
+    })
+
+    expect(service.fakeS3.deleteCalls).toContain(
+      `enrichment-screenshots/${ids[0]}.webp`,
+    )
+    expect(await repository.findByEnrichmentId(ids[0])).toBeNull()
+    expect(await repository.findByEnrichmentId(ids[1])).not.toBeNull()
+    expect(await repository.findByEnrichmentId(ids[2])).not.toBeNull()
+  })
+
+  it('aborts the batch and does NOT insert when DB delete fails during eviction', async () => {
+    const ids = [generator.nextId(), generator.nextId()]
+    for (const id of ids) await seedEnrichment(context, id)
+
+    const { redisService } = makeRedisService()
+    const service = new TestScreenshotStorageService(
+      repository,
+      makeConfigsService({ maxItems: 1 }),
+      redisService,
+    )
+
+    await service.storeOrEvict({
+      enrichmentId: ids[0],
+      processed: makeProcessed({ webp: Buffer.alloc(1024, 1) }),
+    })
+
+    // Mock the repo's deleteByEnrichmentId to fail when called for eviction.
+    const origDelete = repository.deleteByEnrichmentId.bind(repository)
+    const failingDelete = vi
+      .spyOn(repository, 'deleteByEnrichmentId')
+      .mockImplementation(async () => {
+        throw new Error('simulated DB delete failure')
+      })
+
+    await expect(
+      service.storeOrEvict({
+        enrichmentId: ids[1],
+        processed: makeProcessed({ webp: Buffer.alloc(1024, 2) }),
+      }),
+    ).rejects.toThrow(/aborted batch/)
+
+    // The new row must NOT have been inserted.
+    failingDelete.mockRestore()
+    expect(await repository.findByEnrichmentId(ids[1])).toBeNull()
+
+    // We abort BEFORE the S3 put for the new id, so its object never appears.
+    expect(
+      service.fakeS3.objects.has(`enrichment-screenshots/${ids[1]}.webp`),
+    ).toBe(false)
+
+    // Restore repository state for subsequent tests.
+    await origDelete(ids[0]).catch(() => undefined)
+  })
+
+  it('delete removes the row and calls S3 deleteObject', async () => {
+    const id = generator.nextId()
+    await seedEnrichment(context, id)
+    const { redisService } = makeRedisService()
+    const service = new TestScreenshotStorageService(
+      repository,
+      makeConfigsService(),
+      redisService,
+    )
+
+    await service.storeOrEvict({
+      enrichmentId: id,
+      processed: makeProcessed({ webp: Buffer.alloc(1024, 7) }),
+    })
+
+    await service.delete(id)
+
+    expect(service.fakeS3.deleteCalls).toContain(
+      `enrichment-screenshots/${id}.webp`,
+    )
+    expect(await repository.findByEnrichmentId(id)).toBeNull()
+  })
+
+  it('delete is a no-op when the row is missing', async () => {
+    const id = generator.nextId()
+    const { redisService } = makeRedisService()
+    const service = new TestScreenshotStorageService(
+      repository,
+      makeConfigsService(),
+      redisService,
+    )
+
+    await expect(service.delete(id)).resolves.toBeUndefined()
+    expect(service.fakeS3.deleteCalls).toHaveLength(0)
+  })
+
+  it('delete() proceeds with DB delete even if S3 delete fails', async () => {
+    const id = generator.nextId()
+    await seedEnrichment(context, id)
+    const { redisService } = makeRedisService()
+    const service = new TestScreenshotStorageService(
+      repository,
+      makeConfigsService(),
+      redisService,
+    )
+
+    await service.storeOrEvict({
+      enrichmentId: id,
+      processed: makeProcessed({ webp: Buffer.alloc(1024, 9) }),
+    })
+
+    // Force the next S3 delete for this object key to fail.
+    const objectKey = `enrichment-screenshots/${id}.webp`
+    service.fakeS3.deleteFailKeys.add(objectKey)
+
+    const warnSpy = vi
+      .spyOn(Logger.prototype, 'warn')
+      .mockImplementation(() => undefined)
+
+    await expect(service.delete(id)).resolves.toBeUndefined()
+
+    expect(service.fakeS3.deleteCalls).toContain(objectKey)
+    expect(await repository.findByEnrichmentId(id)).toBeNull()
+    expect(warnSpy).toHaveBeenCalled()
+    const warnedMessage = warnSpy.mock.calls.map((c) => String(c[0])).join('\n')
+    expect(warnedMessage).toContain(objectKey)
+  })
+
+  it('touchAccess updates the DB only on the first Redis NX win', async () => {
+    const id = generator.nextId()
+    await seedEnrichment(context, id)
+    await context.db.insert(enrichmentScreenshots).values({
+      enrichmentId: id,
+      objectKey: `enrichment-screenshots/${id}.webp`,
+      bytes: 1024,
+      width: 1280,
+      height: 720,
+      blurhash: null,
+      palette: null,
+    })
+
+    // First SET wins, second returns null (key already exists).
+    const { redisService, setMock } = makeRedisService({
+      setResults: ['OK', null],
+    })
+
+    const touchSpy = vi.spyOn(repository, 'touchAccess')
+    const service = new TestScreenshotStorageService(
+      repository,
+      makeConfigsService(),
+      redisService,
+    )
+
+    await service.touchAccess(id)
+    await service.touchAccess(id)
+
+    expect(setMock).toHaveBeenCalledTimes(2)
+    // Lock in the throttle contract: TTL 3600s + NX mode + value '1'. The
+    // key is built via `getRedisKey` so it includes the env prefix; assert
+    // it contains the enrichment id and the typed segment.
+    expect(setMock).toHaveBeenNthCalledWith(
+      1,
+      expect.stringContaining(`enrichment_screenshot_touch:${id}`),
+      '1',
+      'EX',
+      3600,
+      'NX',
+    )
+    expect(touchSpy).toHaveBeenCalledTimes(1)
+    expect(touchSpy).toHaveBeenCalledWith(id)
+    touchSpy.mockRestore()
+  })
+
+  it('touchAccess swallows Redis errors and skips the DB update', async () => {
+    const id = generator.nextId()
+    const { redisService, setMock } = makeRedisService({ setThrows: true })
+    const touchSpy = vi.spyOn(repository, 'touchAccess')
+    const service = new TestScreenshotStorageService(
+      repository,
+      makeConfigsService(),
+      redisService,
+    )
+
+    await expect(service.touchAccess(id)).resolves.toBeUndefined()
+    expect(setMock).toHaveBeenCalledTimes(1)
+    expect(touchSpy).not.toHaveBeenCalled()
+    touchSpy.mockRestore()
+  })
+})

--- a/dockerfile
+++ b/dockerfile
@@ -16,6 +16,21 @@ FROM node:24-alpine AS runner
 
 RUN apk add zip unzip postgresql-client bash fish rsync jq curl openrc --no-cache
 
+# Chromium + fonts/nss for the agent-browser headless fallback used by the
+# Open Graph enrichment provider (fetchMode = "browser"). Alpine's chromium
+# package is hardened against root, so we pin --no-sandbox via env below.
+RUN apk add --no-cache \
+    chromium \
+    nss \
+    freetype \
+    freetype-dev \
+    harfbuzz \
+    ca-certificates \
+    ttf-freefont \
+    font-noto-cjk
+
+RUN npm i -g agent-browser
+
 WORKDIR /app
 COPY --from=builder /app/out .
 COPY --from=builder /app/assets ./assets
@@ -27,6 +42,11 @@ COPY --chmod=755 docker-entrypoint.sh .
 
 ENV TZ=Asia/Shanghai
 ENV MIGRATIONS_DIR=/app/migrations
+# agent-browser CLI picks up these knobs; system chromium replaces the
+# bundled Chrome download (which has no musl build).
+ENV AGENT_BROWSER_EXECUTABLE_PATH=/usr/bin/chromium-browser
+ENV AGENT_BROWSER_HEADED=0
+ENV AGENT_BROWSER_CHROME_ARGS="--no-sandbox --disable-dev-shm-usage --disable-gpu"
 
 EXPOSE 2333
 

--- a/docs/superpowers/plans/2026-05-13-browser-fetch-session-pool.md
+++ b/docs/superpowers/plans/2026-05-13-browser-fetch-session-pool.md
@@ -1,0 +1,957 @@
+# Browser Fetch Session Pool Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace per-request agent-browser session lifecycle with a bounded pool of long-lived sessions that double as a concurrency semaphore, and close the SSRF gap on the browser fetch path.
+
+**Architecture:** A new `BrowserSessionPool` provider owns up to N (default 2) named long-lived `agent-browser` sessions, lazily created. Each acquisition reserves one slot; concurrent requests beyond the cap queue FIFO. Slots are released back (not closed) on success and discarded (`close` sent, slot removed) on non-timeout failure. An idle timer closes long-unused slots so an idle deploy does not pin chromium in memory. `BrowserFetchService.runSession` is refactored to acquire/release instead of creating a random per-request session. SSRF guards (`parseAndValidateUrl` + `assertHostnameSafe` from `safe-fetch`) are extracted and reused on the browser path so a private/loopback hostname can no longer reach chromium.
+
+**Tech Stack:** NestJS (`@Injectable` + `OnModuleDestroy`), Node `child_process.execFile`, Vitest with `vi.useFakeTimers()` for queue/idle tests.
+
+---
+
+## File Structure
+
+- **Create**: `apps/core/src/modules/enrichment/providers/open-graph/browser-session-pool.ts` — pool service, queue, idle eviction, shutdown.
+- **Create**: `apps/core/test/src/modules/enrichment/browser-session-pool.spec.ts` — unit tests for acquire/release/queue/discard/idle/shutdown.
+- **Create**: `apps/core/src/modules/enrichment/providers/open-graph/url-guard.ts` — extracted SSRF helpers shared between `safe-fetch` and `browser-fetch`.
+- **Modify**: `apps/core/src/modules/enrichment/providers/open-graph/safe-fetch.ts` — re-export the SSRF helpers from `url-guard.ts`; remove the inline copies.
+- **Modify**: `apps/core/src/modules/enrichment/providers/open-graph/browser-fetch.service.ts` — replace `runSession` random-session lifecycle with pool acquire/release; apply SSRF guard before invoking chromium.
+- **Modify**: `apps/core/src/modules/enrichment/enrichment.module.ts` — register `BrowserSessionPool` provider.
+- **Modify**: `apps/core/test/src/modules/enrichment/browser-fetch.service.spec.ts` — adapt assertions to pool-based session names (`og-pool-0`) and the absence of a per-request `close` call.
+
+Each file has one clear responsibility. `url-guard.ts` is added because the SSRF logic needs to live outside `safe-fetch` to be reused without creating a circular dependency between `safe-fetch` and `browser-fetch`.
+
+---
+
+## Task 1: Extract SSRF guards into `url-guard.ts`
+
+**Files:**
+- Create: `apps/core/src/modules/enrichment/providers/open-graph/url-guard.ts`
+- Modify: `apps/core/src/modules/enrichment/providers/open-graph/safe-fetch.ts`
+- Test: existing `safe-fetch` tests must keep passing (no new spec)
+
+- [ ] **Step 1: Create the shared guard module**
+
+Create `apps/core/src/modules/enrichment/providers/open-graph/url-guard.ts`:
+
+```ts
+import { lookup } from 'node:dns/promises'
+import { isIP } from 'node:net'
+
+import { isDev } from '~/global/env.global'
+
+const BLOCKED_HOSTNAMES = new Set([
+  'localhost',
+  'localhost.localdomain',
+  'broadcasthost',
+  'ip6-localhost',
+  'ip6-loopback',
+])
+
+const BLOCKED_HOSTNAME_SUFFIXES = ['.localhost', '.local', '.internal']
+
+export class UnsafeUrlError extends Error {
+  constructor(message: string) {
+    super(message)
+    this.name = 'UnsafeUrlError'
+  }
+}
+
+export function parseAndValidateUrl(raw: string): URL {
+  let url: URL
+  try {
+    url = new URL(raw)
+  } catch {
+    throw new UnsafeUrlError(`Invalid URL: ${raw}`)
+  }
+  if (url.protocol !== 'http:' && url.protocol !== 'https:') {
+    throw new UnsafeUrlError(`Disallowed protocol: ${url.protocol}`)
+  }
+  const host = url.hostname.toLowerCase()
+  if (!host) throw new UnsafeUrlError('Empty hostname')
+  if (isDev) return url
+  if (BLOCKED_HOSTNAMES.has(host)) {
+    throw new UnsafeUrlError(`Blocked hostname: ${host}`)
+  }
+  if (BLOCKED_HOSTNAME_SUFFIXES.some((s) => host.endsWith(s))) {
+    throw new UnsafeUrlError(`Blocked hostname suffix: ${host}`)
+  }
+  const stripped = stripIpv6Brackets(host)
+  const ipKind = isIP(stripped)
+  if (ipKind !== 0 && isPrivateIp(stripped, ipKind)) {
+    throw new UnsafeUrlError(`Private IP literal: ${host}`)
+  }
+  return url
+}
+
+export async function assertHostnameSafe(hostname: string): Promise<void> {
+  if (isIP(stripIpv6Brackets(hostname)) !== 0) return
+  let addrs: { address: string; family: number }[]
+  try {
+    addrs = await lookup(hostname, { all: true })
+  } catch (error) {
+    throw new UnsafeUrlError(
+      `DNS lookup failed for ${hostname}: ${(error as Error).message}`,
+    )
+  }
+  if (addrs.length === 0) {
+    throw new UnsafeUrlError(`No DNS records for ${hostname}`)
+  }
+  for (const a of addrs) {
+    if (isPrivateIp(a.address, a.family === 4 ? 4 : 6)) {
+      throw new UnsafeUrlError(
+        `Hostname ${hostname} resolves to private/internal IP ${a.address}`,
+      )
+    }
+  }
+}
+
+export function stripIpv6Brackets(host: string): string {
+  if (host.startsWith('[') && host.endsWith(']')) return host.slice(1, -1)
+  return host
+}
+
+export function isPrivateIp(addr: string, family: number): boolean {
+  if (family === 4) return isPrivateIpv4(addr)
+  if (family === 6) return isPrivateIpv6(addr)
+  return true
+}
+
+function isPrivateIpv4(addr: string): boolean {
+  const parts = addr.split('.').map((p) => Number(p))
+  if (
+    parts.length !== 4 ||
+    parts.some((p) => !Number.isInteger(p) || p < 0 || p > 255)
+  ) {
+    return true
+  }
+  const [a, b] = parts
+  if (a === 0) return true
+  if (a === 10) return true
+  if (a === 127) return true
+  if (a === 169 && b === 254) return true
+  if (a === 172 && b >= 16 && b <= 31) return true
+  if (a === 192 && b === 168) return true
+  if (a === 192 && b === 0) return true
+  if (a === 198 && (b === 18 || b === 19)) return true
+  if (a === 100 && b >= 64 && b <= 127) return true
+  if (a >= 224) return true
+  return false
+}
+
+function isPrivateIpv6(addr: string): boolean {
+  const lower = addr.toLowerCase()
+  if (lower === '::' || lower === '::1') return true
+  const v4mapped = /^:{2}f{4}:((?:\d+\.){3}\d+)$/i.exec(addr)
+  if (v4mapped) return isPrivateIpv4(v4mapped[1])
+  if (lower.startsWith('fe8') || lower.startsWith('fe9')) return true
+  if (lower.startsWith('fea') || lower.startsWith('feb')) return true
+  if (lower.startsWith('fc') || lower.startsWith('fd')) return true
+  if (lower.startsWith('ff')) return true
+  return false
+}
+```
+
+- [ ] **Step 2: Replace inline definitions in `safe-fetch.ts` with imports**
+
+In `apps/core/src/modules/enrichment/providers/open-graph/safe-fetch.ts`:
+
+Remove the inline `BLOCKED_HOSTNAMES`, `BLOCKED_HOSTNAME_SUFFIXES`, `UnsafeUrlError`, `parseAndValidateUrl`, `assertHostnameSafe`, `stripIpv6Brackets`, `isPrivateIp`, `isPrivateIpv4`, `isPrivateIpv6`, and the imports of `lookup`/`isIP`/`isDev` that those used.
+
+Add at the top:
+
+```ts
+import {
+  assertHostnameSafe,
+  parseAndValidateUrl,
+  UnsafeUrlError,
+  isPrivateIp,
+} from './url-guard'
+```
+
+Keep the existing `export { UnsafeUrlError, isPrivateIp }` shape so external consumers (if any) of `safe-fetch.ts` keep working. Add a re-export line:
+
+```ts
+export { UnsafeUrlError, isPrivateIp } from './url-guard'
+```
+
+- [ ] **Step 3: Run lint + typecheck on the changed files**
+
+Run: `pnpm -C apps/core exec eslint src/modules/enrichment/providers/open-graph/safe-fetch.ts src/modules/enrichment/providers/open-graph/url-guard.ts`
+Expected: 0 errors.
+
+Run: `pnpm -C apps/core exec tsc --noEmit -p tsconfig.json` (the project's `tsc` config validates the whole tree)
+Expected: 0 errors.
+
+- [ ] **Step 4: Run the existing safe-fetch tests**
+
+Run: `pnpm -C apps/core run test -- test/src/modules/enrichment/providers/open-graph/safe-fetch.spec.ts`
+
+If no such file exists, run: `pnpm -C apps/core run test -- test/src/modules/enrichment`
+Expected: all green.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/core/src/modules/enrichment/providers/open-graph/url-guard.ts \
+        apps/core/src/modules/enrichment/providers/open-graph/safe-fetch.ts
+git commit -m "refactor(enrichment): extract SSRF guards into shared url-guard module"
+```
+
+---
+
+## Task 2: Implement `BrowserSessionPool` (test-first)
+
+**Files:**
+- Create: `apps/core/src/modules/enrichment/providers/open-graph/browser-session-pool.ts`
+- Test: `apps/core/test/src/modules/enrichment/browser-session-pool.spec.ts`
+
+### Step 2.1: Write the pool spec (all failing)
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `apps/core/test/src/modules/enrichment/browser-session-pool.spec.ts`:
+
+```ts
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const { execFileMock } = vi.hoisted(() => ({
+  execFileMock: vi.fn(),
+}))
+
+vi.mock('node:child_process', async () => {
+  const actual = await vi.importActual<typeof import('node:child_process')>(
+    'node:child_process',
+  )
+  return { ...actual, execFile: execFileMock }
+})
+
+const { BrowserSessionPool } = await import(
+  '~/modules/enrichment/providers/open-graph/browser-session-pool'
+)
+
+function mockExecFileSuccess(): void {
+  execFileMock.mockImplementation((...args: unknown[]) => {
+    const cb = args.at(-1) as (
+      err: NodeJS.ErrnoException | null,
+      r?: { stdout: string; stderr: string },
+    ) => void
+    setImmediate(() => cb(null, { stdout: '[]', stderr: '' }))
+    return undefined
+  })
+}
+
+beforeEach(() => {
+  execFileMock.mockReset()
+  mockExecFileSuccess()
+  vi.useFakeTimers()
+})
+
+afterEach(() => {
+  vi.useRealTimers()
+})
+
+describe('BrowserSessionPool', () => {
+  it('acquire returns a slot named og-pool-0 on first use', async () => {
+    const pool = new BrowserSessionPool({ maxSize: 2, idleMs: 60_000 })
+    const slot = await pool.acquire()
+    expect(slot.name).toBe('og-pool-0')
+    pool.release(slot)
+    await pool.shutdown()
+  })
+
+  it('two concurrent acquires up to cap return distinct slots without queueing', async () => {
+    const pool = new BrowserSessionPool({ maxSize: 2, idleMs: 60_000 })
+    const a = await pool.acquire()
+    const b = await pool.acquire()
+    expect([a.name, b.name].sort()).toEqual(['og-pool-0', 'og-pool-1'])
+    pool.release(a)
+    pool.release(b)
+    await pool.shutdown()
+  })
+
+  it('third acquire at cap blocks until a slot is released', async () => {
+    const pool = new BrowserSessionPool({ maxSize: 2, idleMs: 60_000 })
+    const a = await pool.acquire()
+    const b = await pool.acquire()
+    const cPromise = pool.acquire()
+    let resolved = false
+    cPromise.then(() => {
+      resolved = true
+    })
+    await Promise.resolve()
+    expect(resolved).toBe(false)
+    pool.release(a)
+    const c = await cPromise
+    expect(c.name).toBe(a.name)
+    pool.release(b)
+    pool.release(c)
+    await pool.shutdown()
+  })
+
+  it('release with discard:true closes the session and frees the slot', async () => {
+    const pool = new BrowserSessionPool({ maxSize: 1, idleMs: 60_000 })
+    const a = await pool.acquire()
+    pool.release(a, { discard: true })
+    // discard issues a close; next acquire creates a fresh session with the
+    // same name (slot index reused).
+    const b = await pool.acquire()
+    expect(b.name).toBe(a.name)
+    const closedCall = execFileMock.mock.calls.find(
+      (call) => (call[1] as string[]).at(-1) === 'close',
+    )
+    expect(closedCall).toBeDefined()
+    pool.release(b)
+    await pool.shutdown()
+  })
+
+  it('idle slot is closed after idleMs and the slot index is recyclable', async () => {
+    const pool = new BrowserSessionPool({ maxSize: 1, idleMs: 1_000 })
+    const a = await pool.acquire()
+    pool.release(a)
+    expect(execFileMock).not.toHaveBeenCalled()
+    vi.advanceTimersByTime(1_000)
+    await vi.runAllTicks()
+    const closedCall = execFileMock.mock.calls.find(
+      (call) => (call[1] as string[]).at(-1) === 'close',
+    )
+    expect(closedCall).toBeDefined()
+    await pool.shutdown()
+  })
+
+  it('shutdown closes every live slot', async () => {
+    const pool = new BrowserSessionPool({ maxSize: 2, idleMs: 60_000 })
+    const a = await pool.acquire()
+    const b = await pool.acquire()
+    pool.release(a)
+    pool.release(b)
+    await pool.shutdown()
+    const closeCalls = execFileMock.mock.calls.filter(
+      (call) => (call[1] as string[]).at(-1) === 'close',
+    )
+    expect(closeCalls.length).toBe(2)
+  })
+
+  it('acquire after shutdown rejects', async () => {
+    const pool = new BrowserSessionPool({ maxSize: 1, idleMs: 60_000 })
+    await pool.shutdown()
+    await expect(pool.acquire()).rejects.toThrow(/shut down/i)
+  })
+
+  it('acquire waiter cancelled by aborted signal rejects without consuming a slot', async () => {
+    const pool = new BrowserSessionPool({ maxSize: 1, idleMs: 60_000 })
+    const a = await pool.acquire()
+    const ac = new AbortController()
+    const waiter = pool.acquire({ signal: ac.signal })
+    ac.abort()
+    await expect(waiter).rejects.toThrow(/aborted/i)
+    pool.release(a)
+    // ensure no leftover waiter consumed the freed slot
+    const b = await pool.acquire()
+    expect(b.name).toBe(a.name)
+    pool.release(b)
+    await pool.shutdown()
+  })
+})
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `pnpm -C apps/core run test -- test/src/modules/enrichment/browser-session-pool.spec.ts`
+Expected: FAIL with "Cannot find module '.../browser-session-pool'" (file does not exist yet).
+
+### Step 2.2: Implement the pool
+
+- [ ] **Step 3: Create the pool**
+
+Create `apps/core/src/modules/enrichment/providers/open-graph/browser-session-pool.ts`:
+
+```ts
+import { execFile } from 'node:child_process'
+import { promisify } from 'node:util'
+
+import { Injectable, Logger, type OnModuleDestroy } from '@nestjs/common'
+
+const execFileAsync = promisify(execFile)
+
+const DEFAULT_EXECUTABLE = process.env.AGENT_BROWSER_BIN || 'agent-browser'
+const DEFAULT_MAX_SIZE = Number(
+  process.env.AGENT_BROWSER_MAX_CONCURRENT ?? '2',
+)
+const DEFAULT_IDLE_MS = Number(process.env.AGENT_BROWSER_IDLE_MS ?? '60000')
+const CLOSE_TIMEOUT_MS = 5_000
+
+export interface PoolSlot {
+  readonly name: string
+}
+
+export interface AcquireOptions {
+  signal?: AbortSignal
+}
+
+export interface ReleaseOptions {
+  /**
+   * Close the underlying session and discard the slot. Use when the command
+   * that ran on this slot raised a non-timeout error so the next caller does
+   * not reuse a potentially-broken chromium state.
+   */
+  discard?: boolean
+}
+
+interface InternalSlot {
+  index: number
+  name: string
+  inUse: boolean
+  /** chromium has actually been started under this name. */
+  live: boolean
+  idleTimer?: NodeJS.Timeout
+}
+
+interface Waiter {
+  resolve: (slot: PoolSlot) => void
+  reject: (err: Error) => void
+  signal?: AbortSignal
+  onAbort?: () => void
+}
+
+export interface BrowserSessionPoolOptions {
+  maxSize?: number
+  idleMs?: number
+  executable?: string
+}
+
+/**
+ * Bounded pool of long-lived `agent-browser --session` names. Acts as both a
+ * resource cache (avoids per-request chromium spin-up) and a concurrency
+ * semaphore (no more than `maxSize` in-flight captures).
+ *
+ * State note: chromium cookies / localStorage persist across reuses of the
+ * same slot. Open Graph fetches do not send credentials, so cross-origin
+ * leakage is bounded to whatever a previously-visited page chose to set
+ * publicly. Operators wanting stricter isolation should set
+ * `AGENT_BROWSER_MAX_CONCURRENT=1` + `AGENT_BROWSER_IDLE_MS=0` which approximates
+ * the per-request lifecycle the pool replaced.
+ */
+@Injectable()
+export class BrowserSessionPool implements OnModuleDestroy {
+  private readonly logger = new Logger(BrowserSessionPool.name)
+  private readonly maxSize: number
+  private readonly idleMs: number
+  private readonly executable: string
+
+  private readonly slots: InternalSlot[] = []
+  private readonly waiters: Waiter[] = []
+  private shuttingDown = false
+
+  constructor(options?: BrowserSessionPoolOptions) {
+    this.maxSize = Math.max(1, options?.maxSize ?? DEFAULT_MAX_SIZE)
+    this.idleMs = Math.max(0, options?.idleMs ?? DEFAULT_IDLE_MS)
+    this.executable = options?.executable ?? DEFAULT_EXECUTABLE
+  }
+
+  async acquire(options?: AcquireOptions): Promise<PoolSlot> {
+    if (this.shuttingDown) {
+      throw new Error('BrowserSessionPool has been shut down')
+    }
+    const free = this.slots.find((s) => !s.inUse)
+    if (free) {
+      this.cancelIdleTimer(free)
+      free.inUse = true
+      return { name: free.name }
+    }
+    if (this.slots.length < this.maxSize) {
+      const slot: InternalSlot = {
+        index: this.slots.length,
+        name: `og-pool-${this.slots.length}`,
+        inUse: true,
+        live: false,
+      }
+      this.slots.push(slot)
+      return { name: slot.name }
+    }
+    return new Promise<PoolSlot>((resolve, reject) => {
+      const waiter: Waiter = { resolve, reject, signal: options?.signal }
+      if (options?.signal) {
+        if (options.signal.aborted) {
+          reject(new Error('acquire aborted'))
+          return
+        }
+        waiter.onAbort = () => {
+          const i = this.waiters.indexOf(waiter)
+          if (i !== -1) this.waiters.splice(i, 1)
+          reject(new Error('acquire aborted'))
+        }
+        options.signal.addEventListener('abort', waiter.onAbort, { once: true })
+      }
+      this.waiters.push(waiter)
+    })
+  }
+
+  release(slot: PoolSlot, options?: ReleaseOptions): void {
+    const internal = this.slots.find((s) => s.name === slot.name)
+    if (!internal) return
+    internal.inUse = false
+    if (options?.discard) {
+      void this.closeSlot(internal)
+    } else {
+      // Mark live so subsequent acquirers know agent-browser already
+      // has state for this name.
+      internal.live = true
+      this.scheduleIdleClose(internal)
+    }
+    this.flushWaiter()
+  }
+
+  async onModuleDestroy(): Promise<void> {
+    await this.shutdown()
+  }
+
+  async shutdown(): Promise<void> {
+    if (this.shuttingDown) return
+    this.shuttingDown = true
+    for (const waiter of this.waiters.splice(0)) {
+      if (waiter.signal && waiter.onAbort) {
+        waiter.signal.removeEventListener('abort', waiter.onAbort)
+      }
+      waiter.reject(new Error('BrowserSessionPool has been shut down'))
+    }
+    await Promise.all(this.slots.map((s) => this.closeSlot(s, true)))
+  }
+
+  /**
+   * Hook called by `BrowserFetchService` after the first successful command on
+   * a freshly-allocated slot — at that point chromium has truly started, so
+   * subsequent shutdown / discard knows to issue `close`.
+   */
+  markLive(slot: PoolSlot): void {
+    const internal = this.slots.find((s) => s.name === slot.name)
+    if (internal) internal.live = true
+  }
+
+  private flushWaiter(): void {
+    if (this.waiters.length === 0) return
+    const free = this.slots.find((s) => !s.inUse)
+    if (!free) return
+    const waiter = this.waiters.shift()!
+    if (waiter.signal && waiter.onAbort) {
+      waiter.signal.removeEventListener('abort', waiter.onAbort)
+    }
+    this.cancelIdleTimer(free)
+    free.inUse = true
+    waiter.resolve({ name: free.name })
+  }
+
+  private cancelIdleTimer(slot: InternalSlot): void {
+    if (slot.idleTimer) {
+      clearTimeout(slot.idleTimer)
+      slot.idleTimer = undefined
+    }
+  }
+
+  private scheduleIdleClose(slot: InternalSlot): void {
+    this.cancelIdleTimer(slot)
+    if (this.idleMs <= 0) {
+      void this.closeSlot(slot)
+      return
+    }
+    slot.idleTimer = setTimeout(() => {
+      slot.idleTimer = undefined
+      if (!slot.inUse) void this.closeSlot(slot)
+    }, this.idleMs)
+  }
+
+  private async closeSlot(
+    slot: InternalSlot,
+    forceRemoveFromList = false,
+  ): Promise<void> {
+    this.cancelIdleTimer(slot)
+    if (slot.live) {
+      try {
+        await execFileAsync(this.executable, ['--session', slot.name, 'close'], {
+          timeout: CLOSE_TIMEOUT_MS,
+          windowsHide: true,
+          env: process.env,
+        })
+      } catch (error) {
+        this.logger.debug(
+          `pool close failed for ${slot.name}: ${(error as Error).message}`,
+        )
+      }
+    }
+    slot.live = false
+    if (forceRemoveFromList) return
+    // Discard: remove from list so the index can be reused next time.
+    const idx = this.slots.indexOf(slot)
+    if (idx !== -1) this.slots.splice(idx, 1)
+  }
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `pnpm -C apps/core run test -- test/src/modules/enrichment/browser-session-pool.spec.ts`
+Expected: 8 tests pass.
+
+- [ ] **Step 5: Lint + typecheck**
+
+Run: `pnpm -C apps/core exec eslint src/modules/enrichment/providers/open-graph/browser-session-pool.ts test/src/modules/enrichment/browser-session-pool.spec.ts`
+Expected: 0 errors.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add apps/core/src/modules/enrichment/providers/open-graph/browser-session-pool.ts \
+        apps/core/test/src/modules/enrichment/browser-session-pool.spec.ts
+git commit -m "feat(enrichment): bounded browser session pool for OG fetch"
+```
+
+---
+
+## Task 3: Refactor `BrowserFetchService` to use the pool + SSRF guard
+
+**Files:**
+- Modify: `apps/core/src/modules/enrichment/providers/open-graph/browser-fetch.service.ts`
+- Modify: `apps/core/test/src/modules/enrichment/browser-fetch.service.spec.ts`
+
+### Step 3.1: Update browser-fetch tests for pool-based naming
+
+- [ ] **Step 1: Adjust tests**
+
+In `apps/core/test/src/modules/enrichment/browser-fetch.service.spec.ts`:
+
+1. Where the test constructs the service, pass a `BrowserSessionPool` instance:
+
+```ts
+import { BrowserSessionPool } from '~/modules/enrichment/providers/open-graph/browser-session-pool'
+
+// inside the relevant test setup:
+const pool = new BrowserSessionPool({ maxSize: 2, idleMs: 60_000 })
+const service = new BrowserFetchService(pool)
+```
+
+2. Replace any assertion that expects a random `og-${hex}` session name with `expect(sessionName).toMatch(/^og-pool-\d+$/)`.
+
+3. Remove or update assertions that expect the service to call `close` after every fetch — the pool now owns close. Tests that need the slot returned can call `await pool.shutdown()` in an afterEach.
+
+4. Add a new test asserting an SSRF rejection:
+
+```ts
+it('rejects http://localhost before invoking chromium', async () => {
+  const pool = new BrowserSessionPool({ maxSize: 1, idleMs: 60_000 })
+  const service = new BrowserFetchService(pool)
+  await expect(
+    service.fetchPage('http://localhost/path', {
+      timeoutMs: 5_000,
+      maxBodyBytes: 1024,
+    }),
+  ).rejects.toThrow(/Blocked hostname|Private IP/)
+  expect(execFileMock).not.toHaveBeenCalled()
+  await pool.shutdown()
+})
+```
+
+5. Add a test that verifies pool reuse:
+
+```ts
+it('reuses the same session name across two sequential fetches', async () => {
+  const pool = new BrowserSessionPool({ maxSize: 1, idleMs: 60_000 })
+  const service = new BrowserFetchService(pool)
+  setExecFileBehavior(() => ({
+    stdout: JSON.stringify([{}, {}, { value: '<html></html>' }]),
+  }))
+  await service.fetchHtml('https://example.com/a', {
+    timeoutMs: 5_000,
+    maxBodyBytes: 1024,
+  })
+  await service.fetchHtml('https://example.com/b', {
+    timeoutMs: 5_000,
+    maxBodyBytes: 1024,
+  })
+  const openCalls = execFileMock.mock.calls.filter((call) => {
+    const args = call[1] as string[]
+    return args.includes('batch') && args.some((a) => a.startsWith('open '))
+  })
+  expect(openCalls.length).toBe(2)
+  const sessionNames = new Set(
+    openCalls.map((call) => (call[1] as string[])[1]),
+  )
+  expect(sessionNames.size).toBe(1)
+  await pool.shutdown()
+})
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `pnpm -C apps/core run test -- test/src/modules/enrichment/browser-fetch.service.spec.ts`
+Expected: the new SSRF and reuse tests FAIL; existing tests may also fail due to constructor signature change.
+
+### Step 3.2: Refactor the service
+
+- [ ] **Step 3: Refactor `browser-fetch.service.ts`**
+
+In `apps/core/src/modules/enrichment/providers/open-graph/browser-fetch.service.ts`:
+
+1. Remove the random `og-${randomBytes(6)…}` naming and the final `close` invocation in `runSession`.
+2. Inject `BrowserSessionPool` and import the SSRF guard:
+
+```ts
+import { Injectable, Logger } from '@nestjs/common'
+import {
+  assertHostnameSafe,
+  parseAndValidateUrl,
+} from './url-guard'
+import {
+  BrowserSessionPool,
+  type PoolSlot,
+} from './browser-session-pool'
+```
+
+3. New constructor:
+
+```ts
+constructor(private readonly pool: BrowserSessionPool) {}
+```
+
+4. Replace `runSession` so it:
+   - calls `parseAndValidateUrl(rawUrl)` then `await assertHostnameSafe(url.hostname)` (skipping the dev escape hatch is handled inside the helper),
+   - acquires a slot from the pool,
+   - runs the HTML batch (same args, but using `slot.name` for `--session`),
+   - on first success calls `pool.markLive(slot)`,
+   - runs the screenshot batch when `captureScreenshot` is true,
+   - releases the slot on success (no `close`),
+   - on a thrown error: if it is a `UnsafeUrlError` (caught before acquiring), no release; if it happens after acquire, release with `{ discard: true }` for non-timeout errors and `{ discard: false }` for timeout errors (a timed-out session may still be healthy; let idle eviction handle it if not).
+
+Replace the body of `runSession` with:
+
+```ts
+private async runSession(
+  rawUrl: string,
+  opts: SafeFetchOptions & { executable?: string },
+  captureScreenshot: boolean,
+): Promise<FetchPageResult> {
+  const url = parseAndValidateUrl(rawUrl)
+  await assertHostnameSafe(url.hostname)
+
+  const slot = await this.pool.acquire()
+  const executable = opts.executable || DEFAULT_EXECUTABLE
+  const evalScript =
+    '(() => { try { return document.documentElement.outerHTML } catch (_e) { return "" } })()'
+  const b64 = Buffer.from(evalScript, 'utf8').toString('base64')
+
+  const started = Date.now()
+  const ac = new AbortController()
+  const timer = setTimeout(() => ac.abort(), opts.timeoutMs)
+  let html: SafeFetchResult
+  let acquired = true
+  let timedOut = false
+  try {
+    const { stdout } = await execFileAsync(
+      executable,
+      [
+        '--session',
+        slot.name,
+        'batch',
+        '--bail',
+        '--json',
+        `open ${url.toString()}`,
+        'wait 1500',
+        `eval -b ${b64} --json`,
+      ],
+      {
+        signal: ac.signal,
+        maxBuffer: Math.max(opts.maxBodyBytes * 2, 4_194_304),
+        windowsHide: true,
+        env: process.env,
+      },
+    )
+    this.pool.markLive(slot)
+    const rawHtml = extractHtmlFromBatchOutput(stdout)
+    const truncated = rawHtml.length > opts.maxBodyBytes
+    const body = truncated ? rawHtml.slice(0, opts.maxBodyBytes) : rawHtml
+    html = {
+      finalUrl: url.toString(),
+      contentType: 'text/html',
+      body,
+      truncated,
+    }
+  } catch (error) {
+    const err = error as NodeJS.ErrnoException & { stderr?: string }
+    if (ac.signal.aborted) {
+      timedOut = true
+      this.pool.release(slot)
+      acquired = false
+      throw new Error(
+        `agent-browser timed out after ${opts.timeoutMs}ms for ${url.toString()}`,
+        { cause: error },
+      )
+    }
+    this.pool.release(slot, { discard: true })
+    acquired = false
+    if (err.code === 'ENOENT') {
+      throw new Error(
+        `agent-browser executable not found at "${executable}". Install it or set thirdPartyServiceIntegration.openGraph.fetchMode = "fetch".`,
+        { cause: error },
+      )
+    }
+    const detail = err.stderr ? `: ${truncate(err.stderr, 400)}` : ''
+    throw new Error(`agent-browser failed for ${url.toString()}${detail}`, {
+      cause: error,
+    })
+  } finally {
+    clearTimeout(timer)
+  }
+
+  let screenshotBytes: Buffer | undefined
+  if (captureScreenshot && acquired && !timedOut) {
+    const remaining = Math.max(500, opts.timeoutMs - (Date.now() - started))
+    screenshotBytes = await this.captureScreenshot(
+      executable,
+      slot.name,
+      remaining,
+    ).catch((screenshotErr) => {
+      this.logger.debug(
+        `screenshot capture failed for ${url.toString()}: ${(screenshotErr as Error).message}`,
+      )
+      return undefined
+    })
+  }
+
+  if (acquired) this.pool.release(slot)
+  return { html, screenshotBytes }
+}
+```
+
+5. Delete the import of `randomBytes` (no longer used) at the top of the file.
+
+- [ ] **Step 4: Run the browser-fetch tests**
+
+Run: `pnpm -C apps/core run test -- test/src/modules/enrichment/browser-fetch.service.spec.ts`
+Expected: all pass, including the two new tests added in Step 1.
+
+- [ ] **Step 5: Lint + typecheck**
+
+Run: `pnpm -C apps/core exec eslint src/modules/enrichment/providers/open-graph/browser-fetch.service.ts test/src/modules/enrichment/browser-fetch.service.spec.ts`
+Expected: 0 errors.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add apps/core/src/modules/enrichment/providers/open-graph/browser-fetch.service.ts \
+        apps/core/test/src/modules/enrichment/browser-fetch.service.spec.ts
+git commit -m "refactor(enrichment): browser fetch reuses pool sessions + SSRF guard"
+```
+
+---
+
+## Task 4: Wire `BrowserSessionPool` into the enrichment module
+
+**Files:**
+- Modify: `apps/core/src/modules/enrichment/enrichment.module.ts`
+
+- [ ] **Step 1: Register the provider**
+
+In `apps/core/src/modules/enrichment/enrichment.module.ts`:
+
+1. Add the import:
+
+```ts
+import { BrowserSessionPool } from './providers/open-graph/browser-session-pool'
+```
+
+2. Append `BrowserSessionPool` to the `providers` array, before `BrowserFetchService` (Nest resolves DI order from the array order):
+
+```ts
+providers: [
+  EnrichmentScreenshotRepository,
+  EnrichmentService,
+  ProviderRegistry,
+  UrlExtractorService,
+  EnrichmentOriginGuard,
+  BrowserSessionPool,
+  BrowserFetchService,
+  ScreenshotPipelineService,
+  ScreenshotStorageService,
+  ...allProviders,
+],
+```
+
+- [ ] **Step 2: Run the full enrichment test suite**
+
+Run: `pnpm -C apps/core run test -- test/src/modules/enrichment`
+Expected: all pass.
+
+- [ ] **Step 3: Lint + typecheck the touched module**
+
+Run: `pnpm -C apps/core exec eslint src/modules/enrichment/enrichment.module.ts`
+Expected: 0 errors.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add apps/core/src/modules/enrichment/enrichment.module.ts
+git commit -m "feat(enrichment): wire BrowserSessionPool into module"
+```
+
+---
+
+## Task 5: Final verification
+
+**Files:** none modified
+
+- [ ] **Step 1: Run the full repository test suite**
+
+Run: `pnpm -C apps/core run test`
+Expected: all green (note: pre-existing unrelated suites must continue to pass).
+
+- [ ] **Step 2: Run lint on every touched file**
+
+Run:
+
+```bash
+pnpm -C apps/core exec eslint \
+  src/modules/enrichment/providers/open-graph/url-guard.ts \
+  src/modules/enrichment/providers/open-graph/safe-fetch.ts \
+  src/modules/enrichment/providers/open-graph/browser-session-pool.ts \
+  src/modules/enrichment/providers/open-graph/browser-fetch.service.ts \
+  src/modules/enrichment/enrichment.module.ts \
+  test/src/modules/enrichment/browser-session-pool.spec.ts \
+  test/src/modules/enrichment/browser-fetch.service.spec.ts
+```
+
+Expected: 0 errors.
+
+- [ ] **Step 3: Push and open PR update**
+
+```bash
+git push origin feat/enhance-enrichment --force-with-lease
+```
+
+Expected: PR #2708 updated with the new commits.
+
+- [ ] **Step 4: Confirm CI is green on the branch**
+
+Visit the PR page and verify Test (shards 1/2/3) and Lint & Typecheck pass.
+
+---
+
+## Self-Review
+
+- **Spec coverage:**
+  - Session reuse → Task 2 (pool) + Task 3 (fetch service uses it). ✓
+  - Concurrency cap → Task 2 (queue inside pool). ✓
+  - SSRF gap from prior review → Task 1 (extract guards) + Task 3 (apply in fetch service). ✓
+  - Rebase to master → already done before the plan started. ✓
+- **Placeholder scan:** none — every code step contains complete code or an exact command.
+- **Type consistency:** `PoolSlot.name`, `BrowserSessionPool.acquire/release/markLive/shutdown/onModuleDestroy`, `AcquireOptions.signal`, `ReleaseOptions.discard` are defined in Task 2 and referenced consistently in Task 3.
+
+---
+
+## Execution Handoff
+
+Plan complete and saved to `docs/superpowers/plans/2026-05-13-browser-fetch-session-pool.md`. Two execution options:
+
+1. **Subagent-Driven (recommended)** — fresh subagent per task, two-stage review between tasks.
+2. **Inline Execution** — execute tasks in this session with checkpoints.
+
+Which approach?

--- a/docs/superpowers/specs/2026-05-11-knowledge-base-book-tree-design.md
+++ b/docs/superpowers/specs/2026-05-11-knowledge-base-book-tree-design.md
@@ -1,0 +1,470 @@
+# Knowledge Base — Book + Tree Node Design
+
+**Date:** 2026-05-11
+**Status:** Draft (pending implementation plan)
+**Module:** `apps/core/src/modules/book/`
+
+## 1. Goals
+
+Extend the personal blog with a knowledge-base subsystem that hosts multiple independent "books" — long-form structured works such as novels, manuals, wikis, or tutorials. Each book is a self-contained tree of nodes. The subsystem is a brand-new module that does not retrofit existing `post`/`note`/`page` entities; cross-entity coupling is loose (URL/soft references only).
+
+Primary use cases:
+
+- Author a novel chapter-by-chapter with drafts, locked chapters, and reader navigation.
+- Build a structured wiki / handbook with arbitrary-depth folders and entries.
+- Reuse existing platform capabilities: Lexical content, BM25 multilingual search, AI summary/translation/insights, comments, i18n.
+
+Non-goals (deferred to later iterations):
+
+- Cross-book "knowledge graph" computed automatically.
+- Multi-author collaboration / role-based ACL inside a single book.
+- Reading progress per visitor, bookmarks, annotations.
+- RSS/feed of new chapters (will hook into existing subscribe module later).
+- Yohaku (Next.js) reader UI — out of scope for the server-side spec; the public APIs are designed so that a SSR reader can be built on top.
+
+## 2. Domain Model
+
+Four tables, Snowflake `bigint` ids, snake_case at the API boundary (handled by the existing `JSONTransformInterceptor`).
+
+### 2.1 `book`
+
+| Column | Type | Notes |
+|---|---|---|
+| `id` | `bigint` (snowflake) | PK |
+| `slug` | `text` | Unique, URL-safe |
+| `title` | `text` |  |
+| `subtitle` | `text nullable` |  |
+| `cover_url` | `text nullable` |  |
+| `author_id` | `text` | Better Auth user id |
+| `status` | `enum('draft','unlisted','published')` |  |
+| `default_locale` | `text` | e.g. `zh-CN` |
+| `description` | `jsonb nullable` | Lexical JSON — book-level intro |
+| `meta` | `jsonb` default `{}` | Free-form (genre, tags, ISBN-like) |
+| `created_at` | `timestamptz` |  |
+| `updated_at` | `timestamptz` |  |
+| `published_at` | `timestamptz nullable` |  |
+
+Indexes: `(slug)` unique, `(status, published_at desc)` for public listing.
+
+### 2.2 `book_node`
+
+Adjacency-list tree, sibling-ordered by integer rank.
+
+| Column | Type | Notes |
+|---|---|---|
+| `id` | `bigint` | PK |
+| `book_id` | `bigint` | FK → `book.id`, on delete cascade |
+| `parent_id` | `bigint nullable` | FK → `book_node.id`, on delete cascade |
+| `sort_order` | `int` | Sibling rank; default in 1024-step increments to allow cheap reorder |
+| `type` | `enum('folder','chapter')` | folder ⇒ container only |
+| `slug` | `text` | Unique within `book_id` |
+| `title` | `text` |  |
+| `content` | `jsonb nullable` | Lexical JSON; null for folder |
+| `status` | `enum('draft','unlisted','published')` |  |
+| `password` | `text nullable` | bcrypt hash; per-node lock |
+| `word_count` | `int` default 0 | Computed on save |
+| `meta` | `jsonb` default `{}` |  |
+| `created_at` / `updated_at` / `published_at` | `timestamptz` |  |
+
+Indexes:
+
+- `(book_id, parent_id, sort_order)` — TOC traversal
+- `(book_id, slug)` unique — public addressability
+- `(book_id, status)` — visibility filtering
+
+Constraints:
+
+- `parent_id` must point to a node with the same `book_id` (enforced at service layer; CHECK constraint optional via trigger if needed).
+- `type='folder'` ⇒ `content IS NULL` (CHECK constraint).
+- `type='chapter'` ⇒ `content` may be null (empty chapter is allowed for outlining).
+
+### 2.3 `book_node_locale`
+
+Locale overrides; main `book_node` row holds the `default_locale` content.
+
+| Column | Type | Notes |
+|---|---|---|
+| `id` | `bigint` | PK |
+| `node_id` | `bigint` | FK → `book_node.id`, cascade |
+| `locale` | `text` |  |
+| `title` | `text` |  |
+| `content` | `jsonb` | Lexical JSON |
+| `status` | `enum(...)` | Mirrors node states (a translation may lag) |
+| `source_content_hash` | `text` | Hash of the source `book_node.content` at translation time — UI flags "source updated" when mismatched |
+| `created_at` / `updated_at` | `timestamptz` |  |
+
+Unique `(node_id, locale)`.
+
+### 2.4 `book_backlink`
+
+Reverse-link adjacency, computed from a scan of Lexical content on save.
+
+| Column | Type | Notes |
+|---|---|---|
+| `id` | `bigint` | PK |
+| `source_node_id` | `bigint` | FK → `book_node.id`, cascade |
+| `target_node_id` | `bigint` | FK → `book_node.id`, NOT cascade (see Stale below) |
+| `occurrence` | `int` default 1 | Count of links in source |
+| `is_stale` | `bool` default false | Set true when target deleted |
+| `created_at` / `updated_at` | `timestamptz` |  |
+
+Unique `(source_node_id, target_node_id)`. Indexes on `target_node_id` (lookup backlinks for a chapter) and `source_node_id` (recompute on save).
+
+Stale handling: when a node is deleted, rows where it is `target_node_id` are *not* deleted; they are marked `is_stale=true` so the UI can surface "broken reference". Author may manually clean.
+
+## 3. Tree Operations
+
+### 3.1 Storage strategy
+
+Adjacency list with integer `sort_order`. Subtree queries use recursive CTE scoped by `book_id`:
+
+```sql
+WITH RECURSIVE descendants AS (
+  SELECT * FROM book_node WHERE id = $1
+  UNION ALL
+  SELECT n.* FROM book_node n
+  JOIN descendants d ON n.parent_id = d.id
+)
+SELECT * FROM descendants;
+```
+
+`book_id` filter is always present to limit branching and let PostgreSQL prune via the `(book_id, parent_id, sort_order)` index.
+
+### 3.2 Reorder
+
+Siblings carry integer `sort_order` (initial 1024 steps). Insert-between picks midpoint; if the gap shrinks to ≤ 1, run a per-parent compaction transaction that rewrites siblings to fresh 1024-step ranks. Compaction is O(k) on a single parent's children — cheap.
+
+### 3.3 Move
+
+Endpoint `POST /books/:bookId/nodes/:id/move` with `{ newParentId, beforeId? }`:
+
+1. Validate `newParentId` belongs to the same book.
+2. Validate that `newParentId` is not the node itself nor any descendant (single recursive CTE check).
+3. Acquire a per-book advisory lock (`pg_advisory_xact_lock(book_id)`) to serialize concurrent moves within a book.
+4. Compute new `sort_order` based on `beforeId`.
+5. Update `parent_id` + `sort_order`.
+
+### 3.4 Delete
+
+Default mode: cascade — the node and all descendants are removed (DB-level cascade FK).
+Optional mode (`?mode=reparent`): children are reparented to the deleted node's parent. Implementation: in a single transaction, update children's `parent_id` to grandparent and `sort_order` to slot in after the deleted node, then delete.
+
+## 4. HTTP API
+
+All admin routes are `@Auth()`-protected; public routes are open and apply visibility filters.
+
+### 4.1 Admin
+
+```
+POST   /books
+PATCH  /books/:id
+DELETE /books/:id
+
+GET    /books/:bookId/nodes/:id            (incl. drafts)
+POST   /books/:bookId/nodes                { parent_id, type, title, slug?, content? }
+PATCH  /books/:bookId/nodes/:id
+DELETE /books/:bookId/nodes/:id?mode=cascade|reparent
+
+POST   /books/:bookId/nodes/:id/move       { newParentId, beforeId? }
+POST   /books/:bookId/nodes/:id/reorder    { sortOrder }
+
+PUT    /books/:bookId/nodes/:id/locales/:locale   upsert translation row
+DELETE /books/:bookId/nodes/:id/locales/:locale
+
+POST   /books/:bookId/nodes/:id/translate?targetLocale=en   (kick off ai-translation; writes to locale row)
+POST   /books/:bookId/nodes/:id/summarize                   (kick off ai-summary)
+POST   /books/:bookId/reindex                                (full BM25 rebuild for book)
+```
+
+### 4.2 Public
+
+```
+GET /books                                  paginated list, published only
+GET /books/:slug                            book metadata + TOC tree (published nodes only)
+GET /books/:bookSlug/:nodeSlug?locale=en    node detail + prev/next + locale negotiation
+GET /books/:bookSlug/:nodeSlug/backlinks    list of (book, node) referrers, published only, stale filtered
+POST /books/:bookSlug/:nodeSlug/unlock      { password } → returns content + short-lived unlock token
+```
+
+Response shapes follow existing platform conventions:
+
+- Lists with `@Paginator()` produce `{ data, pagination }`.
+- TOC is an object (not paginated), returned directly.
+- All keys snake_case at boundary (`JSONTransformInterceptor`).
+- `?format=markdown` flag triggers Lexical → Markdown via `helper.lexical.service`.
+
+### 4.3 TOC payload (illustrative)
+
+```json
+{
+  "book": { "id": "...", "slug": "...", "title": "..." },
+  "tree": [
+    {
+      "id": "...", "slug": "preface", "title": "Preface",
+      "type": "chapter", "has_password": false,
+      "child_count": 0, "children": []
+    },
+    {
+      "id": "...", "slug": "part-1", "title": "Part 1",
+      "type": "folder", "has_password": false,
+      "child_count": 12, "children": [ /* ... */ ]
+    }
+  ]
+}
+```
+
+The TOC is computed in a single recursive CTE per request; for very large books (≫ 1000 nodes) we can add a depth cap parameter later.
+
+## 5. Visibility & Access
+
+Effective visibility of a node = `min(book.status, node.status)` where the order is `draft < unlisted < published`.
+
+| Plane | draft | unlisted | published |
+|---|---|---|---|
+| Public list / sitemap / feed | no | no | yes |
+| Direct URL access | owner only | yes | yes |
+| BM25 search index | no | no | yes |
+| AI auto-summary on event | no | no | yes |
+
+`book-node-visibility.service.ts` exposes:
+
+- `applyPublicFilter(query)` — `status='published'` plus parent chain published.
+- `assertReadable(node, currentUser)` — throws `403` if hidden, `404` if draft and not owner.
+
+The repository's `find*` methods accept a visibility option; controllers select it based on the route (admin vs public). No bypass at the controller-level — visibility is owned by the service layer.
+
+## 6. Per-Node Password Lock
+
+- `password` column stores a bcrypt hash; never returned in any response.
+- Public node detail for a locked node returns:
+  ```json
+  { "id": "...", "title": "...", "slug": "...", "has_password": true, "content": null }
+  ```
+- Client posts `POST /books/.../:nodeSlug/unlock { password }`; on success the response returns the full content plus a JWT cookie scoped to the node id, valid 15 minutes. Subsequent fetches with the cookie return content directly.
+- BM25 indexer skips locked nodes entirely (no token leakage via search snippets).
+- AI summary, translation, insights are admin-triggered only for locked nodes — never auto-run on publish; any cached output is keyed by node id and access-gated through the same unlock flow on the public side.
+- Locked chapters disable public comment posting; existing comments remain hidden until unlocked.
+
+## 7. Lexical Integration
+
+### 7.1 Content nodes
+
+`content` reuses the same Lexical JSON shape as `note`. The headless editor and `$toMarkdown()` conversion in `helper.lexical.service.ts` are reused unchanged.
+
+### 7.2 Wiki links — URL scheme
+
+To avoid touching `@haklex/rich-headless`, wiki links are encoded as standard Lexical link nodes with URL scheme `book://<bookSlug>/<nodeSlug>` (or `book://./<nodeSlug>` for same-book links). The scanner (`lexical/wiki-link.scanner.ts`) walks the Lexical tree on save, extracts target slugs, resolves to node ids, and produces a `{ targetNodeId, occurrence }[]` list.
+
+A future enhancement can introduce a dedicated `BookWikiLinkNode` in haklex for richer UI (preview popovers, broken-link badges); the scanner contract is stable enough to accommodate both.
+
+### 7.3 On-save pipeline
+
+When a chapter is created or updated:
+
+1. Compute `word_count` from Lexical text nodes.
+2. Run wiki-link scanner → diff against existing `book_backlink` rows where `source_node_id = node.id` → upsert / delete / increment occurrence.
+3. Emit `BookNodeUpdated` (or `BookNodePublished` if status transitions to published).
+
+Word count and backlink upsert happen synchronously inside the save transaction; event-driven consumers (search index, AI) run async.
+
+## 8. Multi-language
+
+The main `book_node` row holds the canonical content in `book.default_locale`. `book_node_locale` stores per-locale overrides for title + content.
+
+Locale negotiation on read:
+
+1. Read query `?locale=xx`; default to `Accept-Language` header → `book.default_locale`.
+2. If a `book_node_locale` row exists for `(node_id, locale)`, return it; otherwise return the main row.
+3. Response meta includes `locale`, `locale_fallback: boolean`.
+
+AI translation (`POST /books/.../:id/translate?targetLocale=en`):
+
+- Runs `ai-translation` over the canonical content.
+- Output is parsed through `lexical-translation-parser`.
+- Resulting Lexical JSON is written to `book_node_locale` with `source_content_hash` set to the hash of the canonical content at translation time.
+- Public API exposes `locale_source_stale: true` when `source_content_hash` no longer matches.
+
+TOC titles likewise honor locale negotiation per node.
+
+## 9. Search (BM25)
+
+The existing `multilingual-bm25-search` indexer gains a new source type `book-node`. Indexed document:
+
+```
+{
+  id: node.id,
+  source: 'book-node',
+  book_id, book_slug, book_title,
+  node_slug, title, content_text, locale,
+  status: 'published'
+}
+```
+
+Triggers:
+
+- `BookNodePublished` → upsert document for canonical + each published locale row.
+- `BookNodeUpdated` (already published) → upsert document(s).
+- `BookNodeUnpublished` / `BookNodeDeleted` → remove document(s).
+- Locked-node and `status != published` rows are never indexed.
+
+Admin endpoint `POST /books/:id/reindex` rebuilds all docs for a book — recovery hatch for index drift.
+
+## 10. AI Integration
+
+All three AI surfaces (summary, translation, insights) integrate by extending their entity key shape to include `book-node`.
+
+- `ai-summary` — cache key `(entity='book-node', node_id, locale, content_hash)`. Reuses chunk-and-reduce logic from existing post/note path. Book-level summary derived from chapter summaries is a later iteration.
+- `ai-translation` — wired via §8.
+- `ai-insights` — adds `book-node` as a tracked entity; pipeline unchanged.
+
+Default behavior is manual trigger only. A boolean option `book.ai_auto_summary_on_publish` (in the existing `option` module) can flip auto-run on for published, non-locked chapters. Token cost considerations gate this default off.
+
+## 11. Comments
+
+Extend `comment.refType` enum to include `book-node`. Comment service's entity loader dispatches on `refType` and loads a `BookNode` via `BookNodeService.findByIdForComment(nodeId, currentUser)`, which:
+
+- Enforces visibility.
+- Refuses to load locked chapters for public posting.
+- Returns minimal node info (book slug + node slug + title) for comment rendering.
+
+Notifications follow the existing reader subscription flow keyed by comment thread.
+
+## 12. Module Layout
+
+```
+apps/core/src/modules/book/
+  book.module.ts
+  controllers/
+    book.controller.ts
+    book.public.controller.ts
+    book-node.controller.ts
+    book-node.public.controller.ts
+  services/
+    book.service.ts
+    book-node.service.ts
+    book-node-tree.service.ts          # recursive CTE, move, reorder, advisory lock
+    book-node-locale.service.ts
+    book-node-visibility.service.ts
+    book-backlink.service.ts
+  repositories/
+    book.repository.ts
+    book-node.repository.ts
+    book-node-locale.repository.ts
+    book-backlink.repository.ts
+  schemas/                              # Zod
+    book.schema.ts
+    book-node.schema.ts
+    book-node-locale.schema.ts
+  dto/
+    create-book.dto.ts
+    update-book.dto.ts
+    create-book-node.dto.ts
+    update-book-node.dto.ts
+    move-book-node.dto.ts
+    upsert-locale.dto.ts
+    unlock-node.dto.ts
+  events/
+    book-node.events.ts                 # BookNodePublished, Updated, Unpublished, Deleted
+  lexical/
+    wiki-link.scanner.ts
+```
+
+Database schema files under `apps/core/src/database/schema/`:
+
+- `book.ts`
+- `book-node.ts` (+ `book_node_locale`)
+- `book-backlink.ts`
+
+Repositories register in `repository.tokens.ts` and extend `BaseRepository`.
+
+File-size budget: 500 lines max. Tree-service may approach the limit; if so, split visibility filtering into `book-node-visibility.service.ts` (already planned) and keep `book-node-tree.service.ts` focused on structural mutations.
+
+## 13. Events
+
+Defined in `events/book-node.events.ts`:
+
+| Event | Payload | Consumers |
+|---|---|---|
+| `BookNodePublished` | `{ nodeId, bookId, locale }` | search indexer, optional AI summarizer, subscribe (future) |
+| `BookNodeUpdated` | `{ nodeId, bookId, changedFields }` | search indexer, backlink propagator |
+| `BookNodeUnpublished` | `{ nodeId, bookId }` | search indexer |
+| `BookNodeDeleted` | `{ nodeId, bookId }` | search indexer, backlink staleness |
+| `BookNodeLocaleUpserted` | `{ nodeId, locale }` | search indexer |
+
+Consumers subscribe via the project's existing `EventManager`. All event handlers must be idempotent; retries are best-effort.
+
+## 14. Migrations
+
+Authored with the `mx-migration-author` skill following the expand-contract pattern (mx-core runs rolling deploys with two replicas via Dokploy).
+
+Phase 1 — expand (this spec):
+
+- Create `book`, `book_node`, `book_node_locale`, `book_backlink` tables with all columns and indexes.
+- Add `book-node` to `comment.refType` enum (Postgres `ADD VALUE`, expand-only operation).
+
+No contract phase required for this initial introduction. Future schema changes (e.g., adding `materialized_path` or switching to `ltree`) will follow expand-contract on their own.
+
+`pnpm -C apps/core run lint:migrations` must pass.
+
+## 15. Testing
+
+Vitest with Postgres testcontainers (`startPgTestContainer()`) and the existing `createE2EApp` helper.
+
+Unit:
+
+- `book-node.repository`: insert/find/visibility filter matrix.
+- `book-node-tree.service`: build, move (anti-cycle), reorder, compaction, delete cascade vs reparent.
+- `book-backlink.service`: wiki-link scanner against Lexical fixtures; upsert/delete diff; stale marking on target deletion.
+- `book-node-visibility.service`: status × parent-status × locked matrix.
+- `wiki-link.scanner`: same-book `./` resolution, cross-book resolution, malformed slugs.
+
+E2E:
+
+- Admin CRUD happy path.
+- Public list + TOC filters drafts/unlisted.
+- Locked node returns redacted payload; unlock round-trip with cookie.
+- Locale negotiation: hit, fallback, stale flag.
+- Move endpoint rejects self-descendant move, succeeds otherwise; sort_order persisted.
+- Backlink upserted on save; stale flag on target delete.
+- Comment with `refType=book-node` end-to-end.
+- Search indexer mock receives expected events on publish/update/delete.
+
+Performance baseline:
+
+- TOC query for a synthetic 1000-node book < 50 ms warm cache via the recursive CTE.
+- `EXPLAIN ANALYZE` captured in test setup for regression detection.
+
+## 16. Risks & Mitigations
+
+| Risk | Mitigation |
+|---|---|
+| Concurrent moves within a book corrupt tree state | `pg_advisory_xact_lock(book_id)` in move/delete txns |
+| Backlink scan blocks save on large chapters | Run scanner inline only on diff'd link set; offload to event queue if measured > 50 ms p99 |
+| BM25 index drifts vs DB | Admin `POST /books/:id/reindex` full-rebuild endpoint |
+| AI translation drifts after source edit | `source_content_hash` stored; public response flags stale |
+| Locked content accidentally indexed | Visibility filter applied at indexer entry; explicit unit test |
+| Tree height explodes (pathological recursion) | Optional depth cap parameter on TOC; can hard-cap at 16 in service if needed |
+| Migration introduces downtime | Expand-only schema add; rolling deploy safe by construction |
+
+## 17. Rollout
+
+Sequenced as separate PRs to keep diffs reviewable:
+
+1. **PR-1 — Foundation**: schema migrations, repositories, book + book_node CRUD, public read, visibility, locale tables and negotiation, per-node password.
+2. **PR-2 — Backlinks**: wiki-link scanner, `book_backlink` table, on-save pipeline, public backlinks endpoint.
+3. **PR-3 — Search**: BM25 indexer extension + reindex endpoint + event handlers.
+4. **PR-4 — AI**: summary/translation/insights wiring + admin endpoints.
+5. **PR-5 — Comments**: refType extension and entity loader.
+6. **PR-6 — (later)** subscribe/feed integration, Yohaku reader UI (separate repo).
+
+Each PR is independently deployable behind the rolling-deploy contract.
+
+## 18. Open Questions
+
+- Should books support arbitrary metadata fields editable via UI, or stay closed to a fixed `meta` jsonb? — left open; UI design decides.
+- Reading-progress per visitor: deferred. May land as a separate module that references `book_node.id` without coupling.
+- Cross-book wiki links: stored, but should the public backlink listing show them? — start with same-book only in the response; cross-book can be opted-in per book later.
+
+---
+
+End of spec.

--- a/docs/superpowers/specs/2026-05-12-enrichment-screenshot-design.md
+++ b/docs/superpowers/specs/2026-05-12-enrichment-screenshot-design.md
@@ -1,0 +1,382 @@
+# Enrichment Screenshot Capture & UI
+
+> 2026-05-12 · scope: `apps/core/src/modules/enrichment` + Yohaku link-card UI · status: design
+
+## Background
+
+The Open Graph fallback provider (`OpenGraphProvider`) now has two fetch modes (see `2026-05-12-enrichment-resolve-hardening-design.md` and the recent `safe-fetch.ts` + `browser-fetch.service.ts` work):
+
+- `fetch` — plain HTTP via `safeFetch`, default.
+- `browser` — agent-browser headless rendering, opt-in via `thirdPartyServiceIntegration.openGraph.fetchMode = 'browser'`. Used for Cloudflare-walled / SPA / heavily-rendered sites.
+
+Browser mode unlocks signals that plain HTTP cannot deliver. The biggest single win is a **page screenshot**: many indie blogs and SPA sites ship no `og:image`, and the link card falls back to a bare title row. A first-paint screenshot fills that gap, and the same screenshot lets us derive a dominant-color palette to tint the card.
+
+On the Yohaku side, link cards are rendered through `dispatch.tsx`. The `web` category lands on `FallbackCard`, which composes `LinkCardShell` + `WideOgMedia` + a meta row. `WideOgMedia` consumes `EnrichmentResult.image` (url + width/height + blurhash). `HoverLinkCard` reuses the same atom in a 360px popover. `InkWash` reads `--color-accent` (currently sourced from `<meta theme-color>` only).
+
+## Goals
+
+1. When `fetchMode = 'browser'`, capture a first-paint screenshot of the target page in the same agent-browser session that fetched HTML, with no second navigation.
+2. Persist screenshots to S3-compatible object storage (re-using `S3Uploader`) under a **double-quota cap** (item count + total bytes). Oldest-by-access entries are evicted before each new write so disk/storage growth is bounded.
+3. Surface the screenshot, blurhash, and palette through `EnrichmentResult.screenshot` so existing API consumers stay backward-compatible (purely additive field).
+4. In Yohaku, use the screenshot as an `og:image` fallback (so empty cards become visual) and as the **primary media** for `HoverLinkCard` (so the hover popover always shows the actual destination, even when an `og:image` is present).
+5. Tint the card via the screenshot's dominant color when no `<meta theme-color>` is set, raising visual-consistency coverage from the small subset of sites that ship `theme-color` to virtually all browser-mode-captured pages.
+
+## Non-Goals
+
+- Mobile-viewport capture (`set viewport 375 812`). Doubles storage cost for marginal product value; revisit after observing P0 in production.
+- A dedicated "screenshot-only" link card variant (the "P2 `ScreenshotCard`" sketch from brainstorming). Wait until we can quantify how many cards land in browser mode *and* lack `description`/`site`.
+- A full-page (long) screenshot. Capture is fixed-viewport 16:9 only; full-page screenshots blow out the popover height budget.
+- Screenshot for the `fetch` HTTP path. Plain `fetch` has no renderer, so the only way to add screenshots there would be to invoke agent-browser purely for visuals — defeats the cost trade-off the user chose by picking `fetchMode = 'fetch'`.
+- A lightbox / zoomable preview of the screenshot. Out of scope; users tap through to the live page.
+- Re-capturing on TTL refresh of existing cached enrichments before this feature ships. Backfill is opt-in via admin refresh and not automatic.
+
+## Architecture
+
+```
+                 ┌─────────────────────────────┐
+                 │   OpenGraphProvider.fetch   │
+                 │   (fetchMode == 'browser')  │
+                 └──────────────┬──────────────┘
+                                │
+                                ▼
+              ┌───────────────────────────────────┐
+              │   BrowserFetchService.fetchPage   │
+              │   (one agent-browser session)     │
+              │                                   │
+              │   1. open <url>                   │
+              │   2. wait 1500                    │
+              │   3. eval outerHTML               │  ← already exists
+              │   4. screenshot to .webp          │  ← NEW
+              │   5. close session                │
+              └──────────────┬────────────────────┘
+                             │  { html, screenshotBytes }
+                             ▼
+              ┌───────────────────────────────────┐
+              │      ScreenshotPipeline           │
+              │                                   │
+              │   sharp(buf):                     │
+              │    - downscale 1280x720           │
+              │    - extract dominant + swatches  │
+              │    - encode blurhash 32x32        │
+              │    - re-encode webp q75           │
+              └──────────────┬────────────────────┘
+                             │
+                             ▼
+              ┌───────────────────────────────────┐
+              │   ScreenshotStorageService        │
+              │                                   │
+              │   1. evictIfOverQuota()           │
+              │      → DELETE oldest by LRU until │
+              │        items ≤ max && bytes ≤ max │
+              │      → S3 deleteObject on each    │
+              │   2. S3 putObject .webp           │
+              │   3. INSERT enrichment_screenshots│
+              └──────────────┬────────────────────┘
+                             │
+                             ▼
+              ┌───────────────────────────────────┐
+              │   OpenGraphProvider injects       │
+              │   result.screenshot = {url,...}   │
+              └───────────────────────────────────┘
+```
+
+API → Yohaku → `dispatch` → `FallbackCard` / `HoverLinkCard` consume `result.screenshot` (purely additive; no schema break).
+
+## Components
+
+### Backend
+
+#### `BrowserFetchService.fetchPage(url, opts)` (extends the existing `fetchHtml`)
+
+Returns `{ html: string, screenshotBytes?: Buffer }`. The existing batch chain (`open`, `wait 1500`, `eval ...`) is extended with one extra step inside the same session:
+
+```
+agent-browser --session og-<hex> batch --bail --json \
+  "open <url>" \
+  "wait 1500" \
+  "eval -b <b64> --json" \
+  "set viewport 1280 720" \
+  "screenshot --screenshot-format webp --screenshot-quality 75 --screenshot-dir <tmpdir>"
+```
+
+The CLI writes the screenshot to a tempfile; the service reads the bytes back and unlinks the file. If the screenshot step fails (CLI error, timeout, missing file), HTML is still returned and `screenshotBytes` is `undefined`. The HTML path must not regress on screenshot failure.
+
+Existing CLI args are kept where they are (no flag changes). Failure to find a screenshot file after the batch completes is logged at `debug` and treated as "no screenshot," not an error.
+
+Timeout (`opts.timeoutMs`, default 25_000 in browser mode) covers the entire batch. The existing `AbortController` + `SIGKILL` path needs no change.
+
+#### `ScreenshotPipelineService` (new, in `providers/open-graph/`)
+
+Pure compute. Takes raw screenshot bytes; returns:
+
+```ts
+interface ProcessedScreenshot {
+  webp: Buffer        // re-encoded at configured quality, possibly downscaled
+  width: number
+  height: number
+  blurhash: string         // lowercase to match the existing EnrichmentImage shape
+  palette: {
+    dominant: string         // #RRGGBB
+    swatches?: string[]      // top-3 distinct, optional
+  }
+}
+```
+
+Implementation:
+
+- `sharp(input).resize(1280, 720, { fit: 'inside', withoutEnlargement: true })`
+- `.stats()` for `.dominant` (re-used pattern from `helper.image.service.ts`)
+- Swatches via histogram bucketing on a 64x64 downscale (top 3 colors by frequency, distance-filtered so swatches do not collapse into near-duplicates). Cheap; ~5ms.
+- Blurhash via the same `blurhash` package and 32x32 raw read pattern already used by `helper.image.service.ts:147-158`. Field name stays lowercase (`blurhash`) to match the existing `EnrichmentImage` shape on the wire; the `JSONTransformInterceptor` snake_case rule does not affect it (no camel hump).
+- Final encode `.webp({ quality: configuredQuality })`.
+
+If `processed.webp.length > maxBytesPerImage`, retry once at `quality - 15`. If still over, drop the screenshot (logged) — never store oversized blobs.
+
+Reuses the existing `sharp` dependency. No new packages.
+
+#### `ScreenshotStorageService` (new)
+
+Owns the put/evict/delete cycle. Exposes:
+
+```ts
+interface ScreenshotStorageService {
+  storeOrEvict(args: {
+    enrichmentId: string            // Snowflake decimal string, matches enrichment_cache.id
+    processed: ProcessedScreenshot
+  }): Promise<{ url: string }>
+  delete(enrichmentId: string): Promise<void>
+  touchAccess(enrichmentId: string): Promise<void>  // throttled via Redis NX-EX 3600
+}
+```
+
+`storeOrEvict` flow:
+
+1. Read current `(count, sum_bytes)` from `enrichment_screenshots` (single aggregate query).
+2. If `count + 1 > maxItems` or `sum_bytes + new.bytes > maxTotalBytes`, select oldest rows by `last_accessed_at ASC`, delete S3 objects (best-effort, swallow 404s), and delete DB rows in batches of 50 until quotas pass.
+3. Run a single SQL transaction: `S3 putObject` first (S3 is the source of truth; if it fails, nothing is written), then `INSERT ... ON CONFLICT (enrichment_id) DO UPDATE` (a re-capture of the same enrichment overwrites bytes + clears old object key first).
+4. Return the public CDN URL (re-uses `S3Uploader.getPublicUrl(objectKey)`).
+
+`touchAccess` is invoked by `EnrichmentController.getOne` and `EnrichmentController.resolve` on cache hit. To prevent write amplification, it short-circuits if `last_accessed_at` was updated within the last hour — checked via a Redis key `enrich:scr:touch:<id>` with `EX 3600 NX`. The Redis check is the same pattern already used by other "touch" paths (see existing `EnrichmentService` cache layer).
+
+`delete` is called from admin "delete enrichment" / "purge cache" paths (best-effort; failure does not block the enrichment delete).
+
+#### Schema: `enrichment_screenshots` table
+
+New table, additive only. No changes to existing `enrichments` table.
+
+```sql
+CREATE TABLE enrichment_screenshots (
+  enrichment_id      TEXT PRIMARY KEY REFERENCES enrichment_cache(id) ON DELETE CASCADE,
+  object_key         TEXT NOT NULL,
+  bytes              INTEGER NOT NULL,
+  width              INTEGER NOT NULL,
+  height             INTEGER NOT NULL,
+  blurhash           TEXT,
+  palette            JSONB,
+  created_at         TIMESTAMPTZ NOT NULL DEFAULT now(),
+  last_accessed_at   TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE INDEX enrichment_screenshots_lru_idx
+  ON enrichment_screenshots (last_accessed_at ASC);
+```
+
+`enrichment_id` is `TEXT` because `enrichment_cache.id` is a Snowflake decimal string stored via `pkText()` (see `packages/db-schema/src/schema/columns.ts`). The matching Drizzle helper for the FK column is `refText('enrichment_id')`. Column name `blurhash` is lowercase to match the wire shape — see the pipeline interface note above.
+
+Migration safety (rolling deploy, Dokploy 2 replicas — see `2026-05-05-database-migration-release-phase-design.md`):
+
+- Pure additive `CREATE TABLE` + `CREATE INDEX`. New replicas reference the table; old replicas never touch it. Expand-only; no contract step needed.
+- The `ON DELETE CASCADE` removes screenshot rows when an enrichment is deleted, so admin "purge" continues to work without explicit join cleanup; S3 cleanup runs through `ScreenshotStorageService.delete` in the same path.
+- The matching Drizzle schema definition lives under `packages/db-schema/src/schema/enrichment.ts` (extend the existing file rather than creating a new one — the `enrichment_cache` table already lives there). Re-export from `packages/db-schema/src/schema/index.ts` if not already covered by the file-level `*` re-export. Repository is a new class `EnrichmentScreenshotRepository extends BaseRepository<typeof enrichmentScreenshots>` registered through `apps/core/src/processors/database/repository.tokens.ts` per existing pattern.
+
+This migration is authored using the `mx-migration-author` skill and validated by `pnpm -C apps/core run lint:migrations`.
+
+#### `OpenGraphProvider` integration
+
+Inside the `fetchMode === 'browser'` branch (currently `await this.browserFetch.fetchHtml(...)`):
+
+1. Switch the call to `browserFetch.fetchPage(...)` to receive `{ html, screenshotBytes? }`.
+2. Parse HTML through the existing `parseOpenGraph` path (no change).
+3. If `screenshotBytes` is present and `screenshot.enabled` is true:
+   - Pipe through `ScreenshotPipelineService`.
+   - Call `ScreenshotStorageService.storeOrEvict({ enrichmentId, processed })`.
+   - Set `result.screenshot = { url, width, height, blurHash, palette }` on the enrichment payload.
+4. The enrichment row write path is unchanged; `screenshot` is part of the JSON result column.
+
+If processing or storage fails at any point, the enrichment result is still returned (just without `screenshot`). Failure is logged at `warn`; the user-visible card degrades to the existing fallback behavior.
+
+The enrichment row must exist (have an `id`) before the screenshot row is written, since `enrichment_screenshots.enrichment_id` is a foreign key. The natural place is inside `EnrichmentService.fetchAndPersist` *after* the `INSERT ... RETURNING id` step, not inside the provider's `fetch()` (which does not see the row id).
+
+To keep `OpenGraphProvider.fetch`'s public return type unchanged, `BrowserFetchService` owns a request-scoped channel for the raw bytes:
+
+```ts
+// inside BrowserFetchService
+private readonly bytesByResult = new WeakMap<EnrichmentResult, Buffer>()
+
+takeScreenshotBytes(result: EnrichmentResult): Buffer | undefined {
+  const buf = this.bytesByResult.get(result)
+  this.bytesByResult.delete(result)
+  return buf
+}
+```
+
+`OpenGraphProvider.fetch()` writes into the WeakMap with the result instance it is about to return; `EnrichmentService.fetchAndPersist` calls `browserFetch.takeScreenshotBytes(result)` *after* persisting the row, runs the pipeline + storage steps, then updates the row's `screenshot` JSON field. The WeakMap auto-clears once the result object is garbage-collected, so there is no manual TTL to track. The `EnrichmentResult` public shape (and therefore the API response) never carries `screenshotBytes`.
+
+#### Config
+
+Adds a new sub-section under `thirdPartyServiceIntegration.openGraph`:
+
+```ts
+screenshot: {
+  enabled: false,                  // default OFF; opt-in
+  maxItems: 500,
+  maxTotalBytes: 100 * 1024 * 1024,
+  maxBytesPerImage: 512 * 1024,
+  webpQuality: 75,
+}
+```
+
+Schema validation lives in `configs.schema.ts` next to the existing `openGraph` schema. Defaults wired through `configs.default.ts`. Schema field uses `field.number` + `z.preprocess` mirroring the existing `timeoutMs`/`maxBodyBytes` fields.
+
+#### Touch path (LRU access bookkeeping)
+
+`EnrichmentController.getOne` and `EnrichmentController.resolve` already return the `EnrichmentResult` from the repository on cache hit. After the response is produced, fire-and-forget:
+
+```ts
+if (result.screenshot) {
+  this.storage.touchAccess(result.id).catch(() => {/* ignored */})
+}
+```
+
+The Redis NX-with-TTL gate inside `touchAccess` keeps this from generating a write per hover. Worst case: ~24 writes/day per active link card, well within `enrichment_screenshots` capacity.
+
+### Frontend (Yohaku)
+
+#### Model: `EnrichmentResult.screenshot`
+
+Add to `apps/web/src/models/enrichment.ts`:
+
+```ts
+export interface EnrichmentScreenshot {
+  url: string
+  width: number
+  height: number
+  blurhash?: string
+  palette?: { dominant: string; swatches?: string[] }
+}
+
+export interface EnrichmentResult {
+  // ...existing fields
+  screenshot?: EnrichmentScreenshot
+}
+```
+
+`@mx-space/api-client` types receive the same additive field: extend `packages/api-client/models/recently.ts` (which is where `EnrichmentImage`, `EnrichmentAttribute`, and `EnrichmentResult` already live) with `EnrichmentScreenshot` and `screenshot?: EnrichmentScreenshot` on `EnrichmentResult`. Yohaku imports re-export this through `apps/web/src/models/enrichment.ts` per existing convention.
+
+#### `WideOgMedia` — image-with-screenshot fallback
+
+`WideOgMedia.tsx:12` currently bails when `!image?.url`. Change to:
+
+- Accept an optional `fallbackScreenshot?: EnrichmentScreenshot`.
+- When `image?.url` is absent but `fallbackScreenshot` is present, render the screenshot as the media. The aspect ratio for screenshots is fixed 16:9; the existing portrait/ultra-wide clamping (`safeRatio` line 19) becomes a no-op for screenshots (already inside [1, 3]).
+- When both are absent, render nothing (existing behavior).
+- Blurhash comes from whichever source actually rendered.
+
+Both `FallbackCard` and `HoverLinkCard` already mount this atom — single change site.
+
+#### `FallbackCard` — pass screenshot as fallback
+
+`FallbackCard.tsx:76` — pass `fallbackScreenshot={data.screenshot}` alongside `image={data.image}`. Inline article cards still prefer the `og:image` (matches the design discussion's P1: inline = curated, hover = real).
+
+#### `HoverLinkCard` — screenshot wins when both exist
+
+`HoverLinkCard.tsx:29` — invert the priority. Render the screenshot when present; fall back to `og:image` otherwise. This realizes "hover shows the actual destination," the design point users responded to most strongly.
+
+```tsx
+<WideOgMedia
+  alt={data.image?.alt ?? data.title}
+  image={data.screenshot ? screenshotToImage(data.screenshot) : data.image}
+/>
+```
+
+A small helper `screenshotToImage(s): EnrichmentImage` shapes the screenshot into the existing `EnrichmentImage` shape so `WideOgMedia` does not need a separate code path. Defined locally in `HoverLinkCard.tsx`.
+
+#### `InkWash` — palette-tinted accent
+
+`InkWash.tsx` currently reads `--color-accent` (set inline by `FallbackCard` from `data.color`). Two changes:
+
+1. In `FallbackCard`, when `data.color` does not produce a valid `#RRGGBB`, fall back to `data.screenshot?.palette?.dominant` before giving up. The same `HEX_RE` check applies (palette values come server-side and are sanitized but front-end stays defensive).
+2. Apply the same fallback inside `HoverLinkCard` (currently no accent injection; the popover uses static colors). Adding the inline style here keeps the hover popover visually coherent with the page.
+
+No change to `InkWash` itself — it already reads the CSS variable; we just widen what feeds the variable.
+
+#### `dispatch.tsx`
+
+No change. P2 `ScreenshotCard` is explicitly out of scope.
+
+## Data Flow
+
+1. User visits a page with an inline link → `InlineLinkAnchor` mounts.
+2. On hover, `useInlineLinkEnrichment(href)` triggers React Query → calls `GET /enrichment/resolve?url=<href>`.
+3. Cache miss → `EnrichmentService.fetchAndPersist` → matches `open-graph` provider → `OpenGraphProvider.fetch` runs in `browser` mode.
+4. `BrowserFetchService.fetchPage` runs one agent-browser session, returns `{ html, screenshotBytes }`.
+5. Provider returns `EnrichmentResult`; raw screenshot bytes live in `BrowserFetchService`'s `WeakMap<EnrichmentResult, Buffer>` keyed off the result instance.
+6. `EnrichmentService` persists the row → reads back `id` → calls `browserFetch.takeScreenshotBytes(result)` → pipeline + storage → updates the row's `screenshot` JSON field.
+7. Response is returned to Yohaku. `HoverLinkCard` renders with the screenshot.
+8. On cache hit (subsequent visitors), `EnrichmentController.resolve` returns the cached row and fires `touchAccess` (throttled).
+
+## Error Handling
+
+| Failure | Behavior |
+|---|---|
+| agent-browser CLI missing | `browser-fetch.service.ts` already throws a clear instruction error. No new path. |
+| agent-browser timeout | Existing `AbortController.abort()` → SIGKILL; full enrichment fetch fails (status 500 to caller) — same as today. |
+| HTML returned, screenshot step failed | HTML path proceeds; `result.screenshot` absent. Card degrades to title-only or `og:image` if present. Logged at `debug`. |
+| Sharp processing fails | Same — log at `warn`, no `screenshot` field. |
+| S3 put fails | Same — log at `warn`, no `screenshot` field. The DB row already exists; we just do not add the screenshot fields. |
+| LRU eviction S3 delete returns 404 | Treated as success (object already gone). |
+| LRU eviction DB delete fails | Abort the eviction batch; do not proceed to put. The new screenshot is dropped; next request retries. Prevents quota overrun. |
+| `touchAccess` Redis miss / failure | Skip the access update. LRU may drift slightly toward marking active rows as stale; recoverable on next access. |
+| Frontend: `screenshot.url` 404 (S3 object evicted between row read and image load) | `<img>` falls back to error; consumer-side `onError` clears `screenshot` and `WideOgMedia` re-renders with the `og:image` path. The link card never breaks visually. |
+
+## Testing
+
+### Backend
+
+- `BrowserFetchService` unit tests: mock `execFile`; assert the batch arg array includes the new `screenshot` step in browser mode; assert tempfile cleanup.
+- `ScreenshotPipelineService` unit tests: feed a fixture PNG (`apps/core/test/fixtures/screenshot-*.png`), assert width/height clamp, palette extraction returns valid `#RRGGBB`, blurhash decodes back to a non-trivial canvas, retry-at-lower-quality path triggers when size > threshold, drop path triggers when retry still over.
+- `ScreenshotStorageService` unit tests: in-memory `S3Uploader` mock + a real PG test container (`pg-testcontainer.ts` already exists); cover insert, update-on-conflict, LRU eviction at item-cap, LRU eviction at byte-cap, mixed eviction (cap reached on items but bytes still under). Confirm S3 delete is invoked before DB delete.
+- `EnrichmentService.fetchAndPersist` integration test: fetchMode = 'browser' + capture stub returns bytes → row created → screenshot fields populated → subsequent `resolve` returns the screenshot.
+- Migration test: lives next to `20260506-enrichment-backfill.spec.ts`; verifies the new table exists, indexes are correct, FK cascade fires.
+
+### Frontend
+
+- `WideOgMedia.test.tsx` — add cases:
+  - `image` absent, `fallbackScreenshot` present → renders screenshot.
+  - both present → renders `image`.
+  - both absent → renders nothing.
+- `FallbackCard.test.tsx` — add cases:
+  - `data.color` invalid, `screenshot.palette.dominant` valid → `--color-accent` uses palette dominant.
+  - `og:image` present and `screenshot` present → renders `og:image` (inline preference).
+- `HoverLinkCard.test.tsx` — add cases:
+  - `og:image` present, `screenshot` present → renders screenshot (hover preference).
+  - `screenshot` absent, `og:image` present → renders `og:image`.
+- `InlineLinkAnchor` tests do not need changes (they assert popover lifecycle, not media).
+
+## Rollout
+
+1. Ship the migration + Drizzle schema + repository, with the screenshot pipeline behind `screenshot.enabled = false`. Verifies the table exists in prod without touching any user-visible behavior.
+2. Ship the `BrowserFetchService.fetchPage` extension + pipeline + storage service. Still behind the flag.
+3. Ship the `api-client` type extension and the `EnrichmentResult.screenshot` field plumbing in `EnrichmentService` (still no-op while flag is off).
+4. Ship the Yohaku consumer changes (`WideOgMedia`, `FallbackCard`, `HoverLinkCard`). Optional `screenshot` field; renders identically to today when undefined.
+5. Flip `screenshot.enabled = true` in admin config. Browse the site; watch new rows in `enrichment_screenshots`; confirm S3 bucket fills and LRU eviction kicks in once `maxItems` is exceeded (set a temporary low cap for the test cycle).
+
+Each step is independently revertable. Steps 1-4 are pure-additive code paths. Step 5 is a config flip.
+
+## Open Questions
+
+None blocking. Tracking for future iterations:
+
+- **Mobile-viewport second capture**: if real traffic shows wide gap between mobile/desktop layouts (e.g. publication sites that show full content only on desktop), capture both. Doubles storage cost; decide post-launch.
+- **`ScreenshotCard` variant** (the "P2" sketch): only if observed traffic shows a meaningful slice of cards with `screenshot` but no `description`/`site`. Premature without data.
+- **Refresh policy**: should TTL-expired enrichment refresh also re-capture the screenshot, or only re-fetch HTML? Default behavior: yes, re-capture (one path, same code). Cost: an extra screenshot write per refresh. Revisit if S3 traffic becomes a budget concern.

--- a/packages/api-client/models/recently.ts
+++ b/packages/api-client/models/recently.ts
@@ -49,7 +49,28 @@ export interface EnrichmentAttribute {
   format?: 'number' | 'rating' | 'date' | 'percent' | 'text' | 'duration'
 }
 
+export interface EnrichmentScreenshotPalette {
+  dominant: string
+  swatches?: string[]
+}
+
+export interface EnrichmentScreenshot {
+  url: string
+  width: number
+  height: number
+  blurhash?: string
+  palette?: EnrichmentScreenshotPalette
+}
+
 export interface EnrichmentResult {
+  /**
+   * Cache row Snowflake id (mx-core enrichment_cache.id). Server-populated on
+   * cache hits so frontends can address the underlying row (LRU touch,
+   * admin links). Absent when the result originates from a fresh provider
+   * fetch that has not yet persisted.
+   */
+  id?: string
+
   title: string
   description?: string
   image?: EnrichmentImage
@@ -61,6 +82,7 @@ export interface EnrichmentResult {
   attributes?: EnrichmentAttribute[]
   color?: string
   links?: Array<{ rel: string; url: string; label?: string }>
+  screenshot?: EnrichmentScreenshot
 }
 
 /**

--- a/packages/db-schema/src/schema/enrichment.ts
+++ b/packages/db-schema/src/schema/enrichment.ts
@@ -9,7 +9,7 @@ import {
   varchar,
 } from 'drizzle-orm/pg-core'
 
-import { createdAt, pkText } from './columns'
+import { createdAt, pkText, refText } from './columns'
 
 export const enrichmentCache = pgTable(
   'enrichment_cache',
@@ -39,5 +39,36 @@ export const enrichmentCache = pgTable(
       table.locale,
     ),
     index('enrichment_expires_at_idx').on(table.expiresAt),
+  ],
+)
+
+export interface EnrichmentScreenshotPalette {
+  dominant: string
+  swatches?: string[]
+}
+
+export const enrichmentScreenshots = pgTable(
+  'enrichment_screenshots',
+  {
+    enrichmentId: refText('enrichment_id')
+      .primaryKey()
+      .notNull()
+      .references(() => enrichmentCache.id, { onDelete: 'cascade' }),
+    objectKey: text('object_key').notNull(),
+    bytes: integer('bytes').notNull(),
+    width: integer('width').notNull(),
+    height: integer('height').notNull(),
+    blurhash: text('blurhash'),
+    palette: jsonb('palette').$type<EnrichmentScreenshotPalette>(),
+    createdAt: createdAt(),
+    lastAccessedAt: timestamp('last_accessed_at', {
+      withTimezone: true,
+      mode: 'date',
+    })
+      .notNull()
+      .defaultNow(),
+  },
+  (table) => [
+    index('enrichment_screenshots_lru_idx').on(table.lastAccessedAt.asc()),
   ],
 )


### PR DESCRIPTION
## Summary

Add page-screenshot capture for the OG enrichment provider, with a bounded headless-browser session pool that doubles as a concurrency cap and an SSRF guard on the browser path.

### Pipeline

- **Screenshot Pipeline Service** — sharp → webp re-encode + blurhash + 3-swatch palette + retry-on-byte-cap
- **Browser Fetch Service** — `agent-browser` CLI driver; HTML batch + optional viewport screenshot in the same named session
- **Screenshot Storage Service** — S3 PUT + LRU evict + Redis NX-EX throttle for `last_accessed_at` touches
- **Screenshot Repository** — `enrichment_screenshots` table (migration 0011) with FK CASCADE to `enrichment_cache.id`
- **OpenGraph Provider** — surfaces raw screenshot bytes to `EnrichmentService` via a WeakMap channel so persistence orders correctly (row id → screenshot row)

### Browser Session Pool (this revision)

- `BrowserSessionPool` — bounded, lazy `og-pool-0..N-1` named sessions, doubles as FIFO semaphore
- Default `maxSize=2`, `idleMs=60s` via env `AGENT_BROWSER_MAX_CONCURRENT` / `AGENT_BROWSER_IDLE_MS`
- `release({ discard: true })` tears down sessions whose last command failed
- `OnModuleDestroy` → `await shutdown()` ensures every chromium close is issued before Nest exits
- Cookies / localStorage persist across slot reuse — OG fetch sends no credentials, so leak surface is bounded; operators wanting stricter isolation set `MAX_CONCURRENT=1` + `IDLE_MS=0`

### SSRF Hardening

- Extracted `parseAndValidateUrl` + `assertHostnameSafe` into `url-guard.ts` (shared)
- Browser path now runs the same guard as the HTTP path BEFORE acquiring a slot — private IPs / loopback / `.internal` hosts can no longer reach chromium

### Config / Ops

- `openGraph.fetchMode` toggles `fetch` (default, HTTP) vs `browser` (chromium via agent-browser)
- `openGraph.screenshot.*` — `enabled`, `maxItems`, `maxTotalBytes`, `maxBytesPerImage`, `webpQuality`
- Dockerfile adds chromium + nss + cjk fonts + agent-browser; pinned via `AGENT_BROWSER_EXECUTABLE_PATH=/usr/bin/chromium-browser`

### Migration

`0011_enrichment_screenshots.sql` — new table; brand-new at deploy time so bare `CREATE INDEX` is allowed per migration-lint annotation.

### Docs

- `docs/superpowers/specs/2026-05-12-enrichment-screenshot-design.md`
- `docs/superpowers/specs/2026-05-11-knowledge-base-book-tree-design.md`
- `docs/superpowers/plans/2026-05-13-browser-fetch-session-pool.md`

### Tests

Comprehensive coverage across all new services, including:

- `browser-session-pool.spec.ts` — acquire / queue / discard / idle eviction / shutdown / abort (8 tests)
- `browser-fetch.service.spec.ts` — pool reuse, SSRF rejection, screenshot capture, timeout
- `open-graph-screenshot.integration.spec.ts` — end-to-end with per-harness pool
- `screenshot-storage.service.spec.ts` — eviction, retry, S3 errors swallowed
- `20260512-enrichment-screenshots.spec.ts` — migration behaviour

Total: 158 test files / 1014 tests passing locally.