### PR TITLE
feat(enrichment): harden Open Graph browser mode against anti-bot pages

### DIFF
--- a/apps/core/src/modules/enrichment/enrichment.service.ts
+++ b/apps/core/src/modules/enrichment/enrichment.service.ts
@@ -13,7 +13,11 @@ import { scheduleManager } from '~/utils/schedule.util'
 
 import { EnrichmentRepository } from './enrichment.repository'
 import type { EnrichmentResult, ProviderMeta } from './enrichment.types'
-import { ProviderDisabledError, TokenMissingError } from './enrichment.types'
+import {
+  ChallengeBlockedError,
+  ProviderDisabledError,
+  TokenMissingError,
+} from './enrichment.types'
 import { BrowserFetchService } from './providers/open-graph/browser-fetch.service'
 import { ScreenshotPipelineService } from './providers/open-graph/screenshot-pipeline.service'
 import { ScreenshotStorageService } from './providers/open-graph/screenshot-storage.service'
@@ -99,7 +103,13 @@ export class EnrichmentService implements OnModuleInit {
         } catch (error) {
           // Record per-row failure so backoff kicks in on subsequent SWR
           // resolves; re-throw so the task queue marks the task failed.
-          this.logger.warn(
+          // Challenge pages are expected anti-bot signals, not infra faults —
+          // log at info to keep on-call dashboards clean.
+          const logFn =
+            error instanceof ChallengeBlockedError
+              ? this.logger.log.bind(this.logger)
+              : this.logger.warn.bind(this.logger)
+          logFn(
             `Enrichment refresh task failed for ${payload.provider}:${payload.externalId} (locale=${locale || '∅'}): ${error.message}`,
           )
           try {
@@ -203,7 +213,11 @@ export class EnrichmentService implements OnModuleInit {
       await this.setToRedis(url, cacheLocale, result)
       return { result }
     } catch (error) {
-      this.logger.warn(
+      const logFn =
+        error instanceof ChallengeBlockedError
+          ? this.logger.log.bind(this.logger)
+          : this.logger.warn.bind(this.logger)
+      logFn(
         `Provider ${provider.name} fetch failed for ${match.id} (locale=${cacheLocale || '∅'}): ${error.message}`,
       )
       throw error

--- a/apps/core/src/modules/enrichment/enrichment.types.ts
+++ b/apps/core/src/modules/enrichment/enrichment.types.ts
@@ -127,3 +127,14 @@ export class ProviderDisabledError extends Error {
     this.name = 'ProviderDisabledError'
   }
 }
+
+export class ChallengeBlockedError extends Error {
+  readonly code = 'challenge_blocked' as const
+  constructor(
+    public readonly url: string,
+    public readonly signature: string,
+  ) {
+    super(`challenge page detected for ${url} (signature: "${signature}")`)
+    this.name = 'ChallengeBlockedError'
+  }
+}

--- a/apps/core/src/modules/enrichment/providers/open-graph/browser-fetch.service.ts
+++ b/apps/core/src/modules/enrichment/providers/open-graph/browser-fetch.service.ts
@@ -6,8 +6,20 @@ import { promisify } from 'node:util'
 
 import { Injectable, Logger } from '@nestjs/common'
 
-import type { EnrichmentResult } from '../../enrichment.types'
+import {
+  ChallengeBlockedError,
+  type EnrichmentResult,
+} from '../../enrichment.types'
 import { BrowserSessionPool, type PoolSlot } from './browser-session-pool'
+import {
+  OG_ACCEPT_LANGUAGE,
+  OG_CHALLENGE_RETRY_MAX,
+  OG_CHALLENGE_SIGNATURES,
+  OG_HTML_SCAN_HEAD_BYTES,
+  OG_LAUNCH_ARGS,
+  OG_NETWORKIDLE_MS,
+  OG_USER_AGENT,
+} from './og-browser-constants'
 import type { SafeFetchOptions, SafeFetchResult } from './safe-fetch'
 import {
   assertHostnameSafe,
@@ -19,10 +31,6 @@ const execFileAsync = promisify(execFile)
 
 const DEFAULT_EXECUTABLE = process.env.AGENT_BROWSER_BIN || 'agent-browser'
 
-// agent-browser writes jpeg/png natively (no webp). Downstream sharp re-encodes
-// to webp at the configured `webpQuality` (default 75), so this only needs to
-// be "high enough to survive the round-trip cleanly". 90 leaves enough detail
-// that the sharp pass can still aggressively reduce size.
 const SCREENSHOT_CLI_QUALITY = 90
 const SCREENSHOT_CLI_FORMAT = 'jpeg' as const
 const SCREENSHOT_CLI_EXT = '.jpeg'
@@ -35,6 +43,12 @@ interface FetchPageResult {
   screenshotBytes?: Buffer
 }
 
+interface NavigationPayload {
+  href: string
+  html: string
+  title: string
+}
+
 type CaptureScreenshotDecision =
   | boolean
   | ((html: SafeFetchResult) => boolean | Promise<boolean>)
@@ -44,36 +58,18 @@ type BrowserFetchOptions = SafeFetchOptions & {
   captureScreenshot?: CaptureScreenshotDecision
 }
 
-/**
- * Headless-browser fetcher backed by the agent-browser CLI. Used as the
- * "browser" fetchMode for the Open Graph provider when sites (Cloudflare,
- * Akamai, JS-rendered SPAs) refuse a plain HTTP request.
- *
- * The CLI is invoked via batch mode in a named session so:
- *   1. session state is isolated per request (no cookie bleed across URLs);
- *   2. failures clean up the session even if the batch midway crashes;
- *   3. we can plumb a hard timeout via AbortController -> SIGKILL.
- *
- * Body is captured by evaluating `document.documentElement.outerHTML` after
- * page load, then truncated to `maxBodyBytes` so we match safeFetch's
- * post-conditions and feed the existing parseOpenGraph pipeline unchanged.
- *
- * `fetchPage` extends that with an optional viewport screenshot, captured in
- * the SAME named session (no second navigation). The screenshot step is run
- * as a separate `agent-browser` invocation against the same `--session` after
- * the HTML batch returns successfully, so a failure to write/read the webp
- * file cannot mask HTML success or short-circuit the HTML path.
- */
+const PAGE_SCRIPT = [
+  '(() => { try { return JSON.stringify({ href: window.location.href, ',
+  'html: document.documentElement.outerHTML, ',
+  'title: document.title || "" }) } catch (_e) { ',
+  'return JSON.stringify({ href: window.location.href, html: "", title: "" }) } })()',
+].join('')
+const PAGE_B64 = Buffer.from(PAGE_SCRIPT, 'utf8').toString('base64')
+
 @Injectable()
 export class BrowserFetchService {
   private readonly logger = new Logger(BrowserFetchService.name)
 
-  // Request-scoped channel for raw screenshot bytes. `OpenGraphProvider`
-  // attaches via `attachScreenshotBytes(result, buf)` keyed off the result
-  // instance it is about to return; `EnrichmentService` reads via
-  // `takeScreenshotBytes(result)` after persisting the row (it needs the row
-  // id before it can write the screenshot row). The WeakMap auto-clears
-  // when the result object is garbage-collected, so there is no manual TTL.
   private readonly bytesByResult = new WeakMap<EnrichmentResult, Buffer>()
 
   constructor(private readonly pool: BrowserSessionPool) {}
@@ -113,55 +109,53 @@ export class BrowserFetchService {
 
     const slot: PoolSlot = await this.pool.acquire()
     const executable = opts.executable || DEFAULT_EXECUTABLE
-    const evalScript =
-      '(() => { try { return window.location.href } catch (_e) { return "" } })()'
-    const finalUrlB64 = Buffer.from(evalScript, 'utf8').toString('base64')
-    const pageScript = [
-      '(() => { try { return JSON.stringify({ href: window.location.href, ',
-      'html: document.documentElement.outerHTML }) } catch (_e) { ',
-      'return JSON.stringify({ href: window.location.href, html: "" }) } })()',
-    ].join('')
-    const pageB64 = Buffer.from(pageScript, 'utf8').toString('base64')
 
-    // Shared wall budget. Navigation + HTML extraction consume part of it;
-    // the screenshot step (if any) gets the remainder, so the total time stays
-    // inside `opts.timeoutMs`.
     const started = Date.now()
     const ac = new AbortController()
     const timer = setTimeout(() => ac.abort(), opts.timeoutMs)
+
     let html: SafeFetchResult
     try {
-      const { stdout } = await execFileAsync(
+      let payload = await this.runNavigationBatch(
         executable,
-        [
-          '--session',
-          slot.name,
-          'batch',
-          '--bail',
-          '--json',
-          `open ${url.toString()}`,
-          'wait 1500',
-          `eval -b ${finalUrlB64}`,
-        ],
-        {
-          signal: ac.signal,
-          maxBuffer: Math.max(opts.maxBodyBytes * 2, 4_194_304),
-          windowsHide: true,
-          env: process.env,
-        },
+        slot,
+        url,
+        ac,
+        opts,
       )
       this.pool.markLive(slot)
-      await this.assertBrowserFinalUrlSafe(extractStringFromBatchOutput(stdout))
+      let safeUrl = await this.assertBrowserFinalUrlSafe(payload.href)
 
-      const page = await this.extractPage(executable, slot.name, pageB64, {
-        signal: ac.signal,
-        maxBodyBytes: opts.maxBodyBytes,
-      })
-      const pageFinalUrl = await this.assertBrowserFinalUrlSafe(page.href)
-      const truncated = page.html.length > opts.maxBodyBytes
-      const body = truncated ? page.html.slice(0, opts.maxBodyBytes) : page.html
+      const statusFailure = await this.fetchDocumentStatus(
+        executable,
+        slot,
+        url,
+        ac,
+      )
+      if (statusFailure) {
+        throw new Error(
+          `agent-browser navigation returned HTTP ${statusFailure.status} for ${statusFailure.url}`,
+        )
+      }
+
+      let signature = this.detectChallenge(payload.html, payload.title)
+      let retries = 0
+      while (signature && retries < OG_CHALLENGE_RETRY_MAX) {
+        retries += 1
+        payload = await this.reloadAndExtract(executable, slot, ac, opts)
+        safeUrl = await this.assertBrowserFinalUrlSafe(payload.href)
+        signature = this.detectChallenge(payload.html, payload.title)
+      }
+      if (signature) {
+        throw new ChallengeBlockedError(url.toString(), signature)
+      }
+
+      const truncated = payload.html.length > opts.maxBodyBytes
+      const body = truncated
+        ? payload.html.slice(0, opts.maxBodyBytes)
+        : payload.html
       html = {
-        finalUrl: pageFinalUrl.toString(),
+        finalUrl: safeUrl.toString(),
         contentType: 'text/html',
         body,
         truncated,
@@ -169,20 +163,31 @@ export class BrowserFetchService {
     } catch (error) {
       const err = error as NodeJS.ErrnoException & { stderr?: string }
       if (ac.signal.aborted) {
-        // Timeout: pool keeps the slot — idle eviction will discard it
-        // later if chromium is wedged.
         this.pool.release(slot)
         throw new Error(
           `agent-browser timed out after ${opts.timeoutMs}ms for ${url.toString()}`,
           { cause: error },
         )
       }
-      // Non-timeout: discard the slot so a wedged chromium does not poison
-      // the next caller.
-      this.pool.release(slot, { discard: true })
-      if (error instanceof UnsafeUrlError) {
+      if (
+        error instanceof UnsafeUrlError ||
+        error instanceof ChallengeBlockedError
+      ) {
+        this.pool.release(slot)
         throw error
       }
+      // Surface HTTP-status throw from fetchDocumentStatus without discarding
+      // the slot — chromium is still healthy.
+      if (
+        err instanceof Error &&
+        err.message.startsWith('agent-browser navigation returned HTTP')
+      ) {
+        this.pool.release(slot)
+        throw err
+      }
+      // Non-timeout CLI failure: discard the slot so a wedged chromium does
+      // not poison the next caller.
+      this.pool.release(slot, { discard: true })
       if (err.code === 'ENOENT') {
         throw new Error(
           `agent-browser executable not found at "${executable}". Install it or set thirdPartyServiceIntegration.openGraph.fetchMode = "fetch".`,
@@ -197,10 +202,6 @@ export class BrowserFetchService {
       clearTimeout(timer)
     }
 
-    // Screenshot step. Runs as a SECOND `agent-browser` invocation against
-    // the same named session so a failure cannot mask HTML success. We swallow
-    // all errors here and only log at `debug`.
-    // Reached only on try-block success — `slot` still held, chromium live.
     let screenshotBytes: Buffer | undefined
     let shouldCapture: boolean
     if (typeof captureScreenshot === 'function') {
@@ -216,13 +217,10 @@ export class BrowserFetchService {
       shouldCapture = captureScreenshot
     }
     if (shouldCapture) {
-      // Floor at 500ms so a near-exhausted budget still gives the CLI a
-      // realistic shot rather than passing 0 (AbortController fires
-      // immediately on a zero timer in some Node versions).
       const remaining = Math.max(500, opts.timeoutMs - (Date.now() - started))
       screenshotBytes = await this.captureScreenshot(
         executable,
-        slot.name,
+        slot,
         remaining,
       ).catch((screenshotErr) => {
         this.logger.debug(
@@ -236,39 +234,142 @@ export class BrowserFetchService {
     return { html, screenshotBytes }
   }
 
-  private async extractPage(
+  private buildBaseArgs(slot: PoolSlot): string[] {
+    return [
+      '--session',
+      slot.name,
+      '--user-agent',
+      OG_USER_AGENT,
+      '--headers',
+      JSON.stringify({ 'Accept-Language': OG_ACCEPT_LANGUAGE }),
+      '--args',
+      OG_LAUNCH_ARGS,
+    ]
+  }
+
+  private async runNavigationBatch(
     executable: string,
-    sessionName: string,
-    pageB64: string,
-    opts: { signal: AbortSignal; maxBodyBytes: number },
-  ): Promise<{ href: string; html: string }> {
+    slot: PoolSlot,
+    url: URL,
+    ac: AbortController,
+    opts: SafeFetchOptions,
+  ): Promise<NavigationPayload> {
     const { stdout } = await execFileAsync(
       executable,
       [
-        '--session',
-        sessionName,
+        ...this.buildBaseArgs(slot),
         'batch',
         '--bail',
         '--json',
-        `eval -b ${pageB64}`,
+        `open ${url.toString()}`,
+        `wait --load networkidle --timeout ${OG_NETWORKIDLE_MS}`,
+        `eval -b ${PAGE_B64}`,
       ],
       {
-        signal: opts.signal,
+        signal: ac.signal,
         maxBuffer: Math.max(opts.maxBodyBytes * 2, 4_194_304),
         windowsHide: true,
         env: process.env,
       },
     )
-    const raw = extractStringFromBatchOutput(stdout)
+    return parseNavigationPayload(extractStringFromBatchOutput(stdout))
+  }
+
+  private async reloadAndExtract(
+    executable: string,
+    slot: PoolSlot,
+    ac: AbortController,
+    opts: SafeFetchOptions,
+  ): Promise<NavigationPayload> {
+    const { stdout } = await execFileAsync(
+      executable,
+      [
+        ...this.buildBaseArgs(slot),
+        'batch',
+        '--bail',
+        '--json',
+        'reload',
+        `wait --load networkidle --timeout ${OG_NETWORKIDLE_MS}`,
+        `eval -b ${PAGE_B64}`,
+      ],
+      {
+        signal: ac.signal,
+        maxBuffer: Math.max(opts.maxBodyBytes * 2, 4_194_304),
+        windowsHide: true,
+        env: process.env,
+      },
+    )
+    return parseNavigationPayload(extractStringFromBatchOutput(stdout))
+  }
+
+  private async fetchDocumentStatus(
+    executable: string,
+    slot: PoolSlot,
+    url: URL,
+    ac: AbortController,
+  ): Promise<{ status: number; url: string } | null> {
+    const hostGlob = `${url.protocol}//${url.hostname}/**`
+    let stdout: string
     try {
-      const parsed = JSON.parse(raw) as { href?: unknown; html?: unknown }
-      return {
-        href: typeof parsed.href === 'string' ? parsed.href : '',
-        html: typeof parsed.html === 'string' ? parsed.html : '',
-      }
-    } catch {
-      return { href: '', html: raw }
+      const res = await execFileAsync(
+        executable,
+        [
+          ...this.buildBaseArgs(slot),
+          'network',
+          'requests',
+          '--filter',
+          hostGlob,
+          '--type',
+          'document',
+          '--status',
+          '400-599',
+          '--json',
+        ],
+        {
+          signal: ac.signal,
+          maxBuffer: 1_048_576,
+          windowsHide: true,
+          env: process.env,
+        },
+      )
+      stdout = res.stdout
+    } catch (error) {
+      // `network requests` is a diagnostic side channel — if the CLI does not
+      // implement the filter shape we expect, swallow and let the main flow
+      // proceed. The challenge detector covers the most common bad-page case.
+      this.logger.debug(
+        `network requests inspection failed for ${url.toString()}: ${(error as Error).message}`,
+      )
+      return null
     }
+    const trimmed = stdout.trim()
+    if (!trimmed) return null
+    let parsed: unknown
+    try {
+      parsed = JSON.parse(trimmed)
+    } catch {
+      return null
+    }
+    if (!Array.isArray(parsed) || parsed.length === 0) return null
+    // Last entry is the final navigation after any redirect chain.
+    const last = parsed.at(-1) as
+      | { status?: unknown; url?: unknown }
+      | undefined
+    const status = typeof last?.status === 'number' ? last.status : NaN
+    const reqUrl = typeof last?.url === 'string' ? last.url : url.toString()
+    if (!Number.isFinite(status) || status < 400) return null
+    return { status, url: reqUrl }
+  }
+
+  private detectChallenge(html: string, title: string): string | null {
+    const headHtml = html.slice(0, OG_HTML_SCAN_HEAD_BYTES).toLowerCase()
+    const lowerTitle = title.toLowerCase()
+    for (const signature of OG_CHALLENGE_SIGNATURES) {
+      if (lowerTitle.includes(signature) || headHtml.includes(signature)) {
+        return signature
+      }
+    }
+    return null
   }
 
   private async assertBrowserFinalUrlSafe(rawUrl: string): Promise<URL> {
@@ -279,7 +380,7 @@ export class BrowserFetchService {
 
   private async captureScreenshot(
     executable: string,
-    sessionName: string,
+    slot: PoolSlot,
     timeoutMs: number,
   ): Promise<Buffer | undefined> {
     const dir = await mkdtemp(join(tmpdir(), 'mx-og-screenshot-'))
@@ -287,16 +388,10 @@ export class BrowserFetchService {
       const ac = new AbortController()
       const timer = setTimeout(() => ac.abort(), timeoutMs)
       try {
-        // agent-browser 0.26.0's `batch` sub-command parser does not recognize
-        // the screenshot-specific flags (e.g. `--screenshot-format`) — it
-        // treats them as positional [selector] tokens and the command fails
-        // with "Element not found". Run viewport + screenshot as two
-        // standalone invocations against the same `--session` instead.
         await execFileAsync(
           executable,
           [
-            '--session',
-            sessionName,
+            ...this.buildBaseArgs(slot),
             'set',
             'viewport',
             String(SCREENSHOT_VIEWPORT_WIDTH),
@@ -312,8 +407,7 @@ export class BrowserFetchService {
         await execFileAsync(
           executable,
           [
-            '--session',
-            sessionName,
+            ...this.buildBaseArgs(slot),
             'screenshot',
             '--screenshot-format',
             SCREENSHOT_CLI_FORMAT,
@@ -333,10 +427,6 @@ export class BrowserFetchService {
         clearTimeout(timer)
       }
 
-      // CLI filename is not stable across versions, so discover the output
-      // instead of hard-coding. Strict: expect exactly one matching file; zero
-      // or many is treated as failure so a CLI behavior shift surfaces here
-      // rather than silently picking one.
       const entries = await readdir(dir)
       const matches = entries.filter(
         (name) =>
@@ -351,7 +441,6 @@ export class BrowserFetchService {
       }
       return await readFile(join(dir, matches[0]))
     } finally {
-      // Best-effort tempdir cleanup. Failure is non-fatal.
       try {
         await rm(dir, { recursive: true, force: true })
       } catch {
@@ -361,12 +450,23 @@ export class BrowserFetchService {
   }
 }
 
-/**
- * agent-browser 0.26 `batch --json` prints a JSON array — one entry per
- * sub-command. The last entry corresponds to our `eval`; the evaluated string
- * is nested at `entry.result.result` (the outer `result` wraps the command
- * envelope, the inner is the eval return value).
- */
+function parseNavigationPayload(raw: string): NavigationPayload {
+  try {
+    const parsed = JSON.parse(raw) as {
+      href?: unknown
+      html?: unknown
+      title?: unknown
+    }
+    return {
+      href: typeof parsed.href === 'string' ? parsed.href : '',
+      html: typeof parsed.html === 'string' ? parsed.html : '',
+      title: typeof parsed.title === 'string' ? parsed.title : '',
+    }
+  } catch {
+    return { href: '', html: raw, title: '' }
+  }
+}
+
 function extractStringFromBatchOutput(stdout: string): string {
   const trimmed = stdout.trim()
   if (!trimmed) return ''

--- a/apps/core/src/modules/enrichment/providers/open-graph/og-browser-constants.ts
+++ b/apps/core/src/modules/enrichment/providers/open-graph/og-browser-constants.ts
@@ -1,0 +1,20 @@
+export const OG_USER_AGENT =
+  'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 ' +
+  '(KHTML, like Gecko) Chrome/138.0.0.0 Safari/537.36'
+
+export const OG_ACCEPT_LANGUAGE = 'zh-CN,zh;q=0.9,en-US;q=0.8,en;q=0.7'
+
+export const OG_LAUNCH_ARGS = '--disable-blink-features=AutomationControlled'
+
+export const OG_CHALLENGE_SIGNATURES = [
+  'just a moment',
+  'attention required',
+  'access denied',
+  'verify you are human',
+  '403 forbidden',
+  'pardon our interruption',
+] as const
+
+export const OG_CHALLENGE_RETRY_MAX = 1
+export const OG_NETWORKIDLE_MS = 10_000
+export const OG_HTML_SCAN_HEAD_BYTES = 8 * 1024

--- a/apps/core/test/src/modules/enrichment/browser-fetch.service.spec.ts
+++ b/apps/core/test/src/modules/enrichment/browser-fetch.service.spec.ts
@@ -4,10 +4,11 @@ import { join } from 'node:path'
 
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
-import type { EnrichmentResult } from '~/modules/enrichment/enrichment.types'
+import {
+  ChallengeBlockedError,
+  type EnrichmentResult,
+} from '~/modules/enrichment/enrichment.types'
 
-// Hoisted so the vi.mock factory below can see the same mock instance the
-// test bodies reach via `execFileMock`.
 const { execFileMock } = vi.hoisted(() => ({
   execFileMock: vi.fn(),
 }))
@@ -23,13 +24,6 @@ vi.mock('node:child_process', async () => {
   }
 })
 
-// SSRF guard's `assertHostnameSafe` runs a real DNS lookup against the URL
-// hostname. The CI / dev machine may resolve `example.com` through a captive
-// portal or CGNAT-style 198.18.x address, which `isPrivateIp` correctly
-// rejects. We mock the DNS module to a stable public IP so the guard accepts
-// the hostnames used by these tests, and so we don't hit network in unit
-// tests. The `file://` protocol test goes through the protocol check, which
-// runs before DNS, so the mock does not need to special-case it.
 vi.mock('node:dns/promises', async () => {
   const actual =
     await vi.importActual<typeof import('node:dns/promises')>(
@@ -41,13 +35,12 @@ vi.mock('node:dns/promises', async () => {
   }
 })
 
-// Import service AFTER the vi.mock setup so `promisify(execFile)` resolves to
-// the mocked execFile. The mocked fn lacks `util.promisify.custom`, so
-// `promisify` wraps it via the standard last-callback contract.
 const { BrowserFetchService } =
   await import('~/modules/enrichment/providers/open-graph/browser-fetch.service')
 const { BrowserSessionPool } =
   await import('~/modules/enrichment/providers/open-graph/browser-session-pool')
+const { OG_ACCEPT_LANGUAGE, OG_LAUNCH_ARGS, OG_NETWORKIDLE_MS, OG_USER_AGENT } =
+  await import('~/modules/enrichment/providers/open-graph/og-browser-constants')
 
 interface ExecFileCall {
   args: string[]
@@ -87,56 +80,98 @@ function setExecFileBehavior(
   })
 }
 
-function parseBatchArgs(args: string[]): {
+interface ParsedCall {
   sessionName: string
   command: string
   subCommands: string[]
   screenshotDir?: string
   flagValue: (flag: string) => string | undefined
-} {
-  // [--session, <name>, <command>, ...rest]
-  const sessionName = args[1]
-  const command = args[2]
-  const rest = args.slice(3)
+}
+
+function parseBatchArgs(args: string[]): ParsedCall {
+  const sessionIdx = args.indexOf('--session')
+  const sessionName = sessionIdx === -1 ? '' : args[sessionIdx + 1]
+  let command = ''
+  for (const a of args) {
+    if (
+      a === 'batch' ||
+      a === 'set' ||
+      a === 'screenshot' ||
+      a === 'network' ||
+      a === 'close' ||
+      a === 'eval'
+    ) {
+      command = a
+      break
+    }
+  }
+  const cmdIdx = command ? args.indexOf(command) : -1
+  const rest = cmdIdx === -1 ? [] : args.slice(cmdIdx + 1)
   const subCommands: string[] = []
-  let screenshotDir: string | undefined
-  for (let i = 0; i < rest.length; i++) {
-    const a = rest[i]
+  for (const a of rest) {
     if (a.startsWith('--')) continue
     subCommands.push(a)
-    const match = /--screenshot-dir\s+(\S+)/.exec(a)
-    if (match) screenshotDir = match[1]
   }
   const flagValue = (flag: string): string | undefined => {
-    const idx = rest.indexOf(flag)
-    if (idx === -1 || idx + 1 >= rest.length) return undefined
-    return rest[idx + 1]
+    const idx = args.indexOf(flag)
+    if (idx === -1 || idx + 1 >= args.length) return undefined
+    return args[idx + 1]
   }
-  if (!screenshotDir) screenshotDir = flagValue('--screenshot-dir')
+  const screenshotDir = flagValue('--screenshot-dir')
   return { sessionName, command, subCommands, screenshotDir, flagValue }
 }
 
-function batchValue(value: string, origin = value): string {
+function navBatchValue(href: string, html: string, title = ''): string {
   return JSON.stringify([
-    { command: ['open', origin], result: { url: origin }, success: true },
-    { command: ['wait', '1500'], result: { ms: 1500 }, success: true },
+    { command: ['open', href], result: { url: href }, success: true },
+    {
+      command: ['wait', '--load', 'networkidle'],
+      result: {},
+      success: true,
+    },
     {
       command: ['eval', '-b', '...'],
-      result: { origin, result: value },
+      result: {
+        origin: href,
+        result: JSON.stringify({ href, html, title }),
+      },
       success: true,
     },
   ])
 }
 
-function pageValue(html: string, href = 'https://example.com/'): string {
-  return batchValue(JSON.stringify({ href, html }), href)
+function reloadBatchValue(href: string, html: string, title = ''): string {
+  return JSON.stringify([
+    { command: ['reload'], result: {}, success: true },
+    {
+      command: ['wait', '--load', 'networkidle'],
+      result: {},
+      success: true,
+    },
+    {
+      command: ['eval', '-b', '...'],
+      result: {
+        origin: href,
+        result: JSON.stringify({ href, html, title }),
+      },
+      success: true,
+    },
+  ])
 }
 
-function isNavigationBatch(parsed: ReturnType<typeof parseBatchArgs>): boolean {
+function isNavigationBatch(parsed: ParsedCall): boolean {
   return (
     parsed.command === 'batch' &&
     parsed.subCommands.some((c) => c.startsWith('open '))
   )
+}
+
+function isReloadBatch(parsed: ParsedCall): boolean {
+  return parsed.command === 'batch' && parsed.subCommands.includes('reload')
+}
+
+function isNetworkRequests(parsed: ParsedCall): boolean {
+  return parsed.command === 'network'
 }
 
 function buildService() {
@@ -160,13 +195,16 @@ describe('BrowserFetchService', () => {
       setExecFileBehavior((call) => {
         calls.push(call)
         const parsed = parseBatchArgs(call.args)
-        if (parsed.command === 'batch') {
-          return isNavigationBatch(parsed)
-            ? { stdout: batchValue('https://example.com/') }
-            : {
-                stdout: pageValue('<html><head><title>x</title></head></html>'),
-              }
+        if (isNavigationBatch(parsed)) {
+          return {
+            stdout: navBatchValue(
+              'https://example.com/',
+              '<html><head><title>x</title></head></html>',
+              'x',
+            ),
+          }
         }
+        if (isNetworkRequests(parsed)) return { stdout: '[]' }
         return { stdout: '' }
       })
 
@@ -183,32 +221,62 @@ describe('BrowserFetchService', () => {
       const batches = calls.filter(
         (c) => parseBatchArgs(c.args).command === 'batch',
       )
-      expect(batches).toHaveLength(2)
+      expect(batches).toHaveLength(1)
       expect(parseBatchArgs(batches[0].args).sessionName).toMatch(
         /^og-pool-\d+$/,
       )
       expect(
-        batches.some((c) =>
-          parseBatchArgs(c.args).subCommands.some((cmd) =>
-            cmd.startsWith('open '),
-          ),
-        ),
-      ).toBe(true)
-      expect(
-        batches.every((c) =>
-          parseBatchArgs(c.args).subCommands.some((cmd) =>
-            cmd.startsWith('eval '),
-          ),
-        ),
-      )
-      // No screenshot step in fetchHtml.
-      expect(
-        batches.some((c) =>
+        calls.some((c) =>
           parseBatchArgs(c.args).subCommands.some((cmd) =>
             cmd.startsWith('screenshot'),
           ),
         ),
       ).toBe(false)
+
+      await pool.shutdown()
+    })
+
+    it('injects UA, Accept-Language, and stealth args on every command', async () => {
+      const calls: ExecFileCall[] = []
+      setExecFileBehavior((call) => {
+        calls.push(call)
+        const parsed = parseBatchArgs(call.args)
+        if (isNavigationBatch(parsed)) {
+          return { stdout: navBatchValue('https://example.com/', '<html/>') }
+        }
+        if (isNetworkRequests(parsed)) return { stdout: '[]' }
+        if (parsed.command === 'close') return { stdout: '' }
+        return { stdout: '' }
+      })
+
+      const { pool, service } = buildService()
+      await service.fetchHtml('https://example.com', {
+        timeoutMs: 5_000,
+        maxBodyBytes: 1024,
+        executable: '/usr/local/bin/agent-browser-fake',
+      })
+
+      const navCall = calls.find((c) =>
+        isNavigationBatch(parseBatchArgs(c.args)),
+      )!
+      expect(navCall.args).toContain('--user-agent')
+      expect(navCall.args[navCall.args.indexOf('--user-agent') + 1]).toBe(
+        OG_USER_AGENT,
+      )
+      expect(navCall.args).toContain('--headers')
+      const headers = JSON.parse(
+        navCall.args[navCall.args.indexOf('--headers') + 1],
+      )
+      expect(headers['Accept-Language']).toBe(OG_ACCEPT_LANGUAGE)
+      expect(navCall.args).toContain('--args')
+      expect(navCall.args[navCall.args.indexOf('--args') + 1]).toBe(
+        OG_LAUNCH_ARGS,
+      )
+      const navBatchCommands = parseBatchArgs(navCall.args).subCommands
+      const waitSub = navBatchCommands.find((c) => c.startsWith('wait '))
+      expect(waitSub).toBe(
+        `wait --load networkidle --timeout ${OG_NETWORKIDLE_MS}`,
+      )
 
       await pool.shutdown()
     })
@@ -221,11 +289,15 @@ describe('BrowserFetchService', () => {
 
       setExecFileBehavior(async (call) => {
         const parsed = parseBatchArgs(call.args)
-        if (parsed.command === 'batch') {
-          return isNavigationBatch(parsed)
-            ? { stdout: batchValue('https://example.com/') }
-            : { stdout: pageValue('<html><body>ok</body></html>') }
+        if (isNavigationBatch(parsed)) {
+          return {
+            stdout: navBatchValue(
+              'https://example.com/',
+              '<html><body>ok</body></html>',
+            ),
+          }
         }
+        if (isNetworkRequests(parsed)) return { stdout: '[]' }
         if (parsed.command === 'screenshot') {
           const dir = parsed.screenshotDir!
           seenScreenshotDirs.push(dir)
@@ -246,22 +318,25 @@ describe('BrowserFetchService', () => {
       expect(res.screenshotBytes).toBeInstanceOf(Buffer)
       expect(res.screenshotBytes!.equals(fakeJpeg)).toBe(true)
 
-      // Tempdir cleanup: it must have been removed after the call.
       expect(seenScreenshotDirs).toHaveLength(1)
       expect(existsSync(seenScreenshotDirs[0])).toBe(false)
 
       await pool.shutdown()
     })
 
-    it('returns html with screenshotBytes undefined when screenshot step errors (and cleans tempdir)', async () => {
+    it('returns html with screenshotBytes undefined when screenshot step errors', async () => {
       const seenScreenshotDirs: string[] = []
       setExecFileBehavior((call) => {
         const parsed = parseBatchArgs(call.args)
-        if (parsed.command === 'batch') {
-          return isNavigationBatch(parsed)
-            ? { stdout: batchValue('https://example.com/') }
-            : { stdout: pageValue('<html><body>still ok</body></html>') }
+        if (isNavigationBatch(parsed)) {
+          return {
+            stdout: navBatchValue(
+              'https://example.com/',
+              '<html><body>still ok</body></html>',
+            ),
+          }
         }
+        if (isNetworkRequests(parsed)) return { stdout: '[]' }
         if (parsed.command === 'screenshot') {
           if (parsed.screenshotDir)
             seenScreenshotDirs.push(parsed.screenshotDir)
@@ -290,11 +365,15 @@ describe('BrowserFetchService', () => {
     it('returns screenshotBytes undefined when no image file is written', async () => {
       setExecFileBehavior((call) => {
         const parsed = parseBatchArgs(call.args)
-        if (parsed.command === 'batch') {
-          return isNavigationBatch(parsed)
-            ? { stdout: batchValue('https://example.com/') }
-            : { stdout: pageValue('<html><body>only html</body></html>') }
+        if (isNavigationBatch(parsed)) {
+          return {
+            stdout: navBatchValue(
+              'https://example.com/',
+              '<html><body>only html</body></html>',
+            ),
+          }
         }
+        if (isNetworkRequests(parsed)) return { stdout: '[]' }
         if (parsed.command === 'screenshot') return { stdout: '' }
         return { stdout: '' }
       })
@@ -317,11 +396,10 @@ describe('BrowserFetchService', () => {
       setExecFileBehavior(async (call) => {
         const parsed = parseBatchArgs(call.args)
         seenCommands.push({ command: parsed.command, args: call.args })
-        if (parsed.command === 'batch') {
-          return isNavigationBatch(parsed)
-            ? { stdout: batchValue('https://example.com/') }
-            : { stdout: pageValue('<html></html>') }
+        if (isNavigationBatch(parsed)) {
+          return { stdout: navBatchValue('https://example.com/', '<html/>') }
         }
+        if (isNetworkRequests(parsed)) return { stdout: '[]' }
         if (parsed.command === 'screenshot') {
           const dir = parsed.screenshotDir!
           await writeFile(join(dir, 'shot.jpeg'), Buffer.from([0xff, 0xd8]))
@@ -339,7 +417,9 @@ describe('BrowserFetchService', () => {
 
       const setCall = seenCommands.find((c) => c.command === 'set')
       expect(setCall).toBeDefined()
-      expect(setCall!.args.slice(2)).toEqual(['set', 'viewport', '1280', '720'])
+      const setArgs = setCall!.args
+      const setIdx = setArgs.indexOf('set')
+      expect(setArgs.slice(setIdx)).toEqual(['set', 'viewport', '1280', '720'])
 
       const shotCall = seenCommands.find((c) => c.command === 'screenshot')
       expect(shotCall).toBeDefined()
@@ -359,16 +439,15 @@ describe('BrowserFetchService', () => {
       const finalUrl = 'https://redirected.example/path?q=1'
       setExecFileBehavior((call) => {
         const parsed = parseBatchArgs(call.args)
-        if (parsed.command === 'batch') {
-          return isNavigationBatch(parsed)
-            ? { stdout: batchValue(finalUrl) }
-            : {
-                stdout: pageValue(
-                  '<html><body>redirected</body></html>',
-                  finalUrl,
-                ),
-              }
+        if (isNavigationBatch(parsed)) {
+          return {
+            stdout: navBatchValue(
+              finalUrl,
+              '<html><body>redirected</body></html>',
+            ),
+          }
         }
+        if (isNetworkRequests(parsed)) return { stdout: '[]' }
         if (parsed.command === 'screenshot') return { stdout: '' }
         return { stdout: '' }
       })
@@ -391,16 +470,15 @@ describe('BrowserFetchService', () => {
       setExecFileBehavior((call) => {
         const parsed = parseBatchArgs(call.args)
         seenCommands.push(parsed.command)
-        if (parsed.command === 'batch') {
-          return isNavigationBatch(parsed)
-            ? { stdout: batchValue('file:///etc/passwd') }
-            : {
-                stdout: pageValue(
-                  '<html>should not read</html>',
-                  'file:///etc/passwd',
-                ),
-              }
+        if (isNavigationBatch(parsed)) {
+          return {
+            stdout: navBatchValue(
+              'file:///etc/passwd',
+              '<html>should not read</html>',
+            ),
+          }
         }
+        if (isNetworkRequests(parsed)) return { stdout: '[]' }
         return { stdout: '' }
       })
 
@@ -413,9 +491,6 @@ describe('BrowserFetchService', () => {
         }),
       ).rejects.toThrow(/Disallowed protocol/)
 
-      expect(
-        seenCommands.filter((command) => command === 'batch'),
-      ).toHaveLength(1)
       expect(seenCommands).not.toContain('screenshot')
       await pool.shutdown()
     })
@@ -425,11 +500,15 @@ describe('BrowserFetchService', () => {
       setExecFileBehavior((call) => {
         const parsed = parseBatchArgs(call.args)
         seenCommands.push(parsed.command)
-        if (parsed.command === 'batch') {
-          return isNavigationBatch(parsed)
-            ? { stdout: batchValue('https://example.com/') }
-            : { stdout: pageValue('<html><body>metadata only</body></html>') }
+        if (isNavigationBatch(parsed)) {
+          return {
+            stdout: navBatchValue(
+              'https://example.com/',
+              '<html><body>metadata only</body></html>',
+            ),
+          }
         }
+        if (isNetworkRequests(parsed)) return { stdout: '[]' }
         return { stdout: '' }
       })
 
@@ -443,7 +522,254 @@ describe('BrowserFetchService', () => {
 
       expect(res.html.body).toContain('metadata only')
       expect(res.screenshotBytes).toBeUndefined()
-      expect(seenCommands).toEqual(['batch', 'batch'])
+      expect(seenCommands.filter((c) => c === 'screenshot')).toHaveLength(0)
+      expect(seenCommands.filter((c) => c === 'set')).toHaveLength(0)
+      await pool.shutdown()
+    })
+  })
+
+  describe('HTTP status throws', () => {
+    it('throws when document request returns 403', async () => {
+      setExecFileBehavior((call) => {
+        const parsed = parseBatchArgs(call.args)
+        if (isNavigationBatch(parsed)) {
+          return {
+            stdout: navBatchValue(
+              'https://example.com/',
+              '<html><body>blocked</body></html>',
+            ),
+          }
+        }
+        if (isNetworkRequests(parsed)) {
+          return {
+            stdout: JSON.stringify([
+              {
+                status: 403,
+                url: 'https://example.com/',
+                method: 'GET',
+                type: 'document',
+              },
+            ]),
+          }
+        }
+        return { stdout: '' }
+      })
+
+      const { pool, service } = buildService()
+      await expect(
+        service.fetchHtml('https://example.com', {
+          timeoutMs: 5_000,
+          maxBodyBytes: 1024,
+          executable: '/usr/local/bin/agent-browser-fake',
+        }),
+      ).rejects.toThrow(/returned HTTP 403/)
+      await pool.shutdown()
+    })
+
+    it('throws with the LAST redirect-chain status when multiple rows present', async () => {
+      setExecFileBehavior((call) => {
+        const parsed = parseBatchArgs(call.args)
+        if (isNavigationBatch(parsed)) {
+          return {
+            stdout: navBatchValue('https://example.com/final', '<html/>'),
+          }
+        }
+        if (isNetworkRequests(parsed)) {
+          return {
+            stdout: JSON.stringify([
+              { status: 302, url: 'https://example.com/', type: 'document' },
+              {
+                status: 500,
+                url: 'https://example.com/final',
+                type: 'document',
+              },
+            ]),
+          }
+        }
+        return { stdout: '' }
+      })
+
+      const { pool, service } = buildService()
+      await expect(
+        service.fetchHtml('https://example.com', {
+          timeoutMs: 5_000,
+          maxBodyBytes: 1024,
+          executable: '/usr/local/bin/agent-browser-fake',
+        }),
+      ).rejects.toThrow(/returned HTTP 500 for https:\/\/example\.com\/final/)
+      await pool.shutdown()
+    })
+
+    it('passes through when network requests output is empty array', async () => {
+      setExecFileBehavior((call) => {
+        const parsed = parseBatchArgs(call.args)
+        if (isNavigationBatch(parsed)) {
+          return {
+            stdout: navBatchValue(
+              'https://example.com/',
+              '<html><body>ok</body></html>',
+            ),
+          }
+        }
+        if (isNetworkRequests(parsed)) return { stdout: '[]' }
+        return { stdout: '' }
+      })
+
+      const { pool, service } = buildService()
+      const html = await service.fetchHtml('https://example.com', {
+        timeoutMs: 5_000,
+        maxBodyBytes: 1024,
+        executable: '/usr/local/bin/agent-browser-fake',
+      })
+      expect(html.body).toContain('ok')
+      await pool.shutdown()
+    })
+
+    it('passes through when network requests call itself errors', async () => {
+      setExecFileBehavior((call) => {
+        const parsed = parseBatchArgs(call.args)
+        if (isNavigationBatch(parsed)) {
+          return {
+            stdout: navBatchValue(
+              'https://example.com/',
+              '<html><body>ok</body></html>',
+            ),
+          }
+        }
+        if (isNetworkRequests(parsed)) {
+          return {
+            error: new Error('cli unknown flag') as NodeJS.ErrnoException,
+          }
+        }
+        return { stdout: '' }
+      })
+
+      const { pool, service } = buildService()
+      const html = await service.fetchHtml('https://example.com', {
+        timeoutMs: 5_000,
+        maxBodyBytes: 1024,
+        executable: '/usr/local/bin/agent-browser-fake',
+      })
+      expect(html.body).toContain('ok')
+      await pool.shutdown()
+    })
+  })
+
+  describe('challenge detection + retry', () => {
+    it('retries once via reload and returns clean payload', async () => {
+      let navCount = 0
+      let reloadCount = 0
+      setExecFileBehavior((call) => {
+        const parsed = parseBatchArgs(call.args)
+        if (isNavigationBatch(parsed)) {
+          navCount += 1
+          return {
+            stdout: navBatchValue(
+              'https://example.com/',
+              '<html><head><title>Just a moment...</title></head></html>',
+              'Just a moment...',
+            ),
+          }
+        }
+        if (isReloadBatch(parsed)) {
+          reloadCount += 1
+          return {
+            stdout: reloadBatchValue(
+              'https://example.com/',
+              '<html><body>real content</body></html>',
+              'Real Site',
+            ),
+          }
+        }
+        if (isNetworkRequests(parsed)) return { stdout: '[]' }
+        return { stdout: '' }
+      })
+
+      const { pool, service } = buildService()
+      const html = await service.fetchHtml('https://example.com', {
+        timeoutMs: 5_000,
+        maxBodyBytes: 1024,
+        executable: '/usr/local/bin/agent-browser-fake',
+      })
+      expect(navCount).toBe(1)
+      expect(reloadCount).toBe(1)
+      expect(html.body).toContain('real content')
+      await pool.shutdown()
+    })
+
+    it('throws ChallengeBlockedError when retry still hits the signature', async () => {
+      setExecFileBehavior((call) => {
+        const parsed = parseBatchArgs(call.args)
+        const challengeHtml =
+          '<html><head><title>Just a moment...</title></head></html>'
+        if (isNavigationBatch(parsed)) {
+          return {
+            stdout: navBatchValue(
+              'https://example.com/',
+              challengeHtml,
+              'Just a moment...',
+            ),
+          }
+        }
+        if (isReloadBatch(parsed)) {
+          return {
+            stdout: reloadBatchValue(
+              'https://example.com/',
+              challengeHtml,
+              'Just a moment...',
+            ),
+          }
+        }
+        if (isNetworkRequests(parsed)) return { stdout: '[]' }
+        return { stdout: '' }
+      })
+
+      const { pool, service } = buildService()
+      await expect(
+        service.fetchHtml('https://example.com', {
+          timeoutMs: 5_000,
+          maxBodyBytes: 1024,
+          executable: '/usr/local/bin/agent-browser-fake',
+        }),
+      ).rejects.toBeInstanceOf(ChallengeBlockedError)
+      await pool.shutdown()
+    })
+
+    it('detects challenge from body when title is clean', async () => {
+      let reloadFired = false
+      setExecFileBehavior((call) => {
+        const parsed = parseBatchArgs(call.args)
+        if (isNavigationBatch(parsed)) {
+          return {
+            stdout: navBatchValue(
+              'https://example.com/',
+              '<html><body><h1>Access Denied</h1></body></html>',
+              'normal title',
+            ),
+          }
+        }
+        if (isReloadBatch(parsed)) {
+          reloadFired = true
+          return {
+            stdout: reloadBatchValue(
+              'https://example.com/',
+              '<html><body>ok</body></html>',
+              'ok',
+            ),
+          }
+        }
+        if (isNetworkRequests(parsed)) return { stdout: '[]' }
+        return { stdout: '' }
+      })
+
+      const { pool, service } = buildService()
+      const html = await service.fetchHtml('https://example.com', {
+        timeoutMs: 5_000,
+        maxBodyBytes: 1024,
+        executable: '/usr/local/bin/agent-browser-fake',
+      })
+      expect(reloadFired).toBe(true)
+      expect(html.body).toContain('<body>ok')
       await pool.shutdown()
     })
   })
@@ -477,9 +803,6 @@ describe('BrowserFetchService', () => {
 
   describe('timeout path', () => {
     it('aborts the HTML batch and throws a timeout error', async () => {
-      // Simulate the CLI never returning within the timeout. We invoke the
-      // callback only after the AbortController has aborted, with an
-      // ECONNABORTED-ish error so the service sees `ac.signal.aborted = true`.
       execFileMock.mockImplementation((...invocationArgs: unknown[]) => {
         const args = invocationArgs[1] as string[]
         const options = invocationArgs[2] as { signal?: AbortSignal }
@@ -487,10 +810,6 @@ describe('BrowserFetchService', () => {
           err: NodeJS.ErrnoException | null,
           result?: { stdout: string; stderr: string },
         ) => void
-        // pool.shutdown issues `--session <name> close` against the slot once
-        // the timeout path runs through `release` (no discard). That call has
-        // no AbortSignal, so we resolve it synchronously instead of leaving
-        // the test hanging on a never-resolving promise.
         if (args.includes('close')) {
           queueMicrotask(() => callback(null, { stdout: '', stderr: '' }))
           return undefined
@@ -516,48 +835,8 @@ describe('BrowserFetchService', () => {
     })
   })
 
-  describe('tempdir cleanup edge case', () => {
-    it('removes the screenshot tempdir it created after a successful run', async () => {
-      // Race-safe: snapshot exactly the tempdir the service mkdtemp'd via
-      // the CLI's --screenshot-dir argument, then assert it is gone after
-      // the call. We don't enumerate sibling entries in os.tmpdir(), so
-      // parallel test files don't perturb the assertion.
-      const seenScreenshotDirs: string[] = []
-      setExecFileBehavior(async (call) => {
-        const parsed = parseBatchArgs(call.args)
-        if (parsed.command === 'batch') {
-          return isNavigationBatch(parsed)
-            ? { stdout: batchValue('https://example.com/') }
-            : { stdout: pageValue('<html/>') }
-        }
-        if (parsed.command === 'screenshot') {
-          const dir = parsed.screenshotDir!
-          seenScreenshotDirs.push(dir)
-          await writeFile(join(dir, 'c.jpeg'), Buffer.from([0xff, 0xd8]))
-          return { stdout: '' }
-        }
-        return { stdout: '' }
-      })
-
-      const { pool, service } = buildService()
-      await service.fetchPage('https://example.com', {
-        timeoutMs: 5_000,
-        maxBodyBytes: 4_000_000,
-        executable: '/usr/local/bin/agent-browser-fake',
-      })
-
-      expect(seenScreenshotDirs).toHaveLength(1)
-      expect(existsSync(seenScreenshotDirs[0])).toBe(false)
-
-      await pool.shutdown()
-    })
-  })
-
   describe('SSRF guard + pool reuse', () => {
     it('rejects file:// URLs before invoking chromium', async () => {
-      // In test/dev mode (__DEV__=true) `parseAndValidateUrl` skips the
-      // hostname/IP block-list but still rejects unsupported protocols, so we
-      // exercise the protocol guard rather than the localhost block-list.
       const pool = new BrowserSessionPool({ maxSize: 1, idleMs: 60_000 })
       const service = new BrowserFetchService(pool)
       await expect(
@@ -575,12 +854,13 @@ describe('BrowserFetchService', () => {
       const service = new BrowserFetchService(pool)
       setExecFileBehavior((call) => {
         const parsed = parseBatchArgs(call.args)
-        if (parsed.command !== 'batch') return { stdout: '' }
-        const open = parsed.subCommands.find((c) => c.startsWith('open '))
-        const href = open ? open.slice('open '.length) : 'https://example.com/'
-        return isNavigationBatch(parsed)
-          ? { stdout: batchValue(href) }
-          : { stdout: pageValue('<html></html>', href) }
+        if (isNavigationBatch(parsed)) {
+          const openSub = parsed.subCommands.find((c) => c.startsWith('open '))!
+          const href = openSub.slice('open '.length)
+          return { stdout: navBatchValue(href, '<html/>') }
+        }
+        if (isNetworkRequests(parsed)) return { stdout: '[]' }
+        return { stdout: '' }
       })
       await service.fetchHtml('https://example.com/a', {
         timeoutMs: 5_000,
@@ -590,16 +870,20 @@ describe('BrowserFetchService', () => {
         timeoutMs: 5_000,
         maxBodyBytes: 1024,
       })
-      const openCalls = execFileMock.mock.calls.filter((call) => {
+      const navCalls = execFileMock.mock.calls.filter((call) => {
         const args = call[1] as string[]
         return (
           args.includes('batch') &&
           args.some((a: string) => a.startsWith('open '))
         )
       })
-      expect(openCalls.length).toBe(2)
+      expect(navCalls.length).toBe(2)
       const sessionNames = new Set(
-        openCalls.map((call) => (call[1] as string[])[1]),
+        navCalls.map((call) => {
+          const a = call[1] as string[]
+          const idx = a.indexOf('--session')
+          return a[idx + 1]
+        }),
       )
       expect(sessionNames.size).toBe(1)
       await pool.shutdown()

--- a/docs/superpowers/specs/2026-05-15-og-browser-hardening-design.md
+++ b/docs/superpowers/specs/2026-05-15-og-browser-hardening-design.md
@@ -1,0 +1,313 @@
+# Open Graph Browser-Mode Hardening
+
+**Status:** Draft
+**Date:** 2026-05-15
+**Owner:** Innei
+**Related:** `docs/superpowers/specs/2026-05-12-enrichment-screenshot-design.md`
+
+## Problem
+
+The Open Graph enrichment provider supports a `browser` fetch mode backed by the
+`agent-browser` CLI. In production it still hits HTTP 403 and Cloudflare/Akamai
+challenge pages with measurable frequency, polluting the enrichment cache with
+"Just a moment" / "Access denied" HTML and capturing the challenge view as a
+screenshot.
+
+Five concrete failure modes drive this:
+
+1. **Headless fingerprint exposed.** Default agent-browser launch leaves
+   `navigator.webdriver === true` and other Chromium automation tells. Bot
+   gates fire immediately.
+2. **No UA or Accept-Language override.** Default Chromium UA on Linux + no
+   `Accept-Language` is a strong "non-human" signal.
+3. **Wait is too short.** `wait 1500` (1.5 s) never gives a Cloudflare JS
+   challenge time to complete; the page DOM at extraction is the challenge,
+   not the real site.
+4. **HTTP status is invisible.** `agent-browser open` does not throw on 4xx /
+   5xx; the service receives the challenge body as if it were normal HTML and
+   caches it.
+5. **Challenge HTML masquerades as success.** Even when status is 200 (CF
+   serves its JS-challenge under 200 + `cf-mitigated` header), the body is a
+   challenge, not the target page, so OG parsing returns garbage and the
+   screenshot pipeline captures the challenge view.
+
+## Goals
+
+- Fail fast and cleanly when a target returns HTTP 4xx/5xx — no challenge body
+  enters the cache.
+- Detect Cloudflare/Akamai/Imperva challenge pages by signature and retry once
+  before giving up.
+- Reduce the rate of cold-start refusals by serving a realistic UA, a
+  reasonable `Accept-Language`, and one chromium flag that removes the most
+  obvious automation tell.
+- Stay within the existing 25 s wall budget for browser-mode fetches — no new
+  config keys.
+
+## Non-Goals
+
+- A full stealth fingerprint suite (`puppeteer-extra-plugin-stealth` parity).
+  Out of scope for this iteration. We do exactly one chromium arg:
+  `--disable-blink-features=AutomationControlled`.
+- Host-level backoff / circuit breaking. The existing per-row
+  `recordFailure` + SWR backoff is sufficient for now.
+- Admin UI / settings surface for UA, Accept-Language, retry budget. All
+  hardcoded constants.
+- HTTP-mode (`fetchMode: 'fetch'`) hardening. Stays on `safeFetch` unchanged.
+- Upstream agent-browser changes. We constrain ourselves to capabilities
+  already shipped in 0.26.
+
+## Design
+
+### Constants
+
+New file `apps/core/src/modules/enrichment/providers/open-graph/og-browser-constants.ts`:
+
+```ts
+// Real Chrome 138 (Linux x86_64) — kept in step with the chromium ship by
+// agent-browser when its skill ref bumps.
+export const OG_USER_AGENT =
+  'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 ' +
+  '(KHTML, like Gecko) Chrome/138.0.0.0 Safari/537.36'
+
+export const OG_ACCEPT_LANGUAGE = 'zh-CN,zh;q=0.9,en-US;q=0.8,en;q=0.7'
+
+// Single chromium arg: removes navigator.webdriver. Other "stealth" tricks
+// (plugins, WebGL vendor, Permissions API) are deferred — they require a
+// JS shim layer, which is out of scope for this iteration.
+export const OG_LAUNCH_ARGS = '--disable-blink-features=AutomationControlled'
+
+// Case-insensitive substring scan against (title + lowercase first 8KB of HTML).
+export const OG_CHALLENGE_SIGNATURES = [
+  'just a moment',
+  'attention required',
+  'access denied',
+  'verify you are human',
+  '403 forbidden',
+  'pardon our interruption',
+]
+
+export const OG_CHALLENGE_RETRY_MAX = 1
+export const OG_NETWORKIDLE_MS = 10_000
+export const OG_HTML_SCAN_HEAD_BYTES = 8 * 1024
+```
+
+### New error type
+
+In `apps/core/src/modules/enrichment/enrichment.types.ts`:
+
+```ts
+export class ChallengeBlockedError extends Error {
+  readonly code = 'challenge_blocked' as const
+  constructor(
+    public readonly url: string,
+    public readonly signature: string,
+  ) {
+    super(`challenge page detected for ${url} (signature: "${signature}")`)
+    this.name = 'ChallengeBlockedError'
+  }
+}
+```
+
+Distinct from generic fetch errors so:
+- `enrichment.service.ts` logs `info` instead of `warn` (challenge is
+  expected, not an outage),
+- a future admin filter can surface "blocked by anti-bot" separately,
+- callers can match by `error.code === 'challenge_blocked'`.
+
+### `runSession` flow (replacement)
+
+`browser-fetch.service.ts` keeps its public surface (`fetchHtml`, `fetchPage`,
+`attachScreenshotBytes`, `takeScreenshotBytes`). The internal `runSession`
+private method is rebuilt around the agent-browser 0.26 batch + network
+inspection capabilities.
+
+**Sequence per request:**
+
+1. `parseAndValidateUrl(rawUrl)` → `assertHostnameSafe(hostname)`.
+2. Acquire pool slot. Compute `baseArgs = ['--session', slot.name,
+   '--user-agent', OG_USER_AGENT, '--headers', JSON.stringify({
+   'Accept-Language': OG_ACCEPT_LANGUAGE }), '--args', OG_LAUNCH_ARGS]`. These
+   are passed on every `execFileAsync` against this slot. agent-browser
+   applies them at chromium launch and ignores on already-running sessions —
+   safe to send unconditionally.
+3. Start wall clock `started = Date.now()`. Allocate AbortController with
+   `opts.timeoutMs`.
+4. **Navigation batch** (single `execFileAsync`, `batch --bail --json`):
+   ```
+   open <url>
+   wait --load networkidle --timeout <OG_NETWORKIDLE_MS>
+   eval -b <pageScript>
+   ```
+   `pageScript` returns `JSON.stringify({ href, html, title })`.
+5. `markLive(slot)`.
+6. `await assertBrowserFinalUrlSafe(parsed.href)`.
+7. **Document status check**: separate `execFileAsync`:
+   ```
+   network requests --filter <hostGlob> --type document --status 400-599 --json
+   ```
+   `hostGlob` is `https://<hostname>/**` so the filter catches the URL and
+   any same-host redirect target while excluding subresources. If the output
+   array is non-empty, take the **last** entry (final navigation after any
+   redirect chain) and throw
+   `Error('agent-browser navigation returned HTTP <status> for <url>')`.
+8. **Challenge detection** (`detectChallenge(html, title)`):
+   - Lowercase `title` and `html.slice(0, OG_HTML_SCAN_HEAD_BYTES)`.
+   - For each entry in `OG_CHALLENGE_SIGNATURES`, return the matching
+     signature if found in either string.
+   - Returns `null` on clean pages.
+9. If signature found and `retriesSoFar < OG_CHALLENGE_RETRY_MAX`:
+   ```
+   batch:
+     reload
+     wait --load networkidle --timeout <OG_NETWORKIDLE_MS>
+     eval -b <pageScript>
+   ```
+   Re-run steps 6–8 on the new payload. If detection still hits, throw
+   `ChallengeBlockedError(url, signature)`.
+10. Truncate `html` to `opts.maxBodyBytes`. Build `SafeFetchResult`.
+11. Resolve `shouldCapture` (boolean or predicate against the safe result).
+12. If capturing, run viewport + screenshot subcommands as today
+    (`captureScreenshot` helper, unchanged), with `remaining = max(500,
+    opts.timeoutMs - elapsed)`.
+13. Release slot. Return `{ html, screenshotBytes }`.
+
+**Error handling:**
+
+| Where | Behavior |
+|---|---|
+| Step 2 — pool acquire | propagate |
+| Step 4/9 — execFileAsync abort | pool.release(slot, no-discard) — slot may still be reusable; rethrow `agent-browser timed out` (existing behavior) |
+| Step 4/9 — execFileAsync non-timeout failure | `pool.release(slot, { discard: true })` (existing behavior) |
+| Step 7 — HTTP ≥ 400 | release slot (no-discard, chromium still healthy), throw `fetch_failed` style error |
+| Step 9 retry exhausted | release slot (no-discard), throw `ChallengeBlockedError` |
+| Step 12 — screenshot failure | swallow + debug log (existing behavior) |
+
+### Method shape inside `browser-fetch.service.ts`
+
+```ts
+private buildBaseArgs(slot: PoolSlot): string[]
+private async runNavigationBatch(
+  executable: string,
+  slot: PoolSlot,
+  url: URL,
+  ac: AbortController,
+  opts: SafeFetchOptions,
+): Promise<{ href: string; html: string; title: string }>
+private async fetchDocumentStatus(
+  executable: string,
+  slot: PoolSlot,
+  originUrl: string,
+  ac: AbortController,
+): Promise<{ status: number; url: string } | null>
+private detectChallenge(html: string, title: string): string | null
+private async reloadAndExtract(
+  executable: string,
+  slot: PoolSlot,
+  ac: AbortController,
+  opts: SafeFetchOptions,
+): Promise<{ href: string; html: string; title: string }>
+```
+
+`runSession` becomes orchestration: acquire, navigate, status check, detect,
+optional retry, screenshot, release.
+
+### Wall-budget accounting (no new config)
+
+Default `DEFAULT_BROWSER_TIMEOUT_MS = 25_000`. Worst-case path:
+
+| Step | Budget |
+|---|---|
+| open + networkidle (capped 10 s) | ≤ 10 s |
+| eval (combined href+html+title) | ≤ 1 s |
+| network requests inspection | ≤ 1 s |
+| reload + networkidle (one retry) | ≤ 10 s |
+| screenshot (set viewport + capture) | ≤ 5 s, floored 500 ms |
+| **total worst** | ≤ 27 s |
+
+The 27 s worst case exceeds 25 s only when *every* step hits its individual
+cap. In practice the absolute AbortController fires at 25 s, dropping the
+screenshot step first (acceptable — screenshot is best-effort). No new
+configuration is added; if real traffic shows the timeout is too tight we
+revisit before adding a config knob.
+
+### Failure flow into `enrichment.service.ts`
+
+No new logic in the service for cold-miss path — `runSession` errors bubble
+up `OpenGraphProvider.fetch` → `fetchAndPersist` → `resolve.catch` → existing
+log + rethrow. Refresh-task path likewise reuses existing `recordFailure`
+backoff.
+
+Only change: lower log level to `info` when `error instanceof
+ChallengeBlockedError`. HTTP-status errors stay at `warn` (an unexpected 4xx
+on a previously-working URL is worth surfacing). The conditional lives in
+the existing `catch` block in `resolve()` and in the `onModuleInit` task
+handler. Rationale for the `info` downgrade: challenge pages are an
+expected domain-level signal from anti-bot infrastructure, not an outage —
+keeping them at `warn` floods on-call dashboards.
+
+## Files changed
+
+**New**
+- `apps/core/src/modules/enrichment/providers/open-graph/og-browser-constants.ts`
+- `apps/core/test/src/modules/enrichment/browser-fetch.spec.ts` (extend if
+  exists)
+
+**Modified**
+- `apps/core/src/modules/enrichment/providers/open-graph/browser-fetch.service.ts`
+  — `runSession` rewrite + 5 new private methods. Estimated final size
+  ≤ 480 LOC (current 388).
+- `apps/core/src/modules/enrichment/enrichment.types.ts` — add
+  `ChallengeBlockedError`.
+- `apps/core/src/modules/enrichment/enrichment.service.ts` — two log-level
+  downgrades only.
+
+**Unchanged**
+- `browser-session-pool.ts`
+- `open-graph.provider.ts`
+- `screenshot-storage.service.ts`, `screenshot-pipeline.service.ts`
+- HTTP-mode path (`safeFetch`)
+
+## Testing
+
+Vitest unit suite with `execFile` mocked. Each test asserts both the argv
+passed to agent-browser and the return value / thrown error.
+
+| Case | Asserts |
+|---|---|
+| clean page, no screenshot | argv contains `--user-agent`, `--headers`, `--args`; batch contains `wait --load networkidle --timeout <OG_NETWORKIDLE_MS>` |
+| HTTP 403 main document | throws non-Challenge `Error` with message containing `403` |
+| HTTP 500 main document | same shape as 403 |
+| challenge first try, clean retry | one `reload` batch, returns clean `SafeFetchResult` |
+| challenge twice | throws `ChallengeBlockedError`, `signature` matches first match |
+| networkidle never fires | AbortController fires, throws timeout error |
+| status query returns empty | no throw, normal path proceeds |
+| screenshot decision predicate returns false | no `set viewport` / `screenshot` invocations |
+| pool discard on non-timeout error | asserts `pool.release(slot, { discard: true })` was called |
+
+E2E with a real chromium is not part of this spec — agent-browser CLI is the
+contract surface, and the unit suite covers it. A staging smoke against a
+known CF-protected URL is fine to run manually but is not gated.
+
+## Rollout
+
+1. Land the change behind no flag (it strictly improves the existing
+   `browser` mode and degrades cleanly to "throws on protected sites" instead
+   of "caches challenge HTML").
+2. Watch enrichment failure metrics for one week. Expect:
+   - Increase in `ChallengeBlockedError` and HTTP-status throws on the cold
+     path (these were silently caching bad data before).
+   - Decrease in "OG card renders a screenshot of a CF challenge" reports.
+3. If `recordFailure` backoff over-suppresses legitimate sites that became
+   reachable, revisit by extending the existing per-row `failureCount`
+   reset behavior — not in this spec.
+
+## Open questions
+
+None remaining for this iteration. Future work (deferred):
+
+- Full stealth shim layer (plugins/WebGL/Permissions/Notification spoof).
+- Per-host backoff cache in Redis keyed by hostname.
+- Admin UI surface for UA / Accept-Language / retry budget if hardcoded
+  defaults prove inadequate.
+- Upstream agent-browser feature request: native `--stealth` flag and
+  `open --fail-on-http-error`.


### PR DESCRIPTION
## Summary
- Stop the screenshot pipeline from capturing Cloudflare/Akamai challenge pages and from caching HTTP 4xx/5xx bodies as if they were normal HTML.
- Inject realistic UA, Accept-Language, and a stealth chromium arg on every `agent-browser` invocation.
- Replace the blind `wait 1500` with `wait --load networkidle` (10s cap), then parse the main document request via `network requests --status 400-599` so failures throw before the row enters the cache.
- Detect challenge pages by signature (title + first 8KB of html), retry once via reload, then throw a typed `ChallengeBlockedError`. Log challenge-error at `info`; reserve `warn` for unexpected fetch faults.

Spec: `docs/superpowers/specs/2026-05-15-og-browser-hardening-design.md`

## Test plan
- [x] \`pnpm -C apps/core run test test/src/modules/enrichment/\` — 237 / 237 pass (40 directly exercise the rewrite)
- [x] \`pnpm exec eslint\` on changed files — clean
- [x] \`pnpm exec prettier --check\` on changed files — clean
- [ ] Staging smoke against a known CF-protected URL (manual; not gated)