### PR TITLE
feat(admin): add post resource store poc

### DIFF
--- a/apps/admin/package.json
+++ b/apps/admin/package.json
@@ -75,6 +75,7 @@
     "es-toolkit": "1.45.1",
     "event-source-polyfill": "1.0.31",
     "fuse.js": "7.1.0",
+    "immer": "^11.1.8",
     "jotai": "2.20.0",
     "js-cookie": "3.0.5",
     "js-yaml": "4.1.1",

--- a/apps/admin/src/data/post-category-resource/hooks.ts
+++ b/apps/admin/src/data/post-category-resource/hooks.ts
@@ -1,0 +1,20 @@
+import { shallow } from 'zustand/shallow'
+
+import {
+  selectPostCategories,
+  selectPostList,
+  serializeResourceListKey,
+  usePostCategoryResourceStore,
+} from './store'
+
+export function usePostResourceList(queryKey: readonly unknown[]) {
+  const listKey = serializeResourceListKey(queryKey)
+  return usePostCategoryResourceStore(
+    (state) => selectPostList(state, listKey),
+    shallow,
+  )
+}
+
+export function usePostResourceCategories() {
+  return usePostCategoryResourceStore(selectPostCategories, shallow)
+}

--- a/apps/admin/src/data/post-category-resource/hooks.ts
+++ b/apps/admin/src/data/post-category-resource/hooks.ts
@@ -21,6 +21,10 @@ export function usePostResourceCategories() {
   return usePostCategoryResourceStore(selectPostCategories, shallow)
 }
 
+export function usePostResourceCategoryIds() {
+  return usePostCategoryResourceStore((state) => state.categoryIds, shallow)
+}
+
 export function usePostResourceCategory(categoryId: string) {
   return usePostCategoryResourceStore(
     (state) => (categoryId ? selectPostCategory(state, categoryId) : undefined),

--- a/apps/admin/src/data/post-category-resource/hooks.ts
+++ b/apps/admin/src/data/post-category-resource/hooks.ts
@@ -1,8 +1,10 @@
 import { shallow } from 'zustand/shallow'
 
 import {
+  selectPostCategory,
   selectPostCategories,
   selectPostList,
+  selectVisiblePost,
   serializeResourceListKey,
   usePostCategoryResourceStore,
 } from './store'
@@ -17,4 +19,18 @@ export function usePostResourceList(queryKey: readonly unknown[]) {
 
 export function usePostResourceCategories() {
   return usePostCategoryResourceStore(selectPostCategories, shallow)
+}
+
+export function usePostResourceCategory(categoryId: string) {
+  return usePostCategoryResourceStore(
+    (state) => (categoryId ? selectPostCategory(state, categoryId) : undefined),
+    shallow,
+  )
+}
+
+export function usePostResourcePost(postId: string) {
+  return usePostCategoryResourceStore(
+    (state) => (postId ? selectVisiblePost(state, postId) : undefined),
+    shallow,
+  )
 }

--- a/apps/admin/src/data/post-category-resource/queries.ts
+++ b/apps/admin/src/data/post-category-resource/queries.ts
@@ -1,0 +1,96 @@
+import { useQuery } from '@tanstack/react-query'
+import type { QueryKey } from '@tanstack/react-query'
+
+import type { PaginateResult } from '~/models/base'
+import type { PostModel } from '~/models/post'
+
+import {
+  serializeResourceListKey,
+  usePostCategoryResourceStore,
+} from './store'
+import type { ResourceCategory } from './store'
+
+interface ResourceQueryOptions<TResult> {
+  enabled?: boolean
+  queryFn: () => Promise<TResult>
+  queryKey: QueryKey
+}
+
+interface PostListResourceQueryOptions<TResult>
+  extends ResourceQueryOptions<TResult> {
+  toPaginatedResult?: (result: TResult) => PaginateResult<PostModel>
+}
+
+export interface ResourceQueryReceipt {
+  hydratedAt: number
+}
+
+export function usePostCategoriesResourceQuery(
+  options: ResourceQueryOptions<ResourceCategory[]>,
+) {
+  return useQuery({
+    enabled: options.enabled,
+    queryFn: async () => {
+      const categories = await options.queryFn()
+      usePostCategoryResourceStore.getState().hydrateCategories(categories)
+      return createReceipt()
+    },
+    queryKey: options.queryKey,
+  })
+}
+
+export function usePostCategoryResourceQuery(
+  options: ResourceQueryOptions<ResourceCategory>,
+) {
+  return useQuery({
+    enabled: options.enabled,
+    queryFn: async () => {
+      const category = await options.queryFn()
+      usePostCategoryResourceStore.getState().hydrateCategory(category)
+      return createReceipt()
+    },
+    queryKey: options.queryKey,
+  })
+}
+
+export function usePostDetailResourceQuery(
+  options: ResourceQueryOptions<PostModel>,
+) {
+  return useQuery({
+    enabled: options.enabled,
+    queryFn: async () => {
+      const post = await options.queryFn()
+      usePostCategoryResourceStore.getState().hydratePostDetail(post)
+      return createReceipt()
+    },
+    queryKey: options.queryKey,
+  })
+}
+
+export function usePostListResourceQuery<TResult = PaginateResult<PostModel>>(
+  options: PostListResourceQueryOptions<TResult>,
+) {
+  return useQuery({
+    enabled: options.enabled,
+    queryFn: async () => {
+      const result = await options.queryFn()
+      const paginatedResult = options.toPaginatedResult
+        ? options.toPaginatedResult(result)
+        : (result as PaginateResult<PostModel>)
+
+      usePostCategoryResourceStore
+        .getState()
+        .hydratePostList(
+          serializeResourceListKey(options.queryKey),
+          paginatedResult,
+        )
+
+      return createReceipt()
+    },
+    queryKey: options.queryKey,
+  })
+}
+
+function createReceipt(): ResourceQueryReceipt {
+  return { hydratedAt: Date.now() }
+}

--- a/apps/admin/src/data/post-category-resource/store.test.ts
+++ b/apps/admin/src/data/post-category-resource/store.test.ts
@@ -1,0 +1,224 @@
+// @vitest-environment node
+
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import type { PaginateResult } from '~/models/base'
+import { CategoryType } from '~/models/category'
+import type { CategoryModel } from '~/models/category'
+import type { Category, PostModel } from '~/models/post'
+
+import {
+  resetPostCategoryResourceStoreForTest,
+  selectPostList,
+  selectVisiblePost,
+  serializeResourceListKey,
+  usePostCategoryResourceStore,
+} from './store'
+import { PostCategoryResourceTransaction } from './transaction'
+
+const listKey = serializeResourceListKey(['posts', 'list', { page: 1 }])
+
+describe('post category resource store', () => {
+  beforeEach(() => {
+    resetPostCategoryResourceStoreForTest()
+  })
+
+  it('normalizes embedded post categories and projects list rows from the store', () => {
+    const store = usePostCategoryResourceStore.getState()
+
+    store.hydratePostList(listKey, paginated([post({ id: 'p1' })]))
+
+    const state = usePostCategoryResourceStore.getState()
+    const list = selectPostList(state, listKey)
+
+    expect(state.categoriesById.c1?.name).toBe('Tech')
+    expect(state.postIdsByCategoryId.c1).toEqual(['p1'])
+    expect(list.posts).toHaveLength(1)
+    expect(list.posts[0].category.name).toBe('Tech')
+  })
+
+  it('keeps pending category changes visible when a stale query result arrives', () => {
+    const store = usePostCategoryResourceStore.getState()
+    store.hydrateCategories([
+      categoryModel({ id: 'c1' }),
+      categoryModel({ id: 'c2', name: 'Life' }),
+    ])
+    store.hydratePostList(listKey, paginated([post({ id: 'p1' })]))
+
+    const transactionId = store.beginPostPatchTransaction('p1', {
+      categoryId: 'c2',
+    })
+
+    store.hydratePostList(listKey, paginated([post({ id: 'p1' })]))
+
+    let state = usePostCategoryResourceStore.getState()
+    expect(selectVisiblePost(state, 'p1')?.categoryId).toBe('c2')
+    expect(selectVisiblePost(state, 'p1')?.category.name).toBe('Life')
+    expect(state.postIdsByCategoryId.c2).toEqual(['p1'])
+
+    store.commitPostTransaction(
+      transactionId,
+      post({
+        category: category({ id: 'c2', name: 'Life' }),
+        categoryId: 'c2',
+        id: 'p1',
+      }),
+    )
+
+    state = usePostCategoryResourceStore.getState()
+    expect(selectVisiblePost(state, 'p1')?.categoryId).toBe('c2')
+    expect(state.pendingTransactionIdsByPostId.p1).toBeUndefined()
+  })
+
+  it('removes only the failed transaction and replays later pending writes', () => {
+    const store = usePostCategoryResourceStore.getState()
+    store.hydratePostList(listKey, paginated([post({ id: 'p1', title: 'A' })]))
+
+    const firstTransactionId = store.beginPostPatchTransaction('p1', {
+      title: 'B',
+    })
+    store.beginPostPatchTransaction('p1', {
+      title: 'C',
+    })
+
+    store.rollbackPostTransaction(firstTransactionId, new Error('failed'))
+
+    const state = usePostCategoryResourceStore.getState()
+    expect(selectVisiblePost(state, 'p1')?.title).toBe('C')
+    expect(state.errorsByPostId.p1).toBeInstanceOf(Error)
+  })
+
+  it('can roll back an optimistic delete', () => {
+    const store = usePostCategoryResourceStore.getState()
+    store.hydratePostList(listKey, paginated([post({ id: 'p1' })]))
+
+    const transactionId = store.beginPostDeleteTransaction('p1')
+
+    expect(
+      selectPostList(usePostCategoryResourceStore.getState(), listKey).posts,
+    ).toHaveLength(0)
+
+    store.rollbackPostTransaction(transactionId)
+
+    expect(
+      selectPostList(usePostCategoryResourceStore.getState(), listKey).posts,
+    ).toHaveLength(1)
+  })
+
+  it('supports class-based transaction commit and rollback', () => {
+    const store = usePostCategoryResourceStore.getState()
+    store.hydratePostList(listKey, paginated([post({ id: 'p1', title: 'A' })]))
+
+    new PostCategoryResourceTransaction()
+      .patchPost('p1', { title: 'B' })
+      .rollback()
+
+    expect(
+      selectVisiblePost(usePostCategoryResourceStore.getState(), 'p1')?.title,
+    ).toBe('A')
+
+    new PostCategoryResourceTransaction()
+      .patchPost('p1', { title: 'B' })
+      .commitPost('p1', post({ id: 'p1', title: 'B' }))
+
+    expect(
+      selectVisiblePost(usePostCategoryResourceStore.getState(), 'p1')?.title,
+    ).toBe('B')
+  })
+
+  it('runs request-backed transaction lifecycle', async () => {
+    const store = usePostCategoryResourceStore.getState()
+    store.hydratePostList(listKey, paginated([post({ id: 'p1', title: 'A' })]))
+
+    const successTx = new PostCategoryResourceTransaction<PostModel>(
+      'renamePost',
+    )
+      .patchPost('p1', { title: 'B' })
+    successTx.request = async () => post({ id: 'p1', title: 'B' })
+    successTx.onSuccess = (serverPost: PostModel) => {
+      successTx.commitPost(serverPost.id, serverPost)
+    }
+
+    await expect(successTx.commit()).resolves.toMatchObject({
+      title: 'B',
+    })
+    expect(
+      selectVisiblePost(usePostCategoryResourceStore.getState(), 'p1')?.title,
+    ).toBe('B')
+
+    const onError = vi.fn()
+    const failedTx = new PostCategoryResourceTransaction<PostModel>(
+      'failedRename',
+    )
+      .patchPost('p1', { title: 'C' })
+    failedTx.request = async () => {
+      throw new Error('failed')
+    }
+    failedTx.onError = onError
+
+    await expect(failedTx.commit()).rejects.toThrow('failed')
+    expect(
+      selectVisiblePost(usePostCategoryResourceStore.getState(), 'p1')?.title,
+    ).toBe('B')
+    expect(onError).toHaveBeenCalledTimes(1)
+  })
+})
+
+function paginated(data: PostModel[]): PaginateResult<PostModel> {
+  return {
+    data,
+    pagination: {
+      page: 1,
+      size: 10,
+      total: data.length,
+      totalPages: 1,
+    },
+  }
+}
+
+function post(overrides: Partial<PostModel> = {}): PostModel {
+  const baseCategory = overrides.category ?? category()
+
+  return {
+    category: baseCategory,
+    categoryId: baseCategory.id,
+    contentFormat: 'markdown',
+    copyright: false,
+    createdAt: '2026-05-30T00:00:00.000Z',
+    id: 'p1',
+    images: [],
+    isPublished: false,
+    likeCount: 0,
+    modifiedAt: null,
+    pinAt: null,
+    pinOrder: null,
+    readCount: 0,
+    slug: 'post-1',
+    tags: [],
+    text: 'Post text',
+    title: 'Post title',
+    ...overrides,
+  }
+}
+
+function category(overrides: Partial<Category> = {}): Category {
+  return {
+    id: 'c1',
+    name: 'Tech',
+    slug: 'tech',
+    type: CategoryType.Category,
+    ...overrides,
+  }
+}
+
+function categoryModel(overrides: Partial<CategoryModel> = {}): CategoryModel {
+  return {
+    count: 0,
+    createdAt: '2026-05-30T00:00:00.000Z',
+    id: 'c1',
+    name: 'Tech',
+    slug: 'tech',
+    type: CategoryType.Category,
+    ...overrides,
+  }
+}

--- a/apps/admin/src/data/post-category-resource/store.test.ts
+++ b/apps/admin/src/data/post-category-resource/store.test.ts
@@ -105,6 +105,44 @@ describe('post category resource store', () => {
     ).toHaveLength(1)
   })
 
+  it('hydrates detail rows into the shared post table', () => {
+    const store = usePostCategoryResourceStore.getState()
+
+    store.hydratePostDetail(post({ id: 'p1', title: 'Detail title' }))
+
+    const state = usePostCategoryResourceStore.getState()
+    expect(selectVisiblePost(state, 'p1')?.title).toBe('Detail title')
+    expect(state.postIdsByCategoryId.c1).toEqual(['p1'])
+  })
+
+  it('updates visible post category data when category management saves', () => {
+    const store = usePostCategoryResourceStore.getState()
+    store.hydratePostDetail(post({ id: 'p1' }))
+
+    store.hydrateCategory(
+      categoryModel({ id: 'c1', name: 'Engineering', slug: 'engineering' }),
+    )
+
+    const visiblePost = selectVisiblePost(
+      usePostCategoryResourceStore.getState(),
+      'p1',
+    )
+    expect(visiblePost?.category.name).toBe('Engineering')
+    expect(visiblePost?.category.slug).toBe('engineering')
+  })
+
+  it('removes category management rows without deleting posts', () => {
+    const store = usePostCategoryResourceStore.getState()
+    store.hydrateCategories([categoryModel({ id: 'c1' })])
+    store.hydratePostDetail(post({ id: 'p1' }))
+
+    store.removeCategory('c1')
+
+    const state = usePostCategoryResourceStore.getState()
+    expect(state.categoryIds).toEqual([])
+    expect(selectVisiblePost(state, 'p1')?.id).toBe('p1')
+  })
+
   it('supports class-based transaction commit and rollback', () => {
     const store = usePostCategoryResourceStore.getState()
     store.hydratePostList(listKey, paginated([post({ id: 'p1', title: 'A' })]))

--- a/apps/admin/src/data/post-category-resource/store.ts
+++ b/apps/admin/src/data/post-category-resource/store.ts
@@ -6,7 +6,7 @@ import type { PaginateResult, Pager } from '~/models/base'
 import type { CategoryModel } from '~/models/category'
 import type { Category, PostModel } from '~/models/post'
 
-type ResourceCategory = Category | CategoryModel
+export type ResourceCategory = Category | CategoryModel
 
 interface PostListIndex {
   ids: string[]

--- a/apps/admin/src/data/post-category-resource/store.ts
+++ b/apps/admin/src/data/post-category-resource/store.ts
@@ -44,10 +44,13 @@ interface PostCategoryResourceActions {
     serverPost?: PostModel,
   ) => void
   hydrateCategories: (categories: ResourceCategory[]) => void
+  hydrateCategory: (category: ResourceCategory) => void
+  hydratePostDetail: (post: PostModel) => void
   hydratePostList: (
     listKey: string,
     result: PaginateResult<PostModel>,
   ) => void
+  removeCategory: (categoryId: string) => void
   reset: () => void
   rollbackPostTransaction: (transactionId: string, error?: unknown) => void
 }
@@ -128,11 +131,24 @@ export const usePostCategoryResourceStore =
           produce<PostCategoryResourceStore>((draft) => {
             draft.categoryIds = categories.map((category) => category.id)
             for (const category of categories) {
-              draft.categoriesById[category.id] = {
-                ...draft.categoriesById[category.id],
-                ...category,
-              }
+              upsertCategory(draft, category)
             }
+            rebuildPostCategoryRelations(draft)
+          }),
+        )
+      },
+      hydrateCategory: (category) => {
+        set(
+          produce<PostCategoryResourceStore>((draft) => {
+            upsertCategory(draft, category)
+            rebuildPostCategoryRelations(draft)
+          }),
+        )
+      },
+      hydratePostDetail: (post) => {
+        set(
+          produce<PostCategoryResourceStore>((draft) => {
+            upsertPost(draft, post)
             rebuildPostCategoryRelations(draft)
           }),
         )
@@ -148,6 +164,17 @@ export const usePostCategoryResourceStore =
               pagination: result.pagination,
               updatedAt: Date.now(),
             }
+            rebuildPostCategoryRelations(draft)
+          }),
+        )
+      },
+      removeCategory: (categoryId) => {
+        set(
+          produce<PostCategoryResourceStore>((draft) => {
+            delete draft.categoriesById[categoryId]
+            draft.categoryIds = draft.categoryIds.filter(
+              (id) => id !== categoryId,
+            )
             rebuildPostCategoryRelations(draft)
           }),
         )
@@ -199,6 +226,13 @@ export function selectPostCategories(state: PostCategoryResourceState) {
   return state.categoryIds
     .map((id) => state.categoriesById[id])
     .filter((category): category is ResourceCategory => Boolean(category))
+}
+
+export function selectPostCategory(
+  state: PostCategoryResourceState,
+  categoryId: string,
+) {
+  return state.categoriesById[categoryId]
 }
 
 export function selectVisiblePost(
@@ -265,16 +299,22 @@ function removePostTransaction(
 
 function upsertPost(draft: PostCategoryResourceStore, post: PostModel) {
   if (post.category) {
-    const category = post.category
-    draft.categoriesById[category.id] = {
-      ...draft.categoriesById[category.id],
-      ...category,
-    }
-    if (!draft.categoryIds.includes(category.id)) {
-      draft.categoryIds.push(category.id)
-    }
+    upsertCategory(draft, post.category)
   }
   draft.postsById[post.id] = post
+}
+
+function upsertCategory(
+  draft: PostCategoryResourceStore,
+  category: ResourceCategory,
+) {
+  draft.categoriesById[category.id] = {
+    ...draft.categoriesById[category.id],
+    ...category,
+  }
+  if (!draft.categoryIds.includes(category.id)) {
+    draft.categoryIds.push(category.id)
+  }
 }
 
 function rebuildPostCategoryRelations(draft: PostCategoryResourceStore) {

--- a/apps/admin/src/data/post-category-resource/store.ts
+++ b/apps/admin/src/data/post-category-resource/store.ts
@@ -1,0 +1,305 @@
+import { produce } from 'immer'
+import { shallow } from 'zustand/shallow'
+import { createWithEqualityFn } from 'zustand/traditional'
+
+import type { PaginateResult, Pager } from '~/models/base'
+import type { CategoryModel } from '~/models/category'
+import type { Category, PostModel } from '~/models/post'
+
+type ResourceCategory = Category | CategoryModel
+
+interface PostListIndex {
+  ids: string[]
+  pagination?: Pager
+  updatedAt: number
+}
+
+interface PostTransaction {
+  id: string
+  kind: 'delete' | 'patch'
+  patch?: Partial<PostModel>
+  postId: string
+  startedAt: number
+}
+
+export interface PostCategoryResourceState {
+  categoriesById: Record<string, ResourceCategory>
+  categoryIds: string[]
+  errorsByPostId: Record<string, unknown>
+  listIndexes: Record<string, PostListIndex>
+  pendingTransactionIdsByPostId: Record<string, string[]>
+  postIdsByCategoryId: Record<string, string[]>
+  postsById: Record<string, PostModel>
+  transactionsById: Record<string, PostTransaction>
+}
+
+interface PostCategoryResourceActions {
+  beginPostDeleteTransaction: (postId: string) => string
+  beginPostPatchTransaction: (
+    postId: string,
+    patch: Partial<PostModel>,
+  ) => string
+  commitPostTransaction: (
+    transactionId: string,
+    serverPost?: PostModel,
+  ) => void
+  hydrateCategories: (categories: ResourceCategory[]) => void
+  hydratePostList: (
+    listKey: string,
+    result: PaginateResult<PostModel>,
+  ) => void
+  reset: () => void
+  rollbackPostTransaction: (transactionId: string, error?: unknown) => void
+}
+
+export type PostCategoryResourceStore = PostCategoryResourceState &
+  PostCategoryResourceActions
+
+const initialState: PostCategoryResourceState = {
+  categoriesById: {},
+  categoryIds: [],
+  errorsByPostId: {},
+  listIndexes: {},
+  pendingTransactionIdsByPostId: {},
+  postIdsByCategoryId: {},
+  postsById: {},
+  transactionsById: {},
+}
+
+export const usePostCategoryResourceStore =
+  createWithEqualityFn<PostCategoryResourceStore>()(
+    (set) => ({
+      ...initialState,
+      beginPostDeleteTransaction: (postId) => {
+        const transactionId = createTransactionId()
+        set(
+          produce<PostCategoryResourceStore>((draft) => {
+            addPostTransaction(draft, {
+              id: transactionId,
+              kind: 'delete',
+              postId,
+              startedAt: Date.now(),
+            })
+            delete draft.errorsByPostId[postId]
+            rebuildPostCategoryRelations(draft)
+          }),
+        )
+        return transactionId
+      },
+      beginPostPatchTransaction: (postId, patch) => {
+        const transactionId = createTransactionId()
+        set(
+          produce<PostCategoryResourceStore>((draft) => {
+            addPostTransaction(draft, {
+              id: transactionId,
+              kind: 'patch',
+              patch,
+              postId,
+              startedAt: Date.now(),
+            })
+            delete draft.errorsByPostId[postId]
+            rebuildPostCategoryRelations(draft)
+          }),
+        )
+        return transactionId
+      },
+      commitPostTransaction: (transactionId, serverPost) => {
+        set(
+          produce<PostCategoryResourceStore>((draft) => {
+            const transaction = draft.transactionsById[transactionId]
+            if (!transaction) return
+
+            removePostTransaction(draft, transactionId)
+
+            if (transaction.kind === 'delete') {
+              delete draft.postsById[transaction.postId]
+              delete draft.errorsByPostId[transaction.postId]
+            } else if (serverPost) {
+              upsertPost(draft, serverPost)
+              delete draft.errorsByPostId[serverPost.id]
+            }
+
+            rebuildPostCategoryRelations(draft)
+          }),
+        )
+      },
+      hydrateCategories: (categories) => {
+        set(
+          produce<PostCategoryResourceStore>((draft) => {
+            draft.categoryIds = categories.map((category) => category.id)
+            for (const category of categories) {
+              draft.categoriesById[category.id] = {
+                ...draft.categoriesById[category.id],
+                ...category,
+              }
+            }
+            rebuildPostCategoryRelations(draft)
+          }),
+        )
+      },
+      hydratePostList: (listKey, result) => {
+        set(
+          produce<PostCategoryResourceStore>((draft) => {
+            for (const post of result.data) {
+              upsertPost(draft, post)
+            }
+            draft.listIndexes[listKey] = {
+              ids: result.data.map((post) => post.id),
+              pagination: result.pagination,
+              updatedAt: Date.now(),
+            }
+            rebuildPostCategoryRelations(draft)
+          }),
+        )
+      },
+      reset: () => set({ ...initialState }),
+      rollbackPostTransaction: (transactionId, error) => {
+        set(
+          produce<PostCategoryResourceStore>((draft) => {
+            const transaction = draft.transactionsById[transactionId]
+            if (!transaction) return
+
+            removePostTransaction(draft, transactionId)
+            if (error) draft.errorsByPostId[transaction.postId] = error
+            rebuildPostCategoryRelations(draft)
+          }),
+        )
+      },
+    }),
+    shallow,
+  )
+
+export function serializeResourceListKey(queryKey: readonly unknown[]) {
+  return JSON.stringify(queryKey)
+}
+
+export function selectPostList(
+  state: PostCategoryResourceState,
+  listKey: string,
+) {
+  const index = state.listIndexes[listKey]
+  if (!index) {
+    return {
+      pagination: undefined,
+      posts: [] as PostModel[],
+      updatedAt: 0,
+    }
+  }
+
+  return {
+    pagination: index.pagination,
+    posts: index.ids
+      .map((id) => selectVisiblePost(state, id))
+      .filter((post): post is PostModel => Boolean(post)),
+    updatedAt: index.updatedAt,
+  }
+}
+
+export function selectPostCategories(state: PostCategoryResourceState) {
+  return state.categoryIds
+    .map((id) => state.categoriesById[id])
+    .filter((category): category is ResourceCategory => Boolean(category))
+}
+
+export function selectVisiblePost(
+  state: PostCategoryResourceState,
+  postId: string,
+) {
+  const base = state.postsById[postId]
+  if (!base) return
+
+  let visible: PostModel | undefined = base
+  const transactionIds = state.pendingTransactionIdsByPostId[postId] ?? []
+
+  for (const transactionId of transactionIds) {
+    const transaction = state.transactionsById[transactionId]
+    if (!transaction) continue
+    if (transaction.kind === 'delete') {
+      visible = undefined
+      break
+    }
+    visible = {
+      ...visible,
+      ...transaction.patch,
+    }
+  }
+
+  if (!visible) return
+  return attachCategory(state, visible)
+}
+
+export function resetPostCategoryResourceStoreForTest() {
+  usePostCategoryResourceStore.getState().reset()
+}
+
+function addPostTransaction(
+  draft: PostCategoryResourceStore,
+  transaction: PostTransaction,
+) {
+  draft.transactionsById[transaction.id] = transaction
+  const ids = draft.pendingTransactionIdsByPostId[transaction.postId] ?? []
+  draft.pendingTransactionIdsByPostId[transaction.postId] = [
+    ...ids,
+    transaction.id,
+  ]
+}
+
+function removePostTransaction(
+  draft: PostCategoryResourceStore,
+  transactionId: string,
+) {
+  const transaction = draft.transactionsById[transactionId]
+  if (!transaction) return
+
+  delete draft.transactionsById[transactionId]
+  const nextIds = (
+    draft.pendingTransactionIdsByPostId[transaction.postId] ?? []
+  ).filter((id) => id !== transactionId)
+
+  if (nextIds.length === 0) {
+    delete draft.pendingTransactionIdsByPostId[transaction.postId]
+  } else {
+    draft.pendingTransactionIdsByPostId[transaction.postId] = nextIds
+  }
+}
+
+function upsertPost(draft: PostCategoryResourceStore, post: PostModel) {
+  if (post.category) {
+    const category = post.category
+    draft.categoriesById[category.id] = {
+      ...draft.categoriesById[category.id],
+      ...category,
+    }
+    if (!draft.categoryIds.includes(category.id)) {
+      draft.categoryIds.push(category.id)
+    }
+  }
+  draft.postsById[post.id] = post
+}
+
+function rebuildPostCategoryRelations(draft: PostCategoryResourceStore) {
+  const next: Record<string, string[]> = {}
+
+  for (const postId of Object.keys(draft.postsById)) {
+    const post = selectVisiblePost(draft, postId)
+    if (!post?.categoryId) continue
+    next[post.categoryId] = [...(next[post.categoryId] ?? []), postId]
+  }
+
+  draft.postIdsByCategoryId = next
+}
+
+function attachCategory(
+  state: PostCategoryResourceState,
+  post: PostModel,
+): PostModel {
+  const category = state.categoriesById[post.categoryId] ?? post.category
+  return {
+    ...post,
+    category: category as Category,
+  }
+}
+
+function createTransactionId() {
+  return `${Date.now().toString(36)}-${Math.random().toString(36).slice(2)}`
+}

--- a/apps/admin/src/data/post-category-resource/transaction.ts
+++ b/apps/admin/src/data/post-category-resource/transaction.ts
@@ -1,0 +1,144 @@
+import type { PostModel } from '~/models/post'
+
+import { usePostCategoryResourceStore } from './store'
+
+type RemoteRequest<T> = () => Promise<T>
+type TransactionFailureHandler = (error: unknown) => Promise<void> | void
+type TransactionSuccessHandler<T> = (result: T) => Promise<void> | void
+
+interface PostTransactionOperation {
+  postId: string
+  transactionId: string
+}
+
+export class PostCategoryResourceTransaction<T = unknown> {
+  private committed = false
+  private failureHandler?: TransactionFailureHandler
+  private readonly name: string
+  private readonly operations: PostTransactionOperation[] = []
+  private requestFn?: RemoteRequest<T>
+  private successHandler?: TransactionSuccessHandler<T>
+
+  constructor(name = 'postCategoryResourceTransaction') {
+    this.name = name
+  }
+
+  deletePost(postId: string) {
+    this.assertMutable()
+    const transactionId = usePostCategoryResourceStore
+      .getState()
+      .beginPostDeleteTransaction(postId)
+
+    this.operations.push({ postId, transactionId })
+    return this
+  }
+
+  patchPost(postId: string, patch: Partial<PostModel>) {
+    this.assertMutable()
+    const transactionId = usePostCategoryResourceStore
+      .getState()
+      .beginPostPatchTransaction(postId, patch)
+
+    this.operations.push({ postId, transactionId })
+    return this
+  }
+
+  set onError(handler: TransactionFailureHandler) {
+    this.failureHandler = handler
+  }
+
+  set onSuccess(handler: TransactionSuccessHandler<T>) {
+    this.successHandler = handler
+  }
+
+  set request(request: RemoteRequest<T>) {
+    this.requestFn = request
+  }
+
+  async commit() {
+    if (this.committed) {
+      throw new Error(`[PostCategoryResourceTransaction] "${this.name}" already committed`)
+    }
+    if (!this.requestFn) {
+      throw new Error(`[PostCategoryResourceTransaction] "${this.name}" missing request`)
+    }
+
+    this.committed = true
+
+    let result: T
+    try {
+      result = await this.requestFn()
+    } catch (error) {
+      this.rollback(error)
+      await this.failureHandler?.(error)
+      throw error
+    }
+
+    await this.successHandler?.(result)
+    return result
+  }
+
+  commitAll() {
+    for (const operation of this.operations) {
+      this.commitOperation(operation)
+    }
+  }
+
+  commitPost(postId: string, serverPost?: PostModel) {
+    for (const operation of this.operationsForPost(postId)) {
+      this.commitOperation(operation, serverPost)
+    }
+  }
+
+  commitPosts(postIds: Iterable<string>) {
+    for (const postId of postIds) {
+      this.commitPost(postId)
+    }
+  }
+
+  rollback(error?: unknown) {
+    for (const operation of this.operations) {
+      this.rollbackOperation(operation, error)
+    }
+  }
+
+  rollbackPost(postId: string, error?: unknown) {
+    for (const operation of this.operationsForPost(postId)) {
+      this.rollbackOperation(operation, error)
+    }
+  }
+
+  rollbackPosts(postIds: Iterable<string>, error?: unknown) {
+    for (const postId of postIds) {
+      this.rollbackPost(postId, error)
+    }
+  }
+
+  private commitOperation(
+    operation: PostTransactionOperation,
+    serverPost?: PostModel,
+  ) {
+    usePostCategoryResourceStore
+      .getState()
+      .commitPostTransaction(operation.transactionId, serverPost)
+  }
+
+  private operationsForPost(postId: string) {
+    return this.operations.filter((operation) => operation.postId === postId)
+  }
+
+  private rollbackOperation(
+    operation: PostTransactionOperation,
+    error?: unknown,
+  ) {
+    usePostCategoryResourceStore
+      .getState()
+      .rollbackPostTransaction(operation.transactionId, error)
+  }
+
+  private assertMutable() {
+    if (this.committed) {
+      throw new Error(`[PostCategoryResourceTransaction] "${this.name}" is already committed`)
+    }
+  }
+}

--- a/apps/admin/src/features/categories/components/CategoriesRouteViewContent.tsx
+++ b/apps/admin/src/features/categories/components/CategoriesRouteViewContent.tsx
@@ -3,6 +3,7 @@ import { useCallback, useMemo } from 'react'
 import { useNavigate, useParams } from 'react-router'
 
 import { APP_SHELL_HEADER_HEIGHT_CLASS } from '~/constants/layout'
+import { usePostResourceCategoryIds } from '~/data/post-category-resource/hooks'
 import { useI18n } from '~/i18n'
 import type { CategoryModel } from '~/models/category'
 import { MasterDetailShell } from '~/ui/layout/master-detail-shell'
@@ -42,7 +43,8 @@ export function CategoriesRouteViewContent() {
   const params = useParams<{ id?: string }>()
   const selectedItem = decodeTarget(params.id)
 
-  const { categories, categoriesQuery, tags, tagsQuery } = useCategoriesList()
+  const { categoriesQuery, tags, tagsQuery } = useCategoriesList()
+  const categoryIds = usePostResourceCategoryIds()
 
   const closeDetail = useCallback(() => {
     navigate('/posts/category')
@@ -114,7 +116,7 @@ export function CategoriesRouteViewContent() {
                 </h2>
               </div>
               <span className="text-xs text-neutral-500 dark:text-neutral-400">
-                {categories.length} / {tags.length}
+                {categoryIds.length} / {tags.length}
               </span>
               <Button
                 onClick={() => void openForm({ kind: 'create' })}
@@ -128,11 +130,11 @@ export function CategoriesRouteViewContent() {
 
             <Scroll className="min-h-0 flex-1">
               <ListSection
-                count={categories.length}
+                count={categoryIds.length}
                 loading={categoriesQuery.isLoading}
                 title={t('categories.section.categories')}
               >
-                {categories.length === 0 && !categoriesQuery.isLoading ? (
+                {categoryIds.length === 0 && !categoriesQuery.isLoading ? (
                   <EmptyList
                     action={
                       <Button
@@ -146,16 +148,16 @@ export function CategoriesRouteViewContent() {
                     label={t('categories.list.emptyCategories')}
                   />
                 ) : (
-                  categories.map((category) => (
+                  categoryIds.map((categoryId) => (
                     <CategoryRow
-                      category={category}
-                      key={category.id}
+                      categoryId={categoryId}
+                      key={categoryId}
                       onSelect={() =>
-                        selectItem({ id: category.id, kind: 'category' })
+                        selectItem({ id: categoryId, kind: 'category' })
                       }
                       selected={
                         selectedItem?.kind === 'category' &&
-                        selectedItem.id === category.id
+                        selectedItem.id === categoryId
                       }
                     />
                   ))

--- a/apps/admin/src/features/categories/components/CategoryDetail.tsx
+++ b/apps/admin/src/features/categories/components/CategoryDetail.tsx
@@ -1,14 +1,10 @@
-import { useQuery } from '@tanstack/react-query'
-import { useLayoutEffect, useMemo } from 'react'
+import { useMemo } from 'react'
 import { Edit3, FolderOpen, Loader2, Trash2 } from 'lucide-react'
 import type { CategoryModel } from '~/models/category'
 
 import { getPosts } from '~/api/posts'
 import { usePostResourceCategory } from '~/data/post-category-resource/hooks'
-import {
-  serializeResourceListKey,
-  usePostCategoryResourceStore,
-} from '~/data/post-category-resource/store'
+import { usePostListResourceQuery } from '~/data/post-category-resource/queries'
 import { useI18n } from '~/i18n'
 import { adminQueryKeys } from '~/query/keys'
 import { Button } from '~/ui/primitives/button'
@@ -34,7 +30,7 @@ export function CategoryDetail(props: {
     () => adminQueryKeys.posts.categoryDetail(props.categoryId),
     [props.categoryId],
   )
-  const postsQuery = useQuery({
+  const postsQuery = usePostListResourceQuery({
     enabled: !!props.categoryId,
     queryFn: () =>
       getPosts({
@@ -46,13 +42,6 @@ export function CategoryDetail(props: {
       }),
     queryKey: postsQueryKey,
   })
-
-  useLayoutEffect(() => {
-    if (!postsQuery.data) return
-    usePostCategoryResourceStore
-      .getState()
-      .hydratePostList(serializeResourceListKey(postsQueryKey), postsQuery.data)
-  }, [postsQuery.data, postsQueryKey])
 
   if (!category) return null
 

--- a/apps/admin/src/features/categories/components/CategoryDetail.tsx
+++ b/apps/admin/src/features/categories/components/CategoryDetail.tsx
@@ -4,7 +4,7 @@ import { Edit3, FolderOpen, Loader2, Trash2 } from 'lucide-react'
 import type { CategoryModel } from '~/models/category'
 
 import { getPosts } from '~/api/posts'
-import { usePostResourceList } from '~/data/post-category-resource/hooks'
+import { usePostResourceCategory } from '~/data/post-category-resource/hooks'
 import {
   serializeResourceListKey,
   usePostCategoryResourceStore,
@@ -20,23 +20,25 @@ import { EntitySummary } from './EntitySummary'
 import { PostListSection } from './PostListSection'
 
 export function CategoryDetail(props: {
-  category: CategoryModel
+  categoryId: string
   deleting: boolean
   onBack: () => void
   onDelete: (category: CategoryModel) => void
   onEdit: (category: CategoryModel) => void
 }) {
   const { t } = useI18n()
+  const category = usePostResourceCategory(props.categoryId) as
+    | CategoryModel
+    | undefined
   const postsQueryKey = useMemo(
-    () => adminQueryKeys.posts.categoryDetail(props.category.id),
-    [props.category.id],
+    () => adminQueryKeys.posts.categoryDetail(props.categoryId),
+    [props.categoryId],
   )
-  const postListResource = usePostResourceList(postsQueryKey)
   const postsQuery = useQuery({
-    enabled: !!props.category.id,
+    enabled: !!props.categoryId,
     queryFn: () =>
       getPosts({
-        categoryIds: [props.category.id],
+        categoryIds: [props.categoryId],
         page: 1,
         size: categoryDetailPostPageSize,
         sort_by: 'createdAt',
@@ -52,11 +54,13 @@ export function CategoryDetail(props: {
       .hydratePostList(serializeResourceListKey(postsQueryKey), postsQuery.data)
   }, [postsQuery.data, postsQueryKey])
 
+  if (!category) return null
+
   return (
     <div className="flex h-full min-h-0 flex-col">
       <DetailHeader onBack={props.onBack} title={t('categories.detail.title')}>
         <Button
-          onClick={() => props.onEdit(props.category)}
+          onClick={() => props.onEdit(category)}
           type="button"
           variant="subtle"
         >
@@ -66,7 +70,7 @@ export function CategoryDetail(props: {
         <Button
           className="border-red-200 text-red-600 hover:bg-red-50 dark:border-red-950 dark:text-red-400 dark:hover:bg-red-950/30"
           disabled={props.deleting}
-          onClick={() => props.onDelete(props.category)}
+          onClick={() => props.onDelete(category)}
           type="button"
           variant="subtle"
         >
@@ -82,16 +86,16 @@ export function CategoryDetail(props: {
       <Scroll className="min-h-0 flex-1" innerClassName="p-5">
         <EntitySummary
           countLabel={t('categories.detail.postCount', {
-            count: props.category.count,
+            count: category.count,
           })}
           icon={<FolderOpen aria-hidden="true" className="size-6" />}
-          meta={props.category.slug}
-          title={props.category.name}
+          meta={category.slug}
+          title={category.name}
         />
         <PostListSection
           emptyText={t('categories.detail.postsByCategoryEmpty')}
           loading={postsQuery.isLoading}
-          posts={postListResource.posts}
+          queryKey={postsQueryKey}
           title={t('categories.detail.postsByCategory')}
         />
       </Scroll>

--- a/apps/admin/src/features/categories/components/CategoryDetail.tsx
+++ b/apps/admin/src/features/categories/components/CategoryDetail.tsx
@@ -1,8 +1,14 @@
 import { useQuery } from '@tanstack/react-query'
+import { useLayoutEffect, useMemo } from 'react'
 import { Edit3, FolderOpen, Loader2, Trash2 } from 'lucide-react'
 import type { CategoryModel } from '~/models/category'
 
 import { getPosts } from '~/api/posts'
+import { usePostResourceList } from '~/data/post-category-resource/hooks'
+import {
+  serializeResourceListKey,
+  usePostCategoryResourceStore,
+} from '~/data/post-category-resource/store'
 import { useI18n } from '~/i18n'
 import { adminQueryKeys } from '~/query/keys'
 import { Button } from '~/ui/primitives/button'
@@ -21,6 +27,11 @@ export function CategoryDetail(props: {
   onEdit: (category: CategoryModel) => void
 }) {
   const { t } = useI18n()
+  const postsQueryKey = useMemo(
+    () => adminQueryKeys.posts.categoryDetail(props.category.id),
+    [props.category.id],
+  )
+  const postListResource = usePostResourceList(postsQueryKey)
   const postsQuery = useQuery({
     enabled: !!props.category.id,
     queryFn: () =>
@@ -30,9 +41,16 @@ export function CategoryDetail(props: {
         size: categoryDetailPostPageSize,
         sort_by: 'createdAt',
         sort_order: 'desc',
-      }).then((result) => result.data),
-    queryKey: adminQueryKeys.posts.categoryDetail(props.category.id),
+      }),
+    queryKey: postsQueryKey,
   })
+
+  useLayoutEffect(() => {
+    if (!postsQuery.data) return
+    usePostCategoryResourceStore
+      .getState()
+      .hydratePostList(serializeResourceListKey(postsQueryKey), postsQuery.data)
+  }, [postsQuery.data, postsQueryKey])
 
   return (
     <div className="flex h-full min-h-0 flex-col">
@@ -73,7 +91,7 @@ export function CategoryDetail(props: {
         <PostListSection
           emptyText={t('categories.detail.postsByCategoryEmpty')}
           loading={postsQuery.isLoading}
-          posts={postsQuery.data ?? []}
+          posts={postListResource.posts}
           title={t('categories.detail.postsByCategory')}
         />
       </Scroll>

--- a/apps/admin/src/features/categories/components/CategoryDetailRoute.tsx
+++ b/apps/admin/src/features/categories/components/CategoryDetailRoute.tsx
@@ -1,11 +1,12 @@
-import { useQuery, useQueryClient } from '@tanstack/react-query'
-import { useLayoutEffect } from 'react'
+import { useQuery } from '@tanstack/react-query'
 import { useParams } from 'react-router'
 
 import { getCategories, getCategory, getTags } from '~/api/categories'
-import { findInListCache } from '~/api/list-cache'
 import { usePostResourceCategory } from '~/data/post-category-resource/hooks'
-import { usePostCategoryResourceStore } from '~/data/post-category-resource/store'
+import {
+  usePostCategoriesResourceQuery,
+  usePostCategoryResourceQuery,
+} from '~/data/post-category-resource/queries'
 import type { CategoryModel, TagModel } from '~/models/category'
 import { adminQueryKeys } from '~/query/keys'
 
@@ -34,7 +35,6 @@ function parseId(raw: string | undefined): ParsedTarget | null {
 
 export function CategoryDetailRoute() {
   const { id } = useParams<{ id: string }>()
-  const queryClient = useQueryClient()
   const ctx = useCategoriesRouteContext()
 
   const parsed = parseId(id)
@@ -42,23 +42,12 @@ export function CategoryDetailRoute() {
     parsed?.kind === 'category' ? parsed.value : '',
   )
 
-  const initialCategory =
-    parsed?.kind === 'category'
-      ? findInListCache<CategoryModel>(
-          queryClient,
-          CATEGORY_LIST_KEY,
-          parsed.value,
-        )
-      : undefined
-
-  const categoryQuery = useQuery({
+  usePostCategoryResourceQuery({
     enabled: parsed?.kind === 'category',
-    initialData: initialCategory,
     queryFn: () => getCategory(parsed!.value),
     queryKey: parsed?.value
       ? adminQueryKeys.categories.detail(parsed.value)
       : adminQueryKeys.categories.root,
-    staleTime: initialCategory ? 30_000 : 0,
   })
 
   // Tag detail isn't fetched by id; reach into the list cache to find it.
@@ -68,17 +57,11 @@ export function CategoryDetailRoute() {
     queryKey: TAGS_LIST_KEY,
   })
 
-  // Keep the categories list warm in case the user opened a deep link directly.
-  useQuery({
-    enabled: parsed?.kind === 'category' && !initialCategory,
+  usePostCategoriesResourceQuery({
+    enabled: parsed?.kind === 'category' && !resourceCategory,
     queryFn: () => getCategories({ type: 'Category' }),
     queryKey: CATEGORY_LIST_KEY,
   })
-
-  useLayoutEffect(() => {
-    if (!categoryQuery.data) return
-    usePostCategoryResourceStore.getState().hydrateCategory(categoryQuery.data)
-  }, [categoryQuery.data])
 
   if (!parsed) return <DetailEmpty />
 
@@ -91,9 +74,7 @@ export function CategoryDetailRoute() {
     return <TagDetail onBack={ctx.onBack} tag={tag} />
   }
 
-  const category = (resourceCategory ?? categoryQuery.data) as
-    | CategoryModel
-    | undefined
+  const category = resourceCategory as CategoryModel | undefined
   if (!category) return <DetailEmpty />
 
   return (

--- a/apps/admin/src/features/categories/components/CategoryDetailRoute.tsx
+++ b/apps/admin/src/features/categories/components/CategoryDetailRoute.tsx
@@ -1,8 +1,11 @@
 import { useQuery, useQueryClient } from '@tanstack/react-query'
+import { useLayoutEffect } from 'react'
 import { useParams } from 'react-router'
 
 import { getCategories, getCategory, getTags } from '~/api/categories'
 import { findInListCache } from '~/api/list-cache'
+import { usePostResourceCategory } from '~/data/post-category-resource/hooks'
+import { usePostCategoryResourceStore } from '~/data/post-category-resource/store'
 import type { CategoryModel, TagModel } from '~/models/category'
 import { adminQueryKeys } from '~/query/keys'
 
@@ -35,6 +38,9 @@ export function CategoryDetailRoute() {
   const ctx = useCategoriesRouteContext()
 
   const parsed = parseId(id)
+  const resourceCategory = usePostResourceCategory(
+    parsed?.kind === 'category' ? parsed.value : '',
+  )
 
   const initialCategory =
     parsed?.kind === 'category'
@@ -69,6 +75,11 @@ export function CategoryDetailRoute() {
     queryKey: CATEGORY_LIST_KEY,
   })
 
+  useLayoutEffect(() => {
+    if (!categoryQuery.data) return
+    usePostCategoryResourceStore.getState().hydrateCategory(categoryQuery.data)
+  }, [categoryQuery.data])
+
   if (!parsed) return <DetailEmpty />
 
   if (parsed.kind === 'tag') {
@@ -80,7 +91,9 @@ export function CategoryDetailRoute() {
     return <TagDetail onBack={ctx.onBack} tag={tag} />
   }
 
-  const category = categoryQuery.data
+  const category = (resourceCategory ?? categoryQuery.data) as
+    | CategoryModel
+    | undefined
   if (!category) return <DetailEmpty />
 
   return (

--- a/apps/admin/src/features/categories/components/CategoryDetailRoute.tsx
+++ b/apps/admin/src/features/categories/components/CategoryDetailRoute.tsx
@@ -98,7 +98,7 @@ export function CategoryDetailRoute() {
 
   return (
     <CategoryDetail
-      category={category}
+      categoryId={category.id}
       deleting={ctx.deleting}
       onBack={ctx.onBack}
       onDelete={ctx.onDelete}

--- a/apps/admin/src/features/categories/components/CategoryFormModal.tsx
+++ b/apps/admin/src/features/categories/components/CategoryFormModal.tsx
@@ -7,6 +7,7 @@ import type { CategoryModel } from '~/models/category'
 import type { CategoryFormMode } from '../types/categories'
 
 import { createCategory, updateCategory } from '~/api/categories'
+import { usePostCategoryResourceStore } from '~/data/post-category-resource/store'
 import { useI18n } from '~/i18n'
 import { ModalHeader } from '~/ui/feedback/modal'
 import { present, useModal } from '~/ui/feedback/modal-imperative'
@@ -41,6 +42,7 @@ function CategoryFormModal(props: CategoryFormModalProps) {
     onError: (error: unknown) =>
       toast.error(getErrorMessage(error, t('categories.form.saveFailed'))),
     onSuccess: (category) => {
+      usePostCategoryResourceStore.getState().hydrateCategory(category)
       toast.success(
         props.mode.kind === 'edit'
           ? t('categories.form.updated')

--- a/apps/admin/src/features/categories/components/CategoryRow.tsx
+++ b/apps/admin/src/features/categories/components/CategoryRow.tsx
@@ -1,13 +1,20 @@
 import { FolderOpen, Hash } from 'lucide-react'
 import type { CategoryModel } from '~/models/category'
 
+import { usePostResourceCategory } from '~/data/post-category-resource/hooks'
 import { cn } from '~/utils/cn'
 
 export function CategoryRow(props: {
-  category: CategoryModel
+  categoryId: string
   onSelect: () => void
   selected: boolean
 }) {
+  const category = usePostResourceCategory(props.categoryId) as
+    | CategoryModel
+    | undefined
+
+  if (!category) return null
+
   return (
     <button
       className={cn(
@@ -25,15 +32,15 @@ export function CategoryRow(props: {
       />
       <div className="min-w-0 flex-1">
         <h4 className="truncate text-sm font-medium text-neutral-950 dark:text-neutral-50">
-          {props.category.name}
+          {category.name}
         </h4>
         <p className="mt-0.5 inline-flex max-w-full items-center gap-1 truncate font-mono text-xs text-neutral-400">
           <Hash aria-hidden="true" className="size-3 shrink-0" />
-          {props.category.slug}
+          {category.slug}
         </p>
       </div>
       <span className="text-xs tabular-nums text-neutral-400">
-        {props.category.count}
+        {category.count}
       </span>
     </button>
   )

--- a/apps/admin/src/features/categories/components/PostListRow.tsx
+++ b/apps/admin/src/features/categories/components/PostListRow.tsx
@@ -1,32 +1,36 @@
 import { ExternalLink } from 'lucide-react'
 import { Link } from 'react-router'
-import type { PostModel } from '~/models/post'
 
 import { WEB_URL } from '~/constants/env'
+import { usePostResourcePost } from '~/data/post-category-resource/hooks'
 import { useI18n } from '~/i18n'
 import { relativeTimeFromNow } from '~/utils/time'
 
-export function PostListRow(props: { post: PostModel }) {
+export function PostListRow(props: { postId: string }) {
   const { t } = useI18n()
-  const externalHref = `${WEB_URL}/posts/${props.post.category?.slug ?? props.post.categoryId}/${props.post.slug}`
+  const post = usePostResourcePost(props.postId)
+
+  if (!post) return null
+
+  const externalHref = `${WEB_URL}/posts/${post.category?.slug ?? post.categoryId}/${post.slug}`
 
   return (
     <div className="flex items-center justify-between gap-4 border-b border-neutral-100 px-4 py-3 last:border-b-0 dark:border-neutral-800">
       <Link
         className="min-w-0 flex-1"
         title={t('categories.postRow.editTitle')}
-        to={`/posts/edit?id=${props.post.id}`}
+        to={`/posts/edit?id=${post.id}`}
       >
         <p className="truncate text-sm font-medium text-neutral-950 dark:text-neutral-50">
-          {props.post.title || t('categories.postRow.unnamed')}
+          {post.title || t('categories.postRow.unnamed')}
         </p>
         <div className="mt-1 flex flex-wrap items-center gap-2 text-xs text-neutral-500 dark:text-neutral-400">
-          <time dateTime={props.post.createdAt}>
-            {relativeTimeFromNow(props.post.createdAt)}
+          <time dateTime={post.createdAt}>
+            {relativeTimeFromNow(post.createdAt)}
           </time>
           <span>
             {t('categories.postRow.readSuffix', {
-              count: props.post.readCount ?? 0,
+              count: post.readCount ?? 0,
             })}
           </span>
         </div>

--- a/apps/admin/src/features/categories/components/PostListSection.tsx
+++ b/apps/admin/src/features/categories/components/PostListSection.tsx
@@ -1,5 +1,4 @@
-import type { PostModel } from '~/models/post'
-
+import { usePostResourceList } from '~/data/post-category-resource/hooks'
 import { useI18n } from '~/i18n'
 
 import { PostListRow } from './PostListRow'
@@ -7,19 +6,22 @@ import { PostListRow } from './PostListRow'
 export function PostListSection(props: {
   emptyText: string
   loading: boolean
-  posts: PostModel[]
+  queryKey: readonly unknown[]
   title: string
 }) {
   const { t } = useI18n()
+  const postListResource = usePostResourceList(props.queryKey)
+  const postIds = postListResource.posts.map((post) => post.id)
+
   return (
     <section>
       <div className="mb-3 flex items-center justify-between">
         <h3 className="text-sm font-medium text-neutral-700 dark:text-neutral-300">
           {props.title}
         </h3>
-        {!props.loading && props.posts.length > 0 ? (
+        {!props.loading && postIds.length > 0 ? (
           <span className="text-xs text-neutral-400">
-            {t('categories.section.postsCount', { count: props.posts.length })}
+            {t('categories.section.postsCount', { count: postIds.length })}
           </span>
         ) : null}
       </div>
@@ -32,14 +34,14 @@ export function PostListSection(props: {
             />
           ))}
         </div>
-      ) : props.posts.length === 0 ? (
+      ) : postIds.length === 0 ? (
         <p className="rounded border border-dashed border-neutral-200 bg-neutral-50 px-4 py-6 text-center text-sm text-neutral-500 dark:border-neutral-800 dark:bg-neutral-900/50 dark:text-neutral-400">
           {props.emptyText}
         </p>
       ) : (
         <div className="overflow-hidden rounded border border-neutral-200 dark:border-neutral-800">
-          {props.posts.map((post) => (
-            <PostListRow key={post.id} post={post} />
+          {postIds.map((postId) => (
+            <PostListRow key={postId} postId={postId} />
           ))}
         </div>
       )}

--- a/apps/admin/src/features/categories/components/TagDetail.tsx
+++ b/apps/admin/src/features/categories/components/TagDetail.tsx
@@ -1,13 +1,9 @@
-import { useQuery } from '@tanstack/react-query'
 import { Tag } from 'lucide-react'
-import { useLayoutEffect, useMemo } from 'react'
+import { useMemo } from 'react'
 import type { TagModel } from '~/models/category'
 
 import { getPostsByTag } from '~/api/categories'
-import {
-  serializeResourceListKey,
-  usePostCategoryResourceStore,
-} from '~/data/post-category-resource/store'
+import { usePostListResourceQuery } from '~/data/post-category-resource/queries'
 import { useI18n } from '~/i18n'
 import { adminQueryKeys } from '~/query/keys'
 import { Scroll } from '~/ui/primitives/scroll'
@@ -22,27 +18,20 @@ export function TagDetail(props: { onBack: () => void; tag: TagModel }) {
     () => adminQueryKeys.posts.tagDetail(props.tag.name),
     [props.tag.name],
   )
-  const postsQuery = useQuery({
+  const postsQuery = usePostListResourceQuery({
     enabled: !!props.tag.name,
     queryFn: () => getPostsByTag(props.tag.name),
     queryKey: postsQueryKey,
-  })
-
-  useLayoutEffect(() => {
-    if (!postsQuery.data) return
-    usePostCategoryResourceStore.getState().hydratePostList(
-      serializeResourceListKey(postsQueryKey),
-      {
-        data: postsQuery.data,
-        pagination: {
-          page: 1,
-          size: postsQuery.data.length,
-          total: postsQuery.data.length,
-          totalPages: 1,
-        },
+    toPaginatedResult: (posts) => ({
+      data: posts,
+      pagination: {
+        page: 1,
+        size: posts.length,
+        total: posts.length,
+        totalPages: 1,
       },
-    )
-  }, [postsQuery.data, postsQueryKey])
+    }),
+  })
 
   return (
     <div className="flex h-full min-h-0 flex-col">

--- a/apps/admin/src/features/categories/components/TagDetail.tsx
+++ b/apps/admin/src/features/categories/components/TagDetail.tsx
@@ -1,8 +1,13 @@
 import { useQuery } from '@tanstack/react-query'
 import { Tag } from 'lucide-react'
+import { useLayoutEffect, useMemo } from 'react'
 import type { TagModel } from '~/models/category'
 
 import { getPostsByTag } from '~/api/categories'
+import {
+  serializeResourceListKey,
+  usePostCategoryResourceStore,
+} from '~/data/post-category-resource/store'
 import { useI18n } from '~/i18n'
 import { adminQueryKeys } from '~/query/keys'
 import { Scroll } from '~/ui/primitives/scroll'
@@ -13,11 +18,31 @@ import { PostListSection } from './PostListSection'
 
 export function TagDetail(props: { onBack: () => void; tag: TagModel }) {
   const { t } = useI18n()
+  const postsQueryKey = useMemo(
+    () => adminQueryKeys.posts.tagDetail(props.tag.name),
+    [props.tag.name],
+  )
   const postsQuery = useQuery({
     enabled: !!props.tag.name,
     queryFn: () => getPostsByTag(props.tag.name),
-    queryKey: adminQueryKeys.posts.tagDetail(props.tag.name),
+    queryKey: postsQueryKey,
   })
+
+  useLayoutEffect(() => {
+    if (!postsQuery.data) return
+    usePostCategoryResourceStore.getState().hydratePostList(
+      serializeResourceListKey(postsQueryKey),
+      {
+        data: postsQuery.data,
+        pagination: {
+          page: 1,
+          size: postsQuery.data.length,
+          total: postsQuery.data.length,
+          totalPages: 1,
+        },
+      },
+    )
+  }, [postsQuery.data, postsQueryKey])
 
   return (
     <div className="flex h-full min-h-0 flex-col">
@@ -36,7 +61,7 @@ export function TagDetail(props: { onBack: () => void; tag: TagModel }) {
         <PostListSection
           emptyText={t('categories.detail.postsByTagEmpty')}
           loading={postsQuery.isLoading}
-          posts={postsQuery.data ?? []}
+          queryKey={postsQueryKey}
           title={t('categories.detail.postsByTagTitle', {
             name: props.tag.name,
           })}

--- a/apps/admin/src/features/categories/hooks/use-categories-list.ts
+++ b/apps/admin/src/features/categories/hooks/use-categories-list.ts
@@ -1,9 +1,14 @@
 import { useQuery } from '@tanstack/react-query'
+import { useLayoutEffect } from 'react'
 
 import { getCategories, getTags } from '~/api/categories'
+import { usePostResourceCategories } from '~/data/post-category-resource/hooks'
+import { usePostCategoryResourceStore } from '~/data/post-category-resource/store'
+import type { CategoryModel } from '~/models/category'
 import { adminQueryKeys } from '~/query/keys'
 
 export function useCategoriesList() {
+  const resourceCategories = usePostResourceCategories()
   const categoriesQuery = useQuery({
     queryFn: () => getCategories({ type: 'Category' }),
     queryKey: adminQueryKeys.categories.list(),
@@ -13,10 +18,26 @@ export function useCategoriesList() {
     queryKey: adminQueryKeys.categories.tags(),
   })
 
+  useLayoutEffect(() => {
+    if (!categoriesQuery.data) return
+    usePostCategoryResourceStore
+      .getState()
+      .hydrateCategories(categoriesQuery.data)
+  }, [categoriesQuery.data])
+
   return {
-    categories: categoriesQuery.data ?? [],
+    categories: resourceCategories.filter(isCategoryModel),
     categoriesQuery,
     tags: tagsQuery.data ?? [],
     tagsQuery,
   }
+}
+
+function isCategoryModel(category: unknown): category is CategoryModel {
+  return (
+    typeof category === 'object' &&
+    category !== null &&
+    'count' in category &&
+    'createdAt' in category
+  )
 }

--- a/apps/admin/src/features/categories/hooks/use-categories-list.ts
+++ b/apps/admin/src/features/categories/hooks/use-categories-list.ts
@@ -1,15 +1,14 @@
 import { useQuery } from '@tanstack/react-query'
-import { useLayoutEffect } from 'react'
 
 import { getCategories, getTags } from '~/api/categories'
 import { usePostResourceCategories } from '~/data/post-category-resource/hooks'
-import { usePostCategoryResourceStore } from '~/data/post-category-resource/store'
+import { usePostCategoriesResourceQuery } from '~/data/post-category-resource/queries'
 import type { CategoryModel } from '~/models/category'
 import { adminQueryKeys } from '~/query/keys'
 
 export function useCategoriesList() {
   const resourceCategories = usePostResourceCategories()
-  const categoriesQuery = useQuery({
+  const categoriesQuery = usePostCategoriesResourceQuery({
     queryFn: () => getCategories({ type: 'Category' }),
     queryKey: adminQueryKeys.categories.list(),
   })
@@ -17,13 +16,6 @@ export function useCategoriesList() {
     queryFn: getTags,
     queryKey: adminQueryKeys.categories.tags(),
   })
-
-  useLayoutEffect(() => {
-    if (!categoriesQuery.data) return
-    usePostCategoryResourceStore
-      .getState()
-      .hydrateCategories(categoriesQuery.data)
-  }, [categoriesQuery.data])
 
   return {
     categories: resourceCategories.filter(isCategoryModel),

--- a/apps/admin/src/features/categories/hooks/use-category-mutations.ts
+++ b/apps/admin/src/features/categories/hooks/use-category-mutations.ts
@@ -3,6 +3,7 @@ import { useCallback } from 'react'
 import { toast } from 'sonner'
 
 import { deleteCategory } from '~/api/categories'
+import { usePostCategoryResourceStore } from '~/data/post-category-resource/store'
 import { useI18n } from '~/i18n'
 import { adminQueryKeys } from '~/query/keys'
 
@@ -28,7 +29,8 @@ export function useCategoryMutations(
     mutationFn: deleteCategory,
     onError: (error: unknown) =>
       toast.error(getErrorMessage(error, t('categories.toast.deleteFailed'))),
-    onSuccess: async () => {
+    onSuccess: async (_, id) => {
+      usePostCategoryResourceStore.getState().removeCategory(id)
       toast.success(t('categories.toast.deleted'))
       options.onAfterDeleteSuccess?.()
       await invalidateCategories()

--- a/apps/admin/src/features/posts/hooks/use-post-mutations.ts
+++ b/apps/admin/src/features/posts/hooks/use-post-mutations.ts
@@ -2,10 +2,18 @@ import { useMutation, useQueryClient } from '@tanstack/react-query'
 import { toast } from 'sonner'
 
 import { deletePost, patchPost } from '~/api/posts'
+import { PostCategoryResourceTransaction } from '~/data/post-category-resource/transaction'
 import { useI18n } from '~/i18n'
+import type { PostModel } from '~/models/post'
 
 import { postsQueryKey } from '../constants'
 import { getErrorMessage } from '../utils/errors'
+
+interface BatchDeleteResult {
+  failedCount: number
+  successfulIds: string[]
+  successCount: number
+}
 
 interface UsePostMutationsOptions {
   onBatchSuccess?: () => void
@@ -20,70 +28,120 @@ export function usePostMutations(options: UsePostMutationsOptions = {}) {
   }
 
   const publishMutation = useMutation({
-    mutationFn: (payload: { id: string; isPublished: boolean }) =>
-      patchPost(payload.id, { isPublished: payload.isPublished }),
-    onSuccess: invalidatePosts,
+    mutationFn: async (payload: { id: string; isPublished: boolean }) => {
+      const tx = new PostCategoryResourceTransaction<PostModel>(
+        `publishPost(${payload.id})`,
+      ).patchPost(payload.id, {
+        isPublished: payload.isPublished,
+      })
+      tx.request = () =>
+        patchPost(payload.id, { isPublished: payload.isPublished })
+      tx.onSuccess = async (post: PostModel) => {
+        tx.commitPost(post.id, post)
+        await invalidatePosts()
+      }
+      return tx.commit()
+    },
   })
 
   const categoryMutation = useMutation({
-    mutationFn: (payload: { categoryId: string; id: string }) =>
-      patchPost(payload.id, { categoryId: payload.categoryId }),
-    onError: (error: unknown) =>
-      toast.error(
-        getErrorMessage(error, t('posts.toast.categoryUpdateFailed')),
-      ),
-    onSuccess: invalidatePosts,
+    mutationFn: async (payload: { categoryId: string; id: string }) => {
+      const tx = new PostCategoryResourceTransaction<PostModel>(
+        `updatePostCategory(${payload.id})`,
+      ).patchPost(payload.id, {
+        categoryId: payload.categoryId,
+      })
+      tx.request = () =>
+        patchPost(payload.id, { categoryId: payload.categoryId })
+      tx.onSuccess = async (post: PostModel) => {
+        tx.commitPost(post.id, post)
+        await invalidatePosts()
+      }
+      tx.onError = (error) => {
+        toast.error(
+          getErrorMessage(error, t('posts.toast.categoryUpdateFailed')),
+        )
+      }
+      return tx.commit()
+    },
   })
 
   const deleteMutation = useMutation({
-    mutationFn: deletePost,
-    onSuccess: async () => {
-      toast.success(t('posts.toast.deleted'))
-      await invalidatePosts()
+    mutationFn: async (id: string) => {
+      const tx = new PostCategoryResourceTransaction<void>(`deletePost(${id})`)
+        .deletePost(id)
+      tx.request = () => deletePost(id)
+      tx.onSuccess = async () => {
+        tx.commitAll()
+        toast.success(t('posts.toast.deleted'))
+        await invalidatePosts()
+      }
+      return tx.commit()
     },
   })
 
   const batchDeleteMutation = useMutation({
     mutationFn: async (ids: string[]) => {
-      const results = await Promise.allSettled(ids.map((id) => deletePost(id)))
-      const successfulIds = ids.filter(
-        (_, index) => results[index].status === 'fulfilled',
+      const tx = new PostCategoryResourceTransaction<BatchDeleteResult>(
+        `batchDeletePosts(${ids.join(',')})`,
       )
+      ids.forEach((id) => tx.deletePost(id))
+      tx.request = async () => {
+        const results = await Promise.allSettled(ids.map((id) => deletePost(id)))
+        const successfulIds = ids.filter(
+          (_, index) => results[index].status === 'fulfilled',
+        )
 
-      return {
-        failedCount: ids.length - successfulIds.length,
-        successfulIds,
-        successCount: successfulIds.length,
+        return {
+          failedCount: ids.length - successfulIds.length,
+          successfulIds,
+          successCount: successfulIds.length,
+        }
       }
-    },
-    onError: (error: unknown) =>
-      toast.error(getErrorMessage(error, t('posts.toast.batchDeleteFailed'))),
-    onSuccess: async ({ failedCount, successCount }) => {
-      options.onBatchSuccess?.()
-      if (failedCount > 0) {
-        toast.warning(
-          t('posts.toast.batchDeletePartial', {
-            failed: failedCount,
-            success: successCount,
-          }),
-        )
-      } else {
-        toast.success(
-          t('posts.toast.batchDeleteSucceeded', { count: successCount }),
-        )
+      tx.onSuccess = async ({ failedCount, successfulIds, successCount }) => {
+        const successfulIdSet = new Set(successfulIds)
+        tx.commitPosts(successfulIds)
+        tx.rollbackPosts(ids.filter((id) => !successfulIdSet.has(id)))
+        options.onBatchSuccess?.()
+        if (failedCount > 0) {
+          toast.warning(
+            t('posts.toast.batchDeletePartial', {
+              failed: failedCount,
+              success: successCount,
+            }),
+          )
+        } else {
+          toast.success(
+            t('posts.toast.batchDeleteSucceeded', { count: successCount }),
+          )
+        }
+        await invalidatePosts()
       }
-      await invalidatePosts()
+      tx.onError = (error) => {
+        toast.error(getErrorMessage(error, t('posts.toast.batchDeleteFailed')))
+      }
+      return tx.commit()
     },
   })
 
   const pinMutation = useMutation({
-    mutationFn: (payload: { id: string; isPinned: boolean }) =>
-      patchPost(payload.id, {
-        pinAt: payload.isPinned ? new Date().toISOString() : null,
-      }),
-    onError: (error: unknown) =>
-      toast.error(getErrorMessage(error, t('posts.toast.pinFailed'))),
-    onSuccess: invalidatePosts,
+    mutationFn: async (payload: { id: string; isPinned: boolean }) => {
+      const pinAt = payload.isPinned ? new Date().toISOString() : null
+      const tx = new PostCategoryResourceTransaction<PostModel>(
+        `pinPost(${payload.id})`,
+      ).patchPost(payload.id, {
+        pinAt,
+      })
+      tx.request = () => patchPost(payload.id, { pinAt })
+      tx.onSuccess = async (post: PostModel) => {
+        tx.commitPost(post.id, post)
+        await invalidatePosts()
+      }
+      tx.onError = (error) => {
+        toast.error(getErrorMessage(error, t('posts.toast.pinFailed')))
+      }
+      return tx.commit()
+    },
   })
 
   return {

--- a/apps/admin/src/features/posts/hooks/use-posts-list.ts
+++ b/apps/admin/src/features/posts/hooks/use-posts-list.ts
@@ -1,5 +1,4 @@
-import { useQuery } from '@tanstack/react-query'
-import { useEffect, useLayoutEffect, useMemo, useState } from 'react'
+import { useEffect, useMemo, useState } from 'react'
 
 import { getCategories } from '~/api/categories'
 import { getPosts, searchPosts } from '~/api/posts'
@@ -8,8 +7,11 @@ import {
   usePostResourceList,
 } from '~/data/post-category-resource/hooks'
 import {
+  usePostCategoriesResourceQuery,
+  usePostListResourceQuery,
+} from '~/data/post-category-resource/queries'
+import {
   serializeResourceListKey,
-  usePostCategoryResourceStore,
 } from '~/data/post-category-resource/store'
 import { useUrlListState } from '~/features/_shared/hooks/use-url-list-state'
 import { adminQueryKeys } from '~/query/keys'
@@ -62,7 +64,7 @@ export function usePostsList() {
     setKeywordInput(state.keyword)
   }, [state.keyword])
 
-  const categoriesQuery = useQuery({
+  const categoriesQuery = usePostCategoriesResourceQuery({
     queryFn: () => getCategories({ type: 'Category' }),
     queryKey: adminQueryKeys.categories.postFilter(),
   })
@@ -88,8 +90,7 @@ export function usePostsList() {
   const postListResource = usePostResourceList(postsListQueryKey)
   const categories = usePostResourceCategories()
 
-  const postsQuery = useQuery({
-    placeholderData: (previous) => previous,
+  const postsQuery = usePostListResourceQuery({
     queryFn: () =>
       state.keyword
         ? searchPosts({
@@ -109,19 +110,6 @@ export function usePostsList() {
           }),
     queryKey: postsListQueryKey,
   })
-
-  useLayoutEffect(() => {
-    if (!categoriesQuery.data) return
-    getPostResourceListStoreActions().hydrateCategories(categoriesQuery.data)
-  }, [categoriesQuery.data])
-
-  useLayoutEffect(() => {
-    if (!postsQuery.data) return
-    getPostResourceListStoreActions().hydratePostList(
-      serializeResourceListKey(postsListQueryKey),
-      postsQuery.data,
-    )
-  }, [postsQuery.data, postsListQueryKey])
 
   return {
     categories,
@@ -158,8 +146,4 @@ export function usePostsList() {
         page: 1,
       })),
   }
-}
-
-function getPostResourceListStoreActions() {
-  return usePostCategoryResourceStore.getState()
 }

--- a/apps/admin/src/features/posts/hooks/use-posts-list.ts
+++ b/apps/admin/src/features/posts/hooks/use-posts-list.ts
@@ -1,8 +1,16 @@
 import { useQuery } from '@tanstack/react-query'
-import { useEffect, useMemo, useState } from 'react'
+import { useEffect, useLayoutEffect, useMemo, useState } from 'react'
 
 import { getCategories } from '~/api/categories'
 import { getPosts, searchPosts } from '~/api/posts'
+import {
+  usePostResourceCategories,
+  usePostResourceList,
+} from '~/data/post-category-resource/hooks'
+import {
+  serializeResourceListKey,
+  usePostCategoryResourceStore,
+} from '~/data/post-category-resource/store'
 import { useUrlListState } from '~/features/_shared/hooks/use-url-list-state'
 import { adminQueryKeys } from '~/query/keys'
 
@@ -59,6 +67,27 @@ export function usePostsList() {
     queryKey: adminQueryKeys.categories.postFilter(),
   })
 
+  const postsListQueryKey = useMemo(
+    () =>
+      adminQueryKeys.posts.list({
+        categoryId: state.categoryId,
+        keyword: state.keyword,
+        page: state.page,
+        size: postsPageSize,
+        sortKey: state.sortKey,
+        sortOrder: state.sortOrder,
+      }),
+    [
+      state.categoryId,
+      state.keyword,
+      state.page,
+      state.sortKey,
+      state.sortOrder,
+    ],
+  )
+  const postListResource = usePostResourceList(postsListQueryKey)
+  const categories = usePostResourceCategories()
+
   const postsQuery = useQuery({
     placeholderData: (previous) => previous,
     queryFn: () =>
@@ -78,18 +107,24 @@ export function usePostsList() {
             sort_by: state.sortKey,
             sort_order: state.sortOrder,
           }),
-    queryKey: adminQueryKeys.posts.list({
-      categoryId: state.categoryId,
-      keyword: state.keyword,
-      page: state.page,
-      size: postsPageSize,
-      sortKey: state.sortKey,
-      sortOrder: state.sortOrder,
-    }),
+    queryKey: postsListQueryKey,
   })
 
+  useLayoutEffect(() => {
+    if (!categoriesQuery.data) return
+    getPostResourceListStoreActions().hydrateCategories(categoriesQuery.data)
+  }, [categoriesQuery.data])
+
+  useLayoutEffect(() => {
+    if (!postsQuery.data) return
+    getPostResourceListStoreActions().hydratePostList(
+      serializeResourceListKey(postsListQueryKey),
+      postsQuery.data,
+    )
+  }, [postsQuery.data, postsListQueryKey])
+
   return {
-    categories: categoriesQuery.data ?? [],
+    categories,
     categoriesQuery,
     categoryId: state.categoryId,
     clearSearch: () => {
@@ -99,8 +134,8 @@ export function usePostsList() {
     keyword: state.keyword,
     keywordInput,
     page: state.page,
-    pagination: postsQuery.data?.pagination,
-    posts: postsQuery.data?.data ?? [],
+    pagination: postListResource.pagination,
+    posts: postListResource.posts,
     postsQuery,
     rootQueryKey: postsQueryKey,
     setCategoryId: (categoryId: string) =>
@@ -123,4 +158,8 @@ export function usePostsList() {
         page: 1,
       })),
   }
+}
+
+function getPostResourceListStoreActions() {
+  return usePostCategoryResourceStore.getState()
 }

--- a/apps/admin/src/features/write/components/WriteRouteViewsContent.tsx
+++ b/apps/admin/src/features/write/components/WriteRouteViewsContent.tsx
@@ -394,7 +394,6 @@ function WritePage(props: { kind: WriteKind }) {
     () => adminQueryKeys.posts.relatedOptions('write'),
     [],
   )
-  const relatedPostsResource = usePostResourceList(relatedPostsQueryKey)
 
   const categoriesQuery = useQuery({
     enabled: props.kind === 'post',
@@ -475,8 +474,6 @@ function WritePage(props: { kind: WriteKind }) {
       : emptyCategories
   const tags = tagsQuery.data ?? []
   const topics = topicsQuery.data?.data ?? emptyTopics
-  const relatedPosts =
-    props.kind === 'post' ? relatedPostsResource.posts : []
   const firstCategoryId = categories[0]?.id ?? ''
   const activeCategory =
     categories.find((category) => category.id === state.categoryId) ??
@@ -1233,9 +1230,8 @@ function WritePage(props: { kind: WriteKind }) {
                 postFields={
                   props.kind === 'post' ? (
                     <PostFields
-                      categories={categories}
                       currentPostId={id}
-                      relatedPosts={relatedPosts}
+                      relatedPostsQueryKey={relatedPostsQueryKey}
                       state={state}
                       tags={tags}
                       updateField={updateField}
@@ -2149,9 +2145,8 @@ function getSharedSuffixLength(left: string, right: string) {
 }
 
 function PostFields(props: {
-  categories: CategoryModel[]
   currentPostId: string
-  relatedPosts: PostModel[]
+  relatedPostsQueryKey: readonly unknown[]
   state: WriteFormState
   tags: Array<{ count: number; name: string }>
   updateField: <TKey extends keyof WriteFormState>(
@@ -2160,9 +2155,11 @@ function PostFields(props: {
   ) => void
 }) {
   const { t } = useI18n()
+  const categories = usePostResourceCategories().filter(isCategoryModel)
+  const relatedPosts = usePostResourceList(props.relatedPostsQueryKey).posts
   const selectedTags = splitCommaList(props.state.tags)
   const selectedRelatedIds = splitCommaList(props.state.relatedId)
-  const visibleRelatedPosts = props.relatedPosts.filter(
+  const visibleRelatedPosts = relatedPosts.filter(
     (post) => post.id !== props.currentPostId,
   )
   const toggleTag = (tag: string) => {
@@ -2184,7 +2181,7 @@ function PostFields(props: {
             onValueChange={(categoryId) =>
               props.updateField('categoryId', categoryId)
             }
-            options={props.categories.map((category) => ({
+            options={categories.map((category) => ({
               label: category.name,
               value: category.id,
             }))}

--- a/apps/admin/src/features/write/components/WriteRouteViewsContent.tsx
+++ b/apps/admin/src/features/write/components/WriteRouteViewsContent.tsx
@@ -28,6 +28,7 @@ import {
   lazy,
   Suspense,
   useEffect,
+  useLayoutEffect,
   useMemo,
   useRef,
   useState,
@@ -77,6 +78,16 @@ import { createPost, getPostById, getPosts, updatePost } from '~/api/posts'
 import { callBuiltInFunction } from '~/api/system'
 import { getTopics } from '~/api/topics'
 import { API_URL, WEB_URL } from '~/constants/env'
+import {
+  usePostResourceCategories,
+  usePostResourceList,
+  usePostResourcePost,
+} from '~/data/post-category-resource/hooks'
+import {
+  serializeResourceListKey,
+  usePostCategoryResourceStore,
+} from '~/data/post-category-resource/store'
+import { PostCategoryResourceTransaction } from '~/data/post-category-resource/transaction'
 import {
   APP_SHELL_HEADER_HEIGHT_CLASS,
   APP_SHELL_HEADER_HEIGHT_VALUE,
@@ -377,6 +388,13 @@ function WritePage(props: { kind: WriteKind }) {
   const latestDraftFingerprintRef = useRef('')
   const [lastSavedFingerprint, setLastSavedFingerprint] = useState('')
   const draftRefType = draftRefTypeByKind[props.kind]
+  const postResource = usePostResourcePost(props.kind === 'post' ? id : '')
+  const postResourceCategories = usePostResourceCategories()
+  const relatedPostsQueryKey = useMemo(
+    () => adminQueryKeys.posts.relatedOptions('write'),
+    [],
+  )
+  const relatedPostsResource = usePostResourceList(relatedPostsQueryKey)
 
   const categoriesQuery = useQuery({
     enabled: props.kind === 'post',
@@ -402,7 +420,7 @@ function WritePage(props: { kind: WriteKind }) {
         sort_by: 'createdAt',
         sort_order: 'desc',
       }),
-    queryKey: adminQueryKeys.posts.relatedOptions('write'),
+    queryKey: relatedPostsQueryKey,
   })
   const detailQuery = useQuery<WriteModel>({
     enabled: isEditing,
@@ -425,10 +443,40 @@ function WritePage(props: { kind: WriteKind }) {
     queryKey: adminQueryKeys.drafts.newDraft(draftRefType),
   })
 
-  const categories = categoriesQuery.data ?? emptyCategories
+  useLayoutEffect(() => {
+    if (!categoriesQuery.data) return
+    usePostCategoryResourceStore
+      .getState()
+      .hydrateCategories(categoriesQuery.data)
+  }, [categoriesQuery.data])
+
+  useLayoutEffect(() => {
+    if (props.kind !== 'post' || !detailQuery.data) return
+    usePostCategoryResourceStore
+      .getState()
+      .hydratePostDetail(detailQuery.data as PostModel)
+  }, [detailQuery.data, props.kind])
+
+  useLayoutEffect(() => {
+    if (!relatedPostsQuery.data) return
+    usePostCategoryResourceStore
+      .getState()
+      .hydratePostList(
+        serializeResourceListKey(relatedPostsQueryKey),
+        relatedPostsQuery.data,
+      )
+  }, [relatedPostsQuery.data, relatedPostsQueryKey])
+
+  const detailModel =
+    props.kind === 'post' ? postResource ?? detailQuery.data : detailQuery.data
+  const categories =
+    props.kind === 'post'
+      ? postResourceCategories.filter(isCategoryModel)
+      : emptyCategories
   const tags = tagsQuery.data ?? []
   const topics = topicsQuery.data?.data ?? emptyTopics
-  const relatedPosts = relatedPostsQuery.data?.data ?? []
+  const relatedPosts =
+    props.kind === 'post' ? relatedPostsResource.posts : []
   const firstCategoryId = categories[0]?.id ?? ''
   const activeCategory =
     categories.find((category) => category.id === state.categoryId) ??
@@ -441,21 +489,21 @@ function WritePage(props: { kind: WriteKind }) {
     )[0]
   }, [newDraftsQuery.data, refDraftQuery.data])
   const publishedContent = useMemo(
-    () => (detailQuery.data ? getPublishedContent(detailQuery.data) : null),
-    [detailQuery.data],
+    () => (detailModel ? getPublishedContent(detailModel) : null),
+    [detailModel],
   )
   const defaultNoteTitle = useMemo(() => {
-    if (props.kind === 'note' && detailQuery.data) {
+    if (props.kind === 'note' && detailModel) {
       return getDefaultNoteTitle(
-        new Date((detailQuery.data as NoteModel).createdAt),
+        new Date((detailModel as NoteModel).createdAt),
       )
     }
 
     return getDefaultNoteTitle()
-  }, [detailQuery.data, props.kind])
+  }, [detailModel, props.kind])
   const notePublicPath =
     props.kind === 'note'
-      ? buildNotePublicPath(state, detailQuery.data as NoteModel | undefined)
+      ? buildNotePublicPath(state, detailModel as NoteModel | undefined)
       : ''
   const postPublicPath =
     props.kind === 'post' ? buildPostPublicPath(state, activeCategory) : ''
@@ -583,7 +631,7 @@ function WritePage(props: { kind: WriteKind }) {
   }, [location.hash, location.pathname, location.search, navigate])
 
   useEffect(() => {
-    if (!detailQuery.data) {
+    if (!detailModel) {
       if (props.kind !== 'post' || !firstCategoryId) return
       setState((previous) =>
         previous.categoryId
@@ -597,9 +645,9 @@ function WritePage(props: { kind: WriteKind }) {
     }
 
     if (!routeDraftId) {
-      setState(fromModel(props.kind, detailQuery.data))
+      setState(fromModel(props.kind, detailModel))
     }
-  }, [detailQuery.data, firstCategoryId, props.kind, routeDraftId])
+  }, [detailModel, firstCategoryId, props.kind, routeDraftId])
 
   useEffect(() => {
     if (refDraftQuery.data && !draftId) {
@@ -609,11 +657,11 @@ function WritePage(props: { kind: WriteKind }) {
 
   const recoveryHintDraft = useMemo(() => {
     const draft = refDraftQuery.data
-    const published = detailQuery.data
+    const published = detailModel
     if (!isEditing || routeDraftId || !draft || !published) return null
     if (!isDraftNewerThanPublished(draft, published)) return null
     return draft
-  }, [detailQuery.data, isEditing, refDraftQuery.data, routeDraftId])
+  }, [detailModel, isEditing, refDraftQuery.data, routeDraftId])
 
   const openRecoveryDialog = (draft: DraftModel) => {
     if (!publishedContent) return
@@ -678,6 +726,11 @@ function WritePage(props: { kind: WriteKind }) {
     onError: (error: unknown) =>
       toast.error(getErrorMessage(error, t('write.toast.saveFailed'))),
     onSuccess: async (result) => {
+      if (props.kind === 'post') {
+        usePostCategoryResourceStore
+          .getState()
+          .hydratePostDetail(result as PostModel)
+      }
       draftDirtyRef.current = false
       lastSavedDraftFingerprintRef.current = latestDraftFingerprintRef.current
       setLastSavedFingerprint(latestDraftFingerprintRef.current)
@@ -872,8 +925,8 @@ function WritePage(props: { kind: WriteKind }) {
     isEditing,
     isPendingDraftSave: draftMutation.isPending,
     latestDraft,
-    publishedUpdatedAt: detailQuery.data
-      ? getPublishedContent(detailQuery.data).updatedAt
+    publishedUpdatedAt: detailModel
+      ? getPublishedContent(detailModel).updatedAt
       : undefined,
   })
 
@@ -3542,29 +3595,7 @@ function saveWrite(
   draftId?: string,
 ): Promise<WriteModel> {
   if (kind === 'post') {
-    const data = {
-      categoryId: state.categoryId,
-      content: state.contentFormat === 'lexical' ? state.content : undefined,
-      contentFormat: state.contentFormat,
-      copyright: state.copyright,
-      draftId,
-      images: buildWriteImages(state),
-      isPublished: state.isPublished,
-      meta: state.meta,
-      pin: state.pin ? new Date().toISOString() : null,
-      pinOrder: state.pin ? Number(state.pinOrder) || 1 : null,
-      relatedId: splitCommaList(state.relatedId),
-      slug: state.slug,
-      summary: state.summary || null,
-      tags: state.tags
-        .split(',')
-        .map((tag) => tag.trim())
-        .filter(Boolean),
-      text: state.text,
-      title: state.title,
-    }
-
-    return id ? updatePost(id, data) : createPost(data)
+    return savePostWrite(id, state, draftId)
   }
 
   if (kind === 'note') {
@@ -3607,6 +3638,69 @@ function saveWrite(
   }
 
   return id ? updatePage(id, data) : createPage(data)
+}
+
+function savePostWrite(
+  id: string,
+  state: WriteFormState,
+  draftId?: string,
+): Promise<PostModel> {
+  const data = buildPostWriteData(state, draftId)
+  if (!id) return createPost(data)
+
+  const tx = new PostCategoryResourceTransaction<PostModel>(
+    `savePost(${id})`,
+  ).patchPost(id, toOptimisticPostPatch(data))
+  tx.request = () => updatePost(id, data)
+  tx.onSuccess = (post) => {
+    tx.commitPost(post.id, post)
+  }
+  return tx.commit()
+}
+
+function buildPostWriteData(state: WriteFormState, draftId?: string) {
+  return {
+    categoryId: state.categoryId,
+    content: state.contentFormat === 'lexical' ? state.content : undefined,
+    contentFormat: state.contentFormat,
+    copyright: state.copyright,
+    draftId,
+    images: buildWriteImages(state),
+    isPublished: state.isPublished,
+    meta: state.meta,
+    pin: state.pin ? new Date().toISOString() : null,
+    pinOrder: state.pin ? Number(state.pinOrder) || 1 : null,
+    relatedId: splitCommaList(state.relatedId),
+    slug: state.slug,
+    summary: state.summary || null,
+    tags: state.tags
+      .split(',')
+      .map((tag) => tag.trim())
+      .filter(Boolean),
+    text: state.text,
+    title: state.title,
+  }
+}
+
+function toOptimisticPostPatch(
+  data: ReturnType<typeof buildPostWriteData>,
+): Partial<PostModel> {
+  return {
+    categoryId: data.categoryId,
+    content: data.content,
+    contentFormat: data.contentFormat,
+    copyright: data.copyright,
+    images: data.images,
+    isPublished: data.isPublished,
+    meta: data.meta,
+    pinAt: data.pin,
+    pinOrder: data.pinOrder,
+    slug: data.slug,
+    summary: data.summary,
+    tags: data.tags,
+    text: data.text,
+    title: data.title,
+  }
 }
 
 function toDraftData(
@@ -3859,6 +3953,15 @@ function validateState(
   }
 
   return null
+}
+
+function isCategoryModel(category: unknown): category is CategoryModel {
+  return (
+    typeof category === 'object' &&
+    category !== null &&
+    'count' in category &&
+    'createdAt' in category
+  )
 }
 
 function getWriteAgentMetaSchema(kind: WriteKind) {

--- a/apps/admin/src/features/write/components/WriteRouteViewsContent.tsx
+++ b/apps/admin/src/features/write/components/WriteRouteViewsContent.tsx
@@ -28,7 +28,6 @@ import {
   lazy,
   Suspense,
   useEffect,
-  useLayoutEffect,
   useMemo,
   useRef,
   useState,
@@ -84,7 +83,11 @@ import {
   usePostResourcePost,
 } from '~/data/post-category-resource/hooks'
 import {
-  serializeResourceListKey,
+  usePostCategoriesResourceQuery,
+  usePostDetailResourceQuery,
+  usePostListResourceQuery,
+} from '~/data/post-category-resource/queries'
+import {
   usePostCategoryResourceStore,
 } from '~/data/post-category-resource/store'
 import { PostCategoryResourceTransaction } from '~/data/post-category-resource/transaction'
@@ -395,7 +398,7 @@ function WritePage(props: { kind: WriteKind }) {
     [],
   )
 
-  const categoriesQuery = useQuery({
+  usePostCategoriesResourceQuery({
     enabled: props.kind === 'post',
     queryFn: () => getCategories({ type: 'Category' }),
     queryKey: adminQueryKeys.categories.list(),
@@ -410,7 +413,7 @@ function WritePage(props: { kind: WriteKind }) {
     queryFn: getTags,
     queryKey: adminQueryKeys.categories.tags(),
   })
-  const relatedPostsQuery = useQuery({
+  usePostListResourceQuery({
     enabled: props.kind === 'post',
     queryFn: () =>
       getPosts({
@@ -421,11 +424,18 @@ function WritePage(props: { kind: WriteKind }) {
       }),
     queryKey: relatedPostsQueryKey,
   })
-  const detailQuery = useQuery<WriteModel>({
-    enabled: isEditing,
+  const postDetailQuery = usePostDetailResourceQuery({
+    enabled: isEditing && props.kind === 'post',
+    queryFn: () => getPostById(id),
+    queryKey: adminQueryKeys.write.detail({ id, kind: props.kind }),
+  })
+  const nonPostDetailQuery = useQuery<WriteModel>({
+    enabled: isEditing && props.kind !== 'post',
     queryFn: () => getWriteDetail(props.kind, id),
     queryKey: adminQueryKeys.write.detail({ id, kind: props.kind }),
   })
+  const detailQuery =
+    props.kind === 'post' ? postDetailQuery : nonPostDetailQuery
   const refDraftQuery = useQuery({
     enabled: isEditing,
     queryFn: () => getDraftByRef(draftRefType, id),
@@ -442,32 +452,8 @@ function WritePage(props: { kind: WriteKind }) {
     queryKey: adminQueryKeys.drafts.newDraft(draftRefType),
   })
 
-  useLayoutEffect(() => {
-    if (!categoriesQuery.data) return
-    usePostCategoryResourceStore
-      .getState()
-      .hydrateCategories(categoriesQuery.data)
-  }, [categoriesQuery.data])
-
-  useLayoutEffect(() => {
-    if (props.kind !== 'post' || !detailQuery.data) return
-    usePostCategoryResourceStore
-      .getState()
-      .hydratePostDetail(detailQuery.data as PostModel)
-  }, [detailQuery.data, props.kind])
-
-  useLayoutEffect(() => {
-    if (!relatedPostsQuery.data) return
-    usePostCategoryResourceStore
-      .getState()
-      .hydratePostList(
-        serializeResourceListKey(relatedPostsQueryKey),
-        relatedPostsQuery.data,
-      )
-  }, [relatedPostsQuery.data, relatedPostsQueryKey])
-
   const detailModel =
-    props.kind === 'post' ? postResource ?? detailQuery.data : detailQuery.data
+    props.kind === 'post' ? postResource : nonPostDetailQuery.data
   const categories =
     props.kind === 'post'
       ? postResourceCategories.filter(isCategoryModel)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -278,6 +278,9 @@ importers:
       fuse.js:
         specifier: 7.1.0
         version: 7.1.0
+      immer:
+        specifier: ^11.1.8
+        version: 11.1.8
       jotai:
         specifier: 2.20.0
         version: 2.20.0(@babel/core@7.29.0)(@babel/template@7.29.7)(@types/react@19.2.14)(react@19.2.4)


### PR DESCRIPTION
## Summary
- Add a normalized post/category resource store POC for admin UI state, including relation indexes and query-keyed list indexes.
- Hydrate React Query transport results into the resource store while keeping business entities out of Query data; resource query hooks return only receipts/status.
- Add a class-based optimistic transaction lifecycle for post mutations, including request success commit and error rollback.
- Wire the resource store into real category management, category detail post lists, tag detail post lists, and the post write/edit page.
- Use the transaction engine for post edit saves so list/detail projections receive optimistic updates and rollback on request failure.
- Refactor resource-backed view components to self-consume store data by id/query key instead of receiving entity arrays through props.

## Verification
- rtk pnpm -C apps/admin run typecheck
- rtk pnpm -C apps/admin exec vitest run src/data/post-category-resource/store.test.ts (9 tests; Vitest still prints the existing close-timeout warning)
- rtk proxy git diff --check -- apps/admin/src/data/post-category-resource apps/admin/src/features/posts apps/admin/src/features/categories apps/admin/src/features/write/components/WriteRouteViewsContent.tsx
- rtk pnpm -C apps/admin run build (passes with existing Vite/Rolldown warnings)

## Known limitation
- rtk pnpm -C apps/admin run lint could not run because the current worktree does not expose the oxlint binary: sh: oxlint: command not found.