### PR TITLE
fix(cli): auth login honors --profile when current pointer is stale

### DIFF
--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -101,7 +101,7 @@ local expiry from the refreshed session.
 
 ### Auth and profiles
 
-`mxs auth login [--profile <name>] [--production]` writes credentials to the named profile. If `--profile` is omitted and a current profile is active, it refreshes that profile. If no current profile exists (fresh install), it creates and selects the `default` profile. Passing `--production` sets the production flag on the target profile after login succeeds.
+`mxs auth login [--profile <name>] [--production]` writes credentials to the named profile. If `--profile` is omitted and a current profile is active, it refreshes that profile. If no current profile exists (fresh install), it creates and selects the `default` profile. If the `current` pointer references a profile whose directory has been removed, `auth login` recovers by creating the requested profile (or recreating the pointed-at one) rather than failing with `profile.not_found`. Passing `--production` sets the production flag on the target profile after login succeeds.
 
 `mxs auth logout [--profile <name>]` clears credentials for the target profile; the profile directory and the `current` pointer are preserved.
 

--- a/packages/cli/src/bin/mxs.ts
+++ b/packages/cli/src/bin/mxs.ts
@@ -36,6 +36,7 @@ import {
 } from '../domain/preflight-guards'
 import {
   currentDryRun,
+  currentProfileFlag,
   type GlobalFlags,
   parseGlobalFlags,
 } from '../domain/runtime-flags'
@@ -348,14 +349,18 @@ export const run = (argv: readonly string[]): Promise<void> => {
   )
 
   const program = Effect.locally(
-    Effect.locally(core, currentOutputOptions, {
-      json: flags.json,
-      output: flags.output,
-      quiet: flags.quiet,
-      verbose: flags.verbose,
-    }),
-    currentDryRun,
-    flags.dryRun,
+    Effect.locally(
+      Effect.locally(core, currentOutputOptions, {
+        json: flags.json,
+        output: flags.output,
+        quiet: flags.quiet,
+        verbose: flags.verbose,
+      }),
+      currentDryRun,
+      flags.dryRun,
+    ),
+    currentProfileFlag,
+    flags.profile?.trim() || undefined,
   )
 
   // Defects bypass the Effect error channel; surface them generically.

--- a/packages/cli/src/cli/auth/login.ts
+++ b/packages/cli/src/cli/auth/login.ts
@@ -1,8 +1,9 @@
 import { Command, Options } from '@effect/cli'
-import { Effect, Option } from 'effect'
+import { Effect, FiberRef, Option } from 'effect'
 import open from 'open'
 
 import { Generic } from '../../domain/errors'
+import { currentProfileFlag } from '../../domain/runtime-flags'
 import { Auth, toCredentials } from '../../services/Auth'
 import {
   Config,
@@ -32,16 +33,31 @@ export const login = Command.make('login', { production }, ({ production }) =>
 
     // 1. Resolve api-url + target profile from current config; prompt when
     //    no URL is available on a fresh install.
-    const resolved = yield* profile.resolve().pipe(
-      Effect.catchTag('Generic', (e) => {
-        // ConfigMissingApiUrl is collapsed into Generic by Profile.resolve;
-        // detect it via the preserved `cause` and prompt instead of failing.
-        const cause = (e as { cause?: { _tag?: string } }).cause
-        return cause?._tag === 'ConfigMissingApiUrl'
-          ? Effect.succeed(null)
-          : Effect.fail(e)
-      }),
-    )
+    //
+    //    The `--profile` global flag is pre-parsed and propagated via a
+    //    FiberRef; forward it as an override so `auth login --profile foo`
+    //    targets `foo` even when the active-profile pointer is missing or
+    //    points at a profile whose directory has been deleted manually.
+    const flagProfile = yield* FiberRef.get(currentProfileFlag)
+    const resolved = yield* profile
+      .resolve(flagProfile ? { profile: flagProfile } : {})
+      .pipe(
+        Effect.catchTags({
+          Generic: (e) => {
+            // ConfigMissingApiUrl is collapsed into Generic by Profile.resolve;
+            // detect it via the preserved `cause` and prompt instead of failing.
+            const cause = (e as { cause?: { _tag?: string } }).cause
+            return cause?._tag === 'ConfigMissingApiUrl'
+              ? Effect.succeed(null)
+              : Effect.fail(e)
+          },
+          // The active-profile pointer (or the resolved profile name) refers
+          // to a directory that does not exist. `auth login` is the command
+          // that *creates* a profile, so treat this as a fresh-install path
+          // rather than a hard error.
+          ProfileNotFound: () => Effect.succeed(null),
+        }),
+      )
 
     let apiUrl: string
     let targetProfile: string | null
@@ -63,7 +79,10 @@ export const login = Command.make('login', { production }, ({ production }) =>
         Effect.mapError((e) => new Generic({ message: e.message, cause: e })),
       )
       apiUrl = parsed.baseUrl
-      targetProfile = yield* config.readCurrent
+      // Prefer the explicit `--profile` flag over a stale `current` pointer.
+      // Falling back to `readCurrent` preserves the historical behaviour on
+      // fresh installs (no flag, no pointer → step 5 lands on DEFAULT_PROFILE).
+      targetProfile = flagProfile?.trim() || (yield* config.readCurrent)
     }
 
     yield* renderer.emitInfoBlock(

--- a/packages/cli/src/domain/runtime-flags.ts
+++ b/packages/cli/src/domain/runtime-flags.ts
@@ -181,3 +181,13 @@ export const parseGlobalFlags = (
 
 export const currentDryRun: FiberRef.FiberRef<boolean> =
   FiberRef.unsafeMake<boolean>(false)
+
+// ---------------------------------------------------------------------------
+// FiberRef: --profile. The flag is already threaded into `Api.layer` via
+// `StoreOverrides`, but commands that talk to the Profile/Config services
+// directly (notably `auth login`, which creates profiles) need to read it
+// without re-parsing argv. Set once in `bin/mxs.ts` after `parseGlobalFlags`.
+// ---------------------------------------------------------------------------
+
+export const currentProfileFlag: FiberRef.FiberRef<string | undefined> =
+  FiberRef.unsafeMake<string | undefined>(undefined)

--- a/packages/cli/test/cli/auth/login.test.ts
+++ b/packages/cli/test/cli/auth/login.test.ts
@@ -1,7 +1,8 @@
-import { Effect, Exit, Layer, Option } from 'effect'
+import { Effect, Exit, FiberRef, Layer, Option } from 'effect'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { login } from '../../../src/cli/auth/login'
+import { currentProfileFlag } from '../../../src/domain/runtime-flags'
 import { Auth, type AuthService } from '../../../src/services/Auth'
 import { Config } from '../../../src/services/Config'
 import { Editor, type EditorService } from '../../../src/services/Editor'
@@ -239,6 +240,99 @@ describe('auth login command', () => {
     } finally {
       writeSpy.mockRestore()
     }
+  })
+
+  it('creates the requested profile when the active pointer references a deleted profile dir', async () => {
+    // Boundary case: the user manually deleted ~/.config/mxs/profiles/default
+    // but the `current` pointer still says `default`. Running
+    // `mxs auth login --profile main` previously failed with
+    // `profile 'default' does not exist`; now the `--profile` override is
+    // honoured and the missing-profile error is downgraded to the
+    // fresh-install prompt path.
+    const mem = makeMemFs()
+    mem.seed(`${mxsDir(XDG)}/current`, 'default\n', 0o644)
+    // No `profiles/default` dir on disk.
+
+    const fsLayer = TestFsLive(mem)
+    const base = Layer.merge(fsLayer, TestPathLive)
+    const configLayer = Config.Default.pipe(Layer.provide(base))
+    const profileLayer = Profile.Default.pipe(Layer.provide(configLayer))
+    const authLayer = Layer.succeed(Auth, makeAuthMock())
+    const promptSpy = vi.fn(() => Effect.succeed('https://blog.example.com'))
+    const editorLayer = Layer.succeed(
+      Editor,
+      makeEditorMock({ prompt: promptSpy as any }),
+    )
+    const layer = Layer.mergeAll(
+      base,
+      configLayer,
+      profileLayer,
+      authLayer,
+      editorLayer,
+      Renderer.Default,
+    )
+
+    const exit = await Effect.runPromiseExit(
+      Effect.locally(
+        login.handler({ production: Option.none() }),
+        currentProfileFlag,
+        'main',
+      ).pipe(Effect.provide(layer)),
+    )
+    expect(Exit.isSuccess(exit)).toBe(true)
+
+    // Prompted because the resolved profile (default) did not exist on disk.
+    expect(promptSpy).toHaveBeenCalledTimes(1)
+
+    // Credentials land under the flag-provided profile, NOT under `default`.
+    const credsPath = `${profileDir(XDG, 'main')}/credentials.json`
+    const creds = JSON.parse(mem.readFile(credsPath) ?? '{}')
+    expect(creds.access_token).toBe('new-access-token')
+
+    expect(mem.readFile(`${mxsDir(XDG)}/current`)?.trim()).toBe('main')
+    expect(mem.readFile(`${profileDir(XDG, 'default')}/credentials.json`)).toBe(
+      null,
+    )
+  })
+
+  it('falls back to the default profile when the active pointer points at a deleted dir and no --profile flag is given', async () => {
+    // Same `current` pointer issue as above, but without `--profile`. The
+    // fresh-install path should kick in and credentials should land under
+    // the pointer's name (legacy compatibility: `readCurrent` still returns
+    // `default`, so writes go there and recreate the dir).
+    const mem = makeMemFs()
+    mem.seed(`${mxsDir(XDG)}/current`, 'default\n', 0o644)
+
+    const fsLayer = TestFsLive(mem)
+    const base = Layer.merge(fsLayer, TestPathLive)
+    const configLayer = Config.Default.pipe(Layer.provide(base))
+    const profileLayer = Profile.Default.pipe(Layer.provide(configLayer))
+    const authLayer = Layer.succeed(Auth, makeAuthMock())
+    const promptSpy = vi.fn(() => Effect.succeed('https://blog.example.com'))
+    const editorLayer = Layer.succeed(
+      Editor,
+      makeEditorMock({ prompt: promptSpy as any }),
+    )
+    const layer = Layer.mergeAll(
+      base,
+      configLayer,
+      profileLayer,
+      authLayer,
+      editorLayer,
+      Renderer.Default,
+    )
+
+    const exit = await Effect.runPromiseExit(
+      login.handler({ production: Option.none() }).pipe(Effect.provide(layer)),
+    )
+    expect(Exit.isSuccess(exit)).toBe(true)
+    expect(promptSpy).toHaveBeenCalledTimes(1)
+
+    const creds = JSON.parse(
+      mem.readFile(`${profileDir(XDG, 'default')}/credentials.json`) ?? '{}',
+    )
+    expect(creds.access_token).toBe('new-access-token')
+    expect(mem.readFile(`${mxsDir(XDG)}/current`)?.trim()).toBe('default')
   })
 
   it('prints slow_down ticks in interactive non-json mode', async () => {


### PR DESCRIPTION
## Summary

Fixes a boundary case in `mxs auth login`:

When `~/.config/mxs/current` references a profile whose directory has been removed manually, every login attempt (even `mxs auth login --profile other`) failed with `profile '<deleted>' does not exist`. The `--profile` flag was honored by `Api.layer` but not by the `login` command path, and `Config.resolve` treated a missing profile directory as a hard error even though `auth login` is the surface that *creates* profiles.

## Changes

- `domain/runtime-flags.ts` — new `currentProfileFlag` FiberRef carrying the parsed `--profile` value, set once in `bin/mxs.ts` after `parseGlobalFlags`.
- `cli/auth/login.ts` — reads the FiberRef and forwards it to `profile.resolve({ profile })`; additionally catches `ProfileNotFound` and falls into the fresh-install prompt branch. Target profile prefers the flag over the stale `current` pointer.
- `README.md` — note the new recovery behavior next to the `auth login` description.
- New tests covering both branches (with and without `--profile` when the pointer references a deleted directory).

## Test plan

- [x] `pnpm -C packages/cli typecheck`
- [x] `pnpm -C packages/cli test` (641 passing)
- [x] Reproduce locally: `rm -rf ~/.config/mxs/profiles/default && mxs auth login --profile main` no longer errors