### PR TITLE
feat(ai-translation): translate Lexical Poll node

### DIFF
--- a/apps/core/src/global/env.global.ts
+++ b/apps/core/src/global/env.global.ts
@@ -5,8 +5,12 @@ export const isMainCluster =
   Number.parseInt(process.env.NODE_APP_INSTANCE) === 0
 export const isMainProcess = cluster.isPrimary || isMainCluster
 
-export const isDev = __DEV__
+export const isDev =
+  typeof __DEV__ !== 'undefined'
+    ? __DEV__
+    : process.env.NODE_ENV === 'development'
 
-export const isTest = __TEST__
+export const isTest =
+  typeof __TEST__ !== 'undefined' ? __TEST__ : !!process.env.TEST
 export const isDebugMode = process.env.DEBUG_MODE === '1'
 export const cwd = process.cwd()

--- a/apps/core/src/modules/ai/ai-translation/lexical-translation-parser.ts
+++ b/apps/core/src/modules/ai/ai-translation/lexical-translation-parser.ts
@@ -95,6 +95,38 @@ function extractExcalidrawTexts(
   }
 }
 
+function extractPollSegments(
+  node: any,
+  propertySegments: PropertySegment[],
+  counter: { t: number; p: number },
+  ctx: BlockContext,
+): void {
+  if (typeof node.question === 'string' && node.question.trim()) {
+    propertySegments.push({
+      id: `p_${counter.p++}`,
+      text: node.question,
+      node,
+      property: 'question',
+      blockId: ctx.blockId,
+      rootIndex: ctx.rootIndex,
+    })
+  }
+  if (Array.isArray(node.options)) {
+    for (const option of node.options) {
+      if (typeof option.label === 'string' && option.label.trim()) {
+        propertySegments.push({
+          id: `p_${counter.p++}`,
+          text: option.label,
+          node: option,
+          property: 'label',
+          blockId: ctx.blockId,
+          rootIndex: ctx.rootIndex,
+        })
+      }
+    }
+  }
+}
+
 function walkNode(
   node: any,
   segments: TranslationSegment[],
@@ -108,6 +140,11 @@ function walkNode(
   // Handle excalidraw: extract text from shapes within snapshot
   if (node.type === LEXICAL_CONTEXT_EXCALIDRAW_TYPE) {
     extractExcalidrawTexts(node, propertySegments, counter, ctx)
+    return
+  }
+
+  if (node.type === 'poll') {
+    extractPollSegments(node, propertySegments, counter, ctx)
     return
   }
 

--- a/apps/core/test/src/modules/ai/lexical-translation-parser.spec.ts
+++ b/apps/core/test/src/modules/ai/lexical-translation-parser.spec.ts
@@ -1067,6 +1067,170 @@ describe('lexical-translation-parser', () => {
     })
   })
 
+  describe('poll node translation', () => {
+    const pollNode = (payload: {
+      pollId?: string
+      question?: string
+      options?: Array<{ id: string; label: string }>
+      mode?: 'single' | 'multiple'
+      closeAt?: string
+      showResults?: string
+    }) => ({
+      type: 'poll',
+      version: 1,
+      pollId: payload.pollId ?? 'poll-1',
+      question: payload.question ?? '',
+      options: payload.options ?? [],
+      mode: payload.mode ?? 'single',
+      ...(payload.closeAt !== undefined && { closeAt: payload.closeAt }),
+      ...(payload.showResults !== undefined && {
+        showResults: payload.showResults,
+      }),
+    })
+
+    it('parses poll node → question + option label segments, no text segments', () => {
+      const json = makeEditorState([
+        {
+          ...pollNode({
+            question: 'Favourite colour?',
+            options: [
+              { id: 'opt-1', label: 'Red' },
+              { id: 'opt-2', label: 'Blue' },
+              { id: 'opt-3', label: 'Green' },
+            ],
+          }),
+          $: { blockId: 'poll-block' },
+        },
+      ])
+      const { segments, propertySegments } = parseLexicalForTranslation(json)
+
+      expect(segments).toHaveLength(0)
+      expect(propertySegments).toHaveLength(4)
+
+      const [q, o1, o2, o3] = propertySegments
+      expect(q.text).toBe('Favourite colour?')
+      expect(q.property).toBe('question')
+      expect(q.key).toBeUndefined()
+      expect(q.blockId).toBe('poll-block')
+      expect(q.rootIndex).toBe(0)
+
+      expect(o1.text).toBe('Red')
+      expect(o1.property).toBe('label')
+      expect(o1.key).toBeUndefined()
+      expect(o1.blockId).toBe('poll-block')
+      expect(o1.rootIndex).toBe(0)
+
+      expect(o2.text).toBe('Blue')
+      expect(o2.key).toBeUndefined()
+      expect(o3.text).toBe('Green')
+      expect(o3.key).toBeUndefined()
+    })
+
+    it('round-trip: translated question and labels, metadata preserved', () => {
+      const json = makeEditorState([
+        pollNode({
+          pollId: 'p42',
+          question: 'What is your OS?',
+          options: [
+            { id: 'a', label: 'Linux' },
+            { id: 'b', label: 'macOS' },
+          ],
+          mode: 'single',
+          closeAt: '2026-12-31',
+          showResults: 'always',
+        }),
+      ])
+
+      const result = parseLexicalForTranslation(json)
+      const { propertySegments } = result
+      expect(propertySegments).toHaveLength(3)
+
+      const translations = new Map<string, string>([
+        [propertySegments[0].id, '你的操作系统是？'],
+        [propertySegments[1].id, 'Linux（不变）'],
+        [propertySegments[2].id, 'macOS（不变）'],
+      ])
+
+      const restored = JSON.parse(
+        restoreLexicalTranslation(result, translations),
+      )
+      const poll = restored.root.children[0]
+
+      expect(poll.question).toBe('你的操作系统是？')
+      expect(poll.options[0].label).toBe('Linux（不变）')
+      expect(poll.options[1].label).toBe('macOS（不变）')
+
+      expect(poll.pollId).toBe('p42')
+      expect(poll.options[0].id).toBe('a')
+      expect(poll.options[1].id).toBe('b')
+      expect(poll.mode).toBe('single')
+      expect(poll.closeAt).toBe('2026-12-31')
+      expect(poll.showResults).toBe('always')
+      expect(poll.type).toBe('poll')
+    })
+
+    it('empty option.label is skipped, option object retained in restored state', () => {
+      const json = makeEditorState([
+        pollNode({
+          question: 'Pick one',
+          options: [
+            { id: 'x', label: 'Valid' },
+            { id: 'y', label: '' },
+            { id: 'z', label: '   ' },
+          ],
+        }),
+      ])
+
+      const result = parseLexicalForTranslation(json)
+      expect(result.propertySegments).toHaveLength(2)
+      expect(result.propertySegments[0].text).toBe('Pick one')
+      expect(result.propertySegments[1].text).toBe('Valid')
+
+      const translations = new Map<string, string>([
+        [result.propertySegments[0].id, '选一个'],
+        [result.propertySegments[1].id, '有效'],
+      ])
+      const restored = JSON.parse(
+        restoreLexicalTranslation(result, translations),
+      )
+      const poll = restored.root.children[0]
+
+      expect(poll.options).toHaveLength(3)
+      expect(poll.options[0].label).toBe('有效')
+      expect(poll.options[1].label).toBe('')
+      expect(poll.options[2].label).toBe('   ')
+    })
+
+    it('poll inside details nested editor state is parsed', () => {
+      const nestedPoll = pollNode({
+        question: 'Nested question',
+        options: [
+          { id: 'n1', label: 'Option A' },
+          { id: 'n2', label: 'Option B' },
+        ],
+      })
+      const json = makeEditorState([detailsNode('See poll', nestedPoll)])
+
+      const { segments, propertySegments } = parseLexicalForTranslation(json)
+      expect(segments).toHaveLength(0)
+
+      const pollSegs = propertySegments.filter(
+        (p) => p.property === 'question' || p.property === 'label',
+      )
+      const summarySegs = propertySegments.filter(
+        (p) => p.property === 'summary',
+      )
+
+      expect(summarySegs).toHaveLength(1)
+      expect(summarySegs[0].text).toBe('See poll')
+
+      expect(pollSegs).toHaveLength(3)
+      expect(pollSegs[0].text).toBe('Nested question')
+      expect(pollSegs[1].text).toBe('Option A')
+      expect(pollSegs[2].text).toBe('Option B')
+    })
+  })
+
   describe('excalidraw text extraction', () => {
     const excalidrawNode = (store: Record<string, any>) => ({
       type: 'excalidraw',

--- a/docs/superpowers/specs/2026-05-12-lexical-poll-translation-design.md
+++ b/docs/superpowers/specs/2026-05-12-lexical-poll-translation-design.md
@@ -1,0 +1,188 @@
+# Lexical Poll Node Translation — Design
+
+**Date:** 2026-05-12
+**Owner:** Innei
+**Status:** Draft
+
+## Problem
+
+The AI translation pipeline walks the Lexical editor state via
+`apps/core/src/modules/ai/ai-translation/lexical-translation-parser.ts` and
+emits two segment kinds:
+
+- `TranslationSegment` for inline `text` leaves.
+- `PropertySegment` for whitelisted node-level string fields (currently
+  `details.summary`, `footnote-section.definitions[key]`, `ruby.reading`),
+  surfaced through `extractLexicalTranslatableProperties` in
+  `apps/core/src/utils/lexical-translatable-property.util.ts`.
+
+The Poll node (`type: 'poll'`, defined in
+`haklex/packages/rich-ext-poll/src/nodes/PollNode.ts`) carries two
+translatable surfaces:
+
+- `question: string`
+- `options: Array<{ id: string; label: string }>` (size >= 2)
+
+Neither surface is text-typed and Poll is not in the property whitelist, so
+the parser passes through Poll silently and AI translation never touches
+either field. Translated posts therefore render the poll in its source
+language while the surrounding prose is localised.
+
+## Goals
+
+1. Translate `poll.question` and every `poll.options[i].label` end-to-end
+   (parse → request to LLM → restore).
+2. Preserve all non-translatable Poll metadata verbatim across the round
+   trip: `pollId`, `options[i].id`, `mode`, `closeAt`, `showResults`,
+   `version`, `type`.
+3. Keep the change additive — existing Lexical translation behaviour for all
+   other node types is unchanged.
+
+## Non-Goals
+
+- Translating poll vote results, tallies, or any runtime poll state. The
+  PollNode `decorate()` output is computed at render time from the data
+  adapter; translation only mutates the serialised authoring data
+  (`question`, `options[].label`).
+- Splitting `question` / `option.label` into multiple inline runs. They are
+  flat strings and remain flat strings post-translation.
+- Adding Poll support to the property whitelist
+  (`extractLexicalTranslatableProperties`). See "Why not the whitelist"
+  below.
+
+## Approach
+
+Add a parser-level special case for `node.type === 'poll'`, modelled on the
+existing Excalidraw branch (`LEXICAL_CONTEXT_EXCALIDRAW_TYPE`) that already
+emits multiple `PropertySegment`s against different `node` references from a
+single source node.
+
+### Parser changes
+
+In `lexical-translation-parser.ts`:
+
+1. Add a helper `extractPollSegments(node, propertySegments, counter, ctx)`:
+   - If `typeof node.question === 'string' && node.question.trim()`, push:
+     ```ts
+     { id: `p_${counter.p++}`, text: node.question, node, property: 'question',
+       blockId: ctx.blockId, rootIndex: ctx.rootIndex }
+     ```
+   - If `Array.isArray(node.options)`, iterate each `option`. When
+     `typeof option.label === 'string' && option.label.trim()`, push:
+     ```ts
+     { id: `p_${counter.p++}`, text: option.label, node: option, property: 'label',
+       blockId: ctx.blockId, rootIndex: ctx.rootIndex }
+     ```
+     The `node` reference points at the option object so the existing
+     restore path (`prop.node[prop.property] = translated`) writes back to
+     `option.label` directly.
+2. In `walkNode`, insert the Poll branch immediately after the Excalidraw
+   branch and before the skip-block / skip-inline checks:
+   ```ts
+   if (node.type === 'poll') {
+     extractPollSegments(node, propertySegments, counter, ctx)
+     return
+   }
+   ```
+   Poll is a `DecoratorNode` with no `children`, so `return` after extraction
+   matches its actual shape and avoids descending into `options` via
+   `scanNestedEditorStates` (which would otherwise inspect every non-known
+   property and reject `options` as not a nested editor state — harmless,
+   but the explicit return makes intent clear).
+
+### Restore path
+
+No changes. `restoreLexicalTranslation` already handles `PropertySegment`
+via:
+
+```ts
+if (prop.key !== undefined) {
+  prop.node[prop.property][prop.key] = translated
+} else {
+  prop.node[prop.property] = translated
+}
+```
+
+Since the Poll segments are emitted with `key === undefined` and `node`
+pointing at either the poll node (for `question`) or the specific option
+object (for `label`), the existing string path produces the correct
+mutation. The option object reference survives because the parser does not
+clone the editor state — `parseLexicalForTranslation` calls `JSON.parse`
+once and all downstream `node` references point into that single object
+tree, which is then re-stringified by `restoreLexicalTranslation`.
+
+### Why not the whitelist
+
+The whitelist in `extractLexicalTranslatableProperties` assumes one source
+field per node maps to one (string) or many (record) translatable values
+written back as `node[property]` or `node[property][key]`. Poll requires:
+
+- Two source fields per node (`question` + `options`).
+- `options` is an array of objects, where the translatable text lives at
+  `options[i].label` and the stable identity key lives at `options[i].id`.
+
+Extending the whitelist abstraction to cover this shape (a new `valueShape`,
+plus restore-side branching that finds the option by id and writes its
+`label`) buys nothing over a small parser-level branch and complicates the
+util's invariants. Excalidraw already establishes the precedent for
+parser-level node-specific extraction when the data shape does not fit the
+generic whitelist.
+
+## Edge Cases
+
+- **Empty `question`**: skip — same convention as other whitelist entries.
+- **Empty `option.label`**: skip per-item, still process other options.
+- **Missing `options` or non-array `options`**: skip the options pass; still
+  attempt `question`.
+- **Option without a stable `id`**: irrelevant for restore (we mutate the
+  object reference, not look it up by id), but the option will still appear
+  in the data flow. No special handling.
+- **Duplicate `option.label` values**: each produces its own segment with a
+  unique `p_N` id, so translations are independent.
+- **Poll inside a nested editor state** (e.g. inside `details.content`):
+  works automatically because `walkNode` is invoked recursively from
+  `scanNestedEditorStates` with a fresh block context.
+- **Poll with code-formatted text**: not applicable — `question` and
+  `label` are plain strings, not formatted text runs.
+
+## Testing
+
+Add cases to `apps/core/test/src/modules/ai/lexical-translation-parser.spec.ts`:
+
+1. `parseLexicalForTranslation` on an editor state containing a single Poll
+   node produces:
+   - One property segment for `question`.
+   - N property segments for the N non-empty option labels.
+   - Zero text segments.
+   - Correct `blockId` / `rootIndex` propagation.
+2. `restoreLexicalTranslation` round-trip:
+   - Given a translations map keyed by the emitted segment ids,
+     re-serialise the editor state.
+   - Re-parse and assert `question`, every `options[i].label`, and unrelated
+     fields (`pollId`, `options[i].id`, `mode`, `closeAt`, `showResults`)
+     match expectations.
+3. Empty `option.label` is skipped (no segment emitted) but the option
+   object remains in the restored state.
+4. Poll nested inside a `details` block (nested editor state) is still
+   parsed.
+
+No new test file required.
+
+## Risk and Rollout
+
+- **Blast radius:** `lexical-translation-parser.ts` only. No schema, API, or
+  database changes. No migration. No effect on non-Poll content.
+- **Backward compatibility:** Posts authored before this change continue to
+  serialise identically. Existing translations of non-Poll content are
+  untouched.
+- **Rollout:** Ship in a single PR. No feature flag — translation runs
+  asynchronously per post and re-translation is already a supported path,
+  so existing posts with Poll nodes will pick up translated `question` /
+  `options[].label` on their next translation cycle.
+
+## Out of Scope / Future Work
+
+- If a future node introduces a similar "array of objects with translatable
+  string field" shape (e.g. a quiz block), consider lifting Poll's parser
+  branch into a small registry that maps `node.type` to a custom extractor.
+  Premature for one node type today.


### PR DESCRIPTION
## Summary

- Adds AI translation for Lexical Poll nodes (`type: 'poll'`): the `question` and every non-empty `option.label` are now extracted as `PropertySegment`s by the translation parser, translated, and written back in place. All non-translatable metadata (`pollId`, `options[i].id`, `mode`, `closeAt`, `showResults`, `type`, `version`) is preserved verbatim.
- Implementation mirrors the existing Excalidraw special-case in `walkNode`: extract before the skip-block checks and emit segments with the appropriate `node` ref (the option object itself for labels) so the existing string-path restore writes back to `option.label` directly. No changes to `restoreLexicalTranslation` or the property-whitelist util.
- Includes a build fix (`fix(build): guard __DEV__/__TEST__ macros for non-vite contexts`) — the vite define macros added in 1783b797 are not substituted in vitest's globalSetup (which runs outside vite), causing `ReferenceError: __DEV__ is not defined` and breaking the entire test suite. Guards added so the module works in both contexts.

## Spec

`docs/superpowers/specs/2026-05-12-lexical-poll-translation-design.md`

## Test plan

- [x] `pnpm -C apps/core exec vitest run test/src/modules/ai/lexical-translation-parser.spec.ts` — all 54 cases pass, including 4 new poll cases (parse, round-trip restore, empty-label skip, nested in details)
- [x] `pnpm -C apps/core exec eslint --max-warnings 0` clean on all changed files
- [ ] Translate a real post containing a poll end-to-end and verify the rendered translated post shows translated question + option labels