### PR TITLE
fix(core): security and performance hardening across business modules

### DIFF
--- a/apps/core/src/common/adapters/fastify.adapter.ts
+++ b/apps/core/src/common/adapters/fastify.adapter.ts
@@ -19,8 +19,22 @@ function logWarn(desc: string, req: FastifyRequest, _context: string) {
   )
 }
 
+// Trust model: the deployment sits behind exactly one reverse proxy hop
+// (Dokploy / Cloudflare). `trustProxy: true` would trust the entire
+// `X-Forwarded-For` chain and let a client spoof its IP by prepending a
+// segment. We instead trust a fixed number of hops (default 1 — the immediate
+// proxy) so Fastify's `request.ip` resolves to the proxy-attested client IP.
+// Override with TRUST_PROXY (an integer hop count, or a comma-separated list
+// of trusted proxy IPs/CIDRs) only if the deployment has more proxy layers.
+const resolveTrustProxy = (): number | string[] => {
+  const raw = process.env.TRUST_PROXY?.trim()
+  if (!raw) return 1
+  if (/^\d+$/.test(raw)) return Number.parseInt(raw, 10)
+  return raw.split(',').map((s) => s.trim())
+}
+
 const app: FastifyAdapter = new FastifyAdapter({
-  trustProxy: true,
+  trustProxy: resolveTrustProxy(),
   logger: false,
 })
 export { app as fastifyApp }

--- a/apps/core/src/common/guards/auth.guard.ts
+++ b/apps/core/src/common/guards/auth.guard.ts
@@ -27,7 +27,6 @@ export class AuthGuard implements CanActivate {
 
     const apiKey = this.authService.getApiKeyFromRequest({
       headers: request.headers,
-      query: request.query as any,
     })
 
     if (!apiKey) {

--- a/apps/core/src/common/guards/spider.guard.ts
+++ b/apps/core/src/common/guards/spider.guard.ts
@@ -49,10 +49,9 @@ export class SpiderGuard implements CanActivate {
       const session = await this.authService.getSessionUser(request.raw)
       if (session?.user?.role === 'owner') return true
 
-      // API key (x-api-key header or `api_key` query).
+      // API key (x-api-key header only).
       const apiKey = this.authService.getApiKeyFromRequest({
         headers: request.headers,
-        query: request.query as any,
       })
       if (!apiKey) return false
       const verified = await this.authService.verifyApiKey(apiKey.key)

--- a/apps/core/src/common/guards/throttler.guard.ts
+++ b/apps/core/src/common/guards/throttler.guard.ts
@@ -1,6 +1,7 @@
 import type { ExecutionContext } from '@nestjs/common'
 import { Injectable } from '@nestjs/common'
 import { ThrottlerGuard } from '@nestjs/throttler'
+
 import type { FastifyBizRequest } from '~/transformers/get-req.transformer'
 import { getNestExecutionContextRequest } from '~/transformers/get-req.transformer'
 import { getIp } from '~/utils/ip.util'
@@ -17,6 +18,9 @@ export class ExtendThrottlerGuard extends ThrottlerGuard {
   }
 
   protected async getTracker(req: FastifyBizRequest) {
-    return getIp(req.raw)
+    // Pass the Fastify request (not req.raw) so getIp can use the framework's
+    // trustProxy-resolved `request.ip` instead of falling back to raw,
+    // client-spoofable forwarding headers.
+    return getIp(req)
   }
 }

--- a/apps/core/src/modules/activity/activity.service.ts
+++ b/apps/core/src/modules/activity/activity.service.ts
@@ -361,13 +361,19 @@ export class ActivityService implements OnModuleInit, OnModuleDestroy {
 
     serializedPresenceData.joinedAt = roomJoinedAtMap[roomName]
 
-    this.webGateway.broadcast(
-      BusinessEvents.ACTIVITY_UPDATE_PRESENCE,
-      serializedPresenceData,
-      {
-        rooms: [roomName],
-      },
-    )
+    try {
+      this.webGateway.broadcast(
+        BusinessEvents.ACTIVITY_UPDATE_PRESENCE,
+        serializedPresenceData,
+        {
+          rooms: [roomName],
+        },
+      )
+    } catch (err) {
+      this.logger.warn(
+        `presence broadcast failed for room ${roomName}: ${err instanceof Error ? err.message : String(err)}`,
+      )
+    }
 
     await this.gatewayService.setSocketMetadata(socket, {
       presence: presenceData,

--- a/apps/core/src/modules/aggregate/aggregate.service.ts
+++ b/apps/core/src/modules/aggregate/aggregate.service.ts
@@ -1,5 +1,7 @@
 import { forwardRef, Inject, Injectable } from '@nestjs/common'
 import { OnEvent } from '@nestjs/event-emitter'
+import dayjs from 'dayjs'
+import utc from 'dayjs/plugin/utc.js'
 
 import { CacheKeys, RedisKeys } from '~/constants/cache.constant'
 import { EventBusEvents } from '~/constants/event-bus.constant'
@@ -28,6 +30,8 @@ import { RecentlyService } from '../recently/recently.service'
 import { SayService } from '../say/say.service'
 import type { RSSProps } from './aggregate.interface'
 import { ReadAndLikeCountDocumentType, TimelineType } from './aggregate.schema'
+
+dayjs.extend(utc)
 
 const omitArticleBody = <T extends { text?: unknown; content?: unknown }>(
   row: T,
@@ -362,9 +366,7 @@ export class AggregateService {
 
   async getPublicationTrend() {
     const now = new Date()
-    const from = new Date(now)
-    from.setMonth(from.getMonth() - 12)
-    from.setHours(0, 0, 0, 0)
+    const from = dayjs.utc().subtract(12, 'months').startOf('month').toDate()
     const [posts, notes] = await Promise.all([
       this.postService.repository.aggregateMonthlyTrend({
         from,

--- a/apps/core/src/modules/ai/ai-article-visibility.util.ts
+++ b/apps/core/src/modules/ai/ai-article-visibility.util.ts
@@ -1,0 +1,35 @@
+import { CollectionRefTypes } from '~/constants/db.constant'
+import { isNoteSecret } from '~/utils/biz.util'
+
+import type { NoteModel } from '../note/note.types'
+import type { PostModel } from '../post/post.types'
+
+type VisibilityArticle = { type: CollectionRefTypes; document: unknown }
+
+/**
+ * Whether an article is publicly visible (published, not password-protected,
+ * not a future-dated note secret). Pages are always visible. Recently entries
+ * are never treated as visible articles.
+ *
+ * Shared by every AI feature (summary, insights, translation) so public
+ * endpoints never leak draft or protected content.
+ */
+export function isGlobalArticleVisible(article: VisibilityArticle): boolean {
+  if (article.type === CollectionRefTypes.Post) {
+    return (article.document as PostModel).isPublished !== false
+  }
+
+  if (article.type === CollectionRefTypes.Note) {
+    const document = article.document as NoteModel
+    if (document.isPublished === false) return false
+    if (document.password) return false
+    if (isNoteSecret(document)) return false
+    return true
+  }
+
+  if (article.type === CollectionRefTypes.Page) {
+    return true
+  }
+
+  return false
+}

--- a/apps/core/src/modules/ai/ai-insights/ai-insights.service.ts
+++ b/apps/core/src/modules/ai/ai-insights/ai-insights.service.ts
@@ -27,6 +27,7 @@ import {
 } from '../ai.constants'
 import { AI_PROMPTS } from '../ai.prompts'
 import { AiService } from '../ai.service'
+import { isGlobalArticleVisible } from '../ai-article-visibility.util'
 import { AiInFlightService } from '../ai-inflight/ai-inflight.service'
 import type { AiStreamEvent } from '../ai-inflight/ai-inflight.types'
 import { AiTaskService } from '../ai-task/ai-task.service'
@@ -132,6 +133,11 @@ export class AiInsightsService implements OnModuleInit {
       article.type === CollectionRefTypes.Recently ||
       article.type === CollectionRefTypes.Page
     ) {
+      throw createAppException(AppErrorCode.CONTENT_NOT_FOUND_CANT_PROCESS)
+    }
+    // Never expose insights for draft / password-protected / future-dated
+    // content. Public endpoints and background tasks both flow through here.
+    if (!isGlobalArticleVisible(article)) {
       throw createAppException(AppErrorCode.CONTENT_NOT_FOUND_CANT_PROCESS)
     }
     const doc = article.document as any

--- a/apps/core/src/modules/ai/ai-summary/ai-summary.service.ts
+++ b/apps/core/src/modules/ai/ai-summary/ai-summary.service.ts
@@ -28,6 +28,7 @@ import {
 } from '../ai.constants'
 import { AI_PROMPTS } from '../ai.prompts'
 import { AiService } from '../ai.service'
+import { isGlobalArticleVisible } from '../ai-article-visibility.util'
 import { AiInFlightService } from '../ai-inflight/ai-inflight.service'
 import type { AiStreamEvent } from '../ai-inflight/ai-inflight.types'
 import { resolveTargetLanguages } from '../ai-language.util'
@@ -201,6 +202,12 @@ export class AiSummaryService implements OnModuleInit {
       article.type === CollectionRefTypes.Recently ||
       article.type === CollectionRefTypes.Page
     ) {
+      throw createAppException(AppErrorCode.CONTENT_NOT_FOUND_CANT_PROCESS)
+    }
+
+    // Never expose summaries for draft / password-protected / future-dated
+    // content. Public endpoints and background tasks both flow through here.
+    if (!isGlobalArticleVisible(article)) {
       throw createAppException(AppErrorCode.CONTENT_NOT_FOUND_CANT_PROCESS)
     }
 

--- a/apps/core/src/modules/ai/ai-translation/ai-translation.service.ts
+++ b/apps/core/src/modules/ai/ai-translation/ai-translation.service.ts
@@ -880,8 +880,11 @@ export class AiTranslationService
       throw createAppException(AppErrorCode.AI_NOT_ENABLED)
     }
 
-    const { document, type } =
-      await this.resolveArticleForTranslation(articleId)
+    // Gate the public stream path on visibility, matching the read path
+    // (`getTranslationForArticle`) so drafts / protected articles never leak.
+    const { article, document } =
+      await this.loadVisibleArticleOrThrow(articleId)
+    const { type } = article
 
     // Check whether a valid translation (matching hash) already exists in the database.
     const existingTranslation = await this.findValidTranslation(

--- a/apps/core/src/modules/ai/ai-translation/base-translation.service.ts
+++ b/apps/core/src/modules/ai/ai-translation/base-translation.service.ts
@@ -1,10 +1,10 @@
 import { CollectionRefTypes } from '~/constants/db.constant'
-import { isNoteSecret } from '~/utils/biz.util'
 import { computeContentHash as computeContentHashUtil } from '~/utils/content.util'
 
 import type { NoteModel } from '../../note/note.types'
 import type { PageModel } from '../../page/page.types'
 import type { PostModel } from '../../post/post.types'
+import { isGlobalArticleVisible } from '../ai-article-visibility.util'
 import type {
   ArticleContent,
   ArticleDocument,
@@ -67,22 +67,6 @@ export abstract class BaseTranslationService {
   }
 
   isArticleVisible(article: GlobalArticle): boolean {
-    if (this.isPostArticle(article)) {
-      return article.document.isPublished !== false
-    }
-
-    if (this.isNoteArticle(article)) {
-      const document = article.document
-      if (document.isPublished === false) return false
-      if (document.password) return false
-      if (isNoteSecret(document)) return false
-      return true
-    }
-
-    if (this.isPageArticle(article)) {
-      return true
-    }
-
-    return false
+    return isGlobalArticleVisible(article)
   }
 }

--- a/apps/core/src/modules/analyze/analyze.controller.ts
+++ b/apps/core/src/modules/analyze/analyze.controller.ts
@@ -5,12 +5,11 @@ import { ApiController } from '~/common/decorators/api-controller.decorator'
 import { Auth } from '~/common/decorators/auth.decorator'
 import { RedisKeys } from '~/constants/cache.constant'
 import { RedisService } from '~/processors/redis/redis.service'
-import type { BasicPagerInput } from '~/shared/dto/pager.dto'
 import { SampleResponse } from '~/shared/sample/sample-response.decorator'
 import { getRedisKey } from '~/utils/redis.util'
 import { getTodayEarly, getWeekStart } from '~/utils/time.util'
 
-import { AnalyzeDto } from './analyze.schema'
+import { AnalyzeDto, AnalyzePagerDto } from './analyze.schema'
 import { AnalyzeService } from './analyze.service'
 import { AnalyzeSampleService } from './sample/analyze-sample.service'
 
@@ -53,7 +52,7 @@ export class AnalyzeController {
 
   @Get('/')
   @SampleResponse(AnalyzeSampleService, 'list')
-  getAnalyze(@Query() query: AnalyzeDto & Partial<BasicPagerInput>) {
+  getAnalyze(@Query() query: AnalyzePagerDto) {
     const { from, to = new Date(), page = 1, size = 50 } = query
     return this.service.getRangeAnalyzeData(from, to, {
       limit: Math.trunc(size),
@@ -62,7 +61,7 @@ export class AnalyzeController {
   }
 
   @Get('/today')
-  getAnalyzeToday(@Query() query: Partial<BasicPagerInput>) {
+  getAnalyzeToday(@Query() query: AnalyzePagerDto) {
     const { page = 1, size = 50 } = query
     const today = new Date()
     const todayEarly = getTodayEarly(today)
@@ -73,7 +72,7 @@ export class AnalyzeController {
   }
 
   @Get('/week')
-  getAnalyzeWeek(@Query() query: Partial<BasicPagerInput>) {
+  getAnalyzeWeek(@Query() query: AnalyzePagerDto) {
     const { page = 1, size = 50 } = query
     const today = new Date()
     const weekStart = getWeekStart(today)
@@ -164,7 +163,9 @@ export class AnalyzeController {
   @Get('/like')
   async getTodayLikedArticle() {
     const client = this.redisService.getClient()
-    const keys = await client.keys(getRedisKey(RedisKeys.Like, '*'))
+    const keys = await this.redisService.scanKeys(
+      getRedisKey(RedisKeys.Like, '*'),
+    )
 
     const data = await Promise.all(
       keys.map(async (key) => {

--- a/apps/core/src/modules/analyze/analyze.schema.ts
+++ b/apps/core/src/modules/analyze/analyze.schema.ts
@@ -1,6 +1,8 @@
 import { createZodDto } from 'nestjs-zod'
 import { z } from 'zod'
 
+import { BasicPagerSchema } from '~/shared/dto/pager.dto'
+
 /**
  * Analyze schema
  */
@@ -23,5 +25,17 @@ export const AnalyzeSchema = z.object({
 
 export class AnalyzeDto extends createZodDto(AnalyzeSchema) {}
 
+/**
+ * Analyze schema with a capped pager (size ≤ 100) so caller-supplied
+ * `page`/`size` are runtime-validated rather than reaching the service raw.
+ * Keeps the legacy default size of 50 for analyze endpoints.
+ */
+export const AnalyzePagerSchema = AnalyzeSchema.merge(BasicPagerSchema).extend({
+  size: BasicPagerSchema.shape.size.default(50),
+})
+
+export class AnalyzePagerDto extends createZodDto(AnalyzePagerSchema) {}
+
 // Type exports
 export type AnalyzeInput = z.infer<typeof AnalyzeSchema>
+export type AnalyzePagerInput = z.infer<typeof AnalyzePagerSchema>

--- a/apps/core/src/modules/auth/auth.controller.ts
+++ b/apps/core/src/modules/auth/auth.controller.ts
@@ -71,8 +71,8 @@ export class AuthController {
   @Auth()
   async deleteToken(@Query() query: StringIdDto) {
     const { id } = query
-    const models = await this.authService.getAllAccessToken()
-    const token = models.find((model) => model.id === id)?.token
+    const secret = await this.authService.getTokenSecret(id)
+    const token = secret?.token
 
     if (!token) {
       throw createAppException(AppErrorCode.AUTH_TOKEN_NOT_FOUND)

--- a/apps/core/src/modules/auth/auth.implement.ts
+++ b/apps/core/src/modules/auth/auth.implement.ts
@@ -15,6 +15,7 @@ import { toNodeHandler } from 'better-auth/node'
 import { bearer, deviceAuthorization, username } from 'better-auth/plugins'
 import { and, eq } from 'drizzle-orm'
 import { customAlphabet } from 'nanoid'
+import wcmatch from 'wildcard-match'
 
 import { API_VERSION, CROSS_DOMAIN } from '~/app.config'
 import { SECURITY } from '~/app.config.test'
@@ -38,6 +39,42 @@ const normalizeOrigin = (url: string | undefined): string | null => {
   } catch {
     return null
   }
+}
+
+// Mirror bootstrap.ts CORS host matching: the configured allowlist entries are
+// matched against an Origin's host (not the full origin) with wildcard support.
+// Matchers are compiled once per allowlist instance, not per request.
+let compiledOriginMatchers: {
+  patterns: string[]
+  matchers: ReturnType<typeof wcmatch>[]
+} | null = null
+
+const getOriginMatchers = (patterns: string[]) => {
+  if (!compiledOriginMatchers || compiledOriginMatchers.patterns !== patterns) {
+    compiledOriginMatchers = {
+      patterns,
+      matchers: patterns.map((pattern) => wcmatch(pattern)),
+    }
+  }
+  return compiledOriginMatchers.matchers
+}
+
+const isAllowedOrigin = (origin: string | undefined): boolean => {
+  if (!origin) return false
+  // Dev mirrors bootstrap.ts `allowAllCors`: reflect any origin (LAN IP, tunnel
+  // host, localhost) so local development against proxies/tunnels works.
+  if (isDev) return true
+  const allowed = CROSS_DOMAIN.allowedOrigins
+  if (!Array.isArray(allowed) || allowed.length === 0) {
+    return false
+  }
+  let host: string
+  try {
+    host = new URL(origin).host
+  } catch {
+    return false
+  }
+  return getOriginMatchers(allowed).some((match) => match(host))
 }
 
 export async function CreateAuth(
@@ -293,13 +330,19 @@ export async function CreateAuth(
 
   const handler = async (req: IncomingMessage, res: ServerResponse) => {
     try {
-      res.setHeader(
-        'Access-Control-Allow-Origin',
-        req.headers.origin || req.headers.referer || req.headers.host || '*',
-      )
+      // Only reflect the Origin (with credentials) when it matches the
+      // configured allowlist. Never echo an arbitrary Origin or `*` alongside
+      // `Allow-Credentials: true` — that would let any site perform
+      // credentialed cross-origin reads of session/account data, bypassing the
+      // Nest CORS allowlist in bootstrap.ts.
+      const requestOrigin = req.headers.origin
+      if (isAllowedOrigin(requestOrigin)) {
+        res.setHeader('Access-Control-Allow-Origin', requestOrigin!)
+        res.setHeader('Access-Control-Allow-Credentials', 'true')
+        res.setHeader('Vary', 'Origin')
+      }
       res.setHeader('Access-Control-Allow-Methods', 'GET, POST, OPTIONS')
       res.setHeader('Access-Control-Allow-Headers', 'Content-Type')
-      res.setHeader('Access-Control-Allow-Credentials', 'true')
       res.setHeader('Access-Control-Max-Age', '86400')
 
       const clonedRequest = new IncomingMessage(req.socket)

--- a/apps/core/src/modules/auth/auth.service.ts
+++ b/apps/core/src/modules/auth/auth.service.ts
@@ -88,11 +88,25 @@ export class AuthService {
 
     return keys.map((token) => ({
       id: token.id,
-      token: token.key,
+      // Never re-expose the full secret on list responses. The plaintext key is
+      // shown once at creation; afterwards the list only carries a masked
+      // display value. The full secret is fetched on demand via getTokenSecret.
+      token: this.maskApiKey(token),
       name: token.name,
       createdAt: token.createdAt,
       expired: token.expiresAt ?? undefined,
     }))
+  }
+
+  private maskApiKey(token: {
+    key?: string | null
+    start?: string | null
+    prefix?: string | null
+  }): string {
+    const prefix = token.prefix || ''
+    const start = token.start || token.key?.slice(0, 6) || ''
+    const visible = `${prefix}${start}`
+    return visible ? `${visible}••••••••` : '••••••••••••••••••••••••'
   }
 
   async getTokenSecret(id: string) {
@@ -472,18 +486,15 @@ export class AuthService {
 
   getApiKeyFromRequest(req: {
     headers?: Record<string, string | string[] | undefined>
-    query?: Record<string, any>
   }) {
     const headers = req.headers || {}
-    const query = req.query || {}
 
+    // Only the `x-api-key` header is honored. The legacy `?token=` query path
+    // was removed: query strings leak into access logs, the Referer header, and
+    // browser history, and are trivially replayable for full owner access.
     const apiKeyHeader = this.pickFirstHeader(headers, 'x-api-key', 'X-API-Key')
     if (apiKeyHeader) {
-      return { key: apiKeyHeader, deprecated: false }
-    }
-
-    if (typeof query.token === 'string') {
-      return { key: query.token, deprecated: true }
+      return { key: apiKeyHeader }
     }
 
     return null

--- a/apps/core/src/modules/backup/backup.service.ts
+++ b/apps/core/src/modules/backup/backup.service.ts
@@ -1,5 +1,5 @@
 import { createReadStream, existsSync, statSync } from 'node:fs'
-import { readdir, readFile, rm, writeFile } from 'node:fs/promises'
+import { mkdir, readdir, readFile, rm, writeFile } from 'node:fs/promises'
 import path, { join, resolve } from 'node:path'
 
 import {
@@ -8,6 +8,7 @@ import {
   Logger,
 } from '@nestjs/common'
 import { CronExpression } from '@nestjs/schedule'
+import JSZip from 'jszip'
 import { mkdirp } from 'mkdirp'
 
 import { POSTGRES } from '~/app.config'
@@ -21,7 +22,7 @@ import { RedisService } from '~/processors/redis/redis.service'
 import { S3Uploader } from '~/utils/s3.util'
 import { scheduleManager } from '~/utils/schedule.util'
 import { $, $throw } from '~/utils/shell.util'
-import { getFolderSize, installPKG } from '~/utils/system.util'
+import { getFolderSize } from '~/utils/system.util'
 import { getMediumDateTime } from '~/utils/time.util'
 
 import { ConfigsService } from '../configs/configs.service'
@@ -77,6 +78,57 @@ export class BackupService {
 
   private shellQuote(value: string | number) {
     return `'${String(value).replaceAll("'", `'\\''`)}'`
+  }
+
+  // Resolve `candidate` against `dir` and assert it stays inside `dir`.
+  // Rejects zip-slip (`../`), absolute paths, and any escape attempt.
+  private assertContained(dir: string, candidate: string): string {
+    const base = resolve(dir)
+    const target = resolve(base, candidate)
+    if (target !== base && !target.startsWith(base + path.sep)) {
+      throw createAppException(AppErrorCode.INVALID_PARAMETER, {
+        message: `Path escapes target directory: ${candidate}`,
+      })
+    }
+    return target
+  }
+
+  // Safe in-process zip extraction (replaces shell `unzip`).
+  // Validates every entry against zip-slip; rejects absolute paths and symlinks.
+  private async safeUnzip(zipFilePath: string, destDir: string) {
+    const base = resolve(destDir)
+    const buffer = await readFile(zipFilePath)
+    const zip = await new JSZip().loadAsync(buffer)
+
+    const entries = Object.values(zip.files)
+    for (const entry of entries) {
+      const name = entry.name
+      if (path.isAbsolute(name) || /^[a-z]:[/\\]/i.test(name)) {
+        throw createAppException(AppErrorCode.INVALID_PARAMETER, {
+          message: `Absolute path entry rejected: ${name}`,
+        })
+      }
+      // Symlink entries carry unix mode bits with the symlink flag (0o120000).
+      const unixMode = (entry as any).unixPermissions as number | null
+      if (typeof unixMode === 'number' && (unixMode & 0o170000) === 0o120000) {
+        throw createAppException(AppErrorCode.INVALID_PARAMETER, {
+          message: `Symlink entry rejected: ${name}`,
+        })
+      }
+      // assertContained throws if the entry escapes destDir.
+      this.assertContained(base, name)
+    }
+
+    for (const entry of entries) {
+      const target = this.assertContained(base, entry.name)
+      if (entry.dir) {
+        await mkdir(target, { recursive: true })
+        continue
+      }
+      await mkdir(path.dirname(target), { recursive: true })
+      const content = await entry.async('nodebuffer')
+      await writeFile(target, Uint8Array.from(content))
+    }
   }
 
   private pgPasswordEnv() {
@@ -292,15 +344,10 @@ export class BackupService {
       }),
     )
 
-    // Unzip
+    // Unzip — in-process, zip-slip-safe extraction (no shell `unzip`).
     try {
-      await $throw(`unzip ${restoreFilePath}`, { cwd: dirPath })
+      await this.safeUnzip(restoreFilePath, dirPath)
     } catch (error: any) {
-      if (error?.exitCode === 127) {
-        throw new InternalServerErrorException(
-          'unzip command not found on server',
-        )
-      }
       this.logger.error(
         `unzip failed: ${error?.message || error}\n\n${error?.stderr || ''}`,
       )
@@ -343,33 +390,44 @@ export class BackupService {
 
     await Promise.all(
       backupDataDirFilenames.map(async (filename) => {
-        const fullpath = join(dirPath, 'backup_data', filename)
-        const targetPath = join(DATA_DIR, filename)
+        // Containment: source must stay within the extracted backup_data dir,
+        // destination within DATA_DIR. Rejects `..`/absolute filenames.
+        const fullpath = this.assertContained(backupDataDir, filename)
+        const targetPath = this.assertContained(DATA_DIR, filename)
 
         await rm(targetPath, { recursive: true, force: true })
 
-        await $throw(`cp -r ${fullpath} ${targetPath}`)
+        await $throw(
+          `cp -r ${this.shellQuote(fullpath)} ${this.shellQuote(targetPath)}`,
+        )
       }),
     )
 
+    // SECURITY: never auto-install dependencies from a restored archive.
+    // An uploaded archive is attacker-controlled; running `npm install` on its
+    // declared deps is arbitrary-code-execution via install scripts. Instead we
+    // surface the package list so an admin can review and install manually.
     try {
       const packageJson = await readFile(join(backupDataDir, 'package.json'), {
         encoding: 'utf8',
       })
       const pkg = JSON.parse(packageJson)
-      if (pkg.dependencies) {
-        await Promise.all(
-          Object.entries(pkg.dependencies).map(([name, version]) => {
-            this.logger.log(`--> Installing dependency ${name}@${version}`)
-            return installPKG(`${name}@${version}`, DATA_DIR).catch((error) => {
-              this.logger.error(
-                `--> Dependency installation failed: ${error.message}`,
-              )
-            })
-          }),
+      const deps = pkg?.dependencies
+      if (deps && typeof deps === 'object' && Object.keys(deps).length > 0) {
+        const list = Object.entries(deps)
+          .map(([name, version]) => `${name}@${version}`)
+          .join(', ')
+        this.logger.warn(
+          `--> Restored archive declares ${
+            Object.keys(deps).length
+          } dependencies. Automatic installation is disabled for security ` +
+            `(install scripts can execute arbitrary code). Review and install ` +
+            `manually if required: ${list}`,
         )
       }
-    } catch {}
+    } catch {
+      // package.json absent or unpar. Restores without a manifest are valid.
+    }
 
     await Promise.all([
       this.redisService.cleanAllRedisKey(),

--- a/apps/core/src/modules/category/category.controller.ts
+++ b/apps/core/src/modules/category/category.controller.ts
@@ -73,32 +73,30 @@ export class CategoryController {
 
       const allPosts: { categoryId: string; post: any }[] = []
 
-      const categoryObjects: Array<{ id: string; cat: any }> = []
+      const categoryObjects = new Map<string, any>()
 
       const categoriesPromise = joint
         ? null
         : this.categoryService.repository.findByIds(ids)
 
-      await Promise.all(
-        ids.map(async (id) => {
-          const rawPosts = await this.postService.listByCategory(id, {
-            includeCategory: false,
-          })
-          const posts: any[] = rawPosts.map((post) => {
-            const cloned = { ...post }
-            for (const field of omitKeys) delete cloned[field]
-            return cloned
-          })
-          for (const post of posts) allPosts.push({ categoryId: id, post })
-        }),
-      )
+      const postsByCategory = await this.postService.listByCategoryIds(ids, {
+        includeCategory: false,
+      })
+      for (const id of ids) {
+        const rawPosts = postsByCategory.get(id) ?? []
+        for (const post of rawPosts) {
+          const cloned: any = { ...post }
+          for (const field of omitKeys) delete cloned[field]
+          allPosts.push({ categoryId: id, post: cloned })
+        }
+      }
 
       const categoriesById = await categoriesPromise
 
       if (categoriesById) {
         const catMap = new Map(categoriesById.map((c) => [String(c.id), c]))
         for (const id of ids) {
-          categoryObjects.push({ id, cat: catMap.get(id) ?? null })
+          categoryObjects.set(id, catMap.get(id) ?? null)
         }
       }
 
@@ -122,12 +120,12 @@ export class CategoryController {
                 results: new Map<string, any>(),
                 meta: new Map<string, any>(),
               }),
-          !joint && categoryObjects.length
+          !joint && categoryObjects.size
             ? this.translationEntryService.getTranslationsBatch(lang, {
                 entityLookups: [
                   {
                     keyPath: 'category.name',
-                    lookupKeys: new Set(categoryObjects.map((c) => c.id)),
+                    lookupKeys: new Set(categoryObjects.keys()),
                   },
                 ],
               })
@@ -150,19 +148,24 @@ export class CategoryController {
           idsMetaMap.set(id, entry)
         }
 
-        for (const { cat } of categoryObjects) {
+        for (const cat of categoryObjects.values()) {
           applyTranslationEntriesInPlace(cat, entryMaps, CATEGORY_NAME_RULES)
         }
       }
 
+      const postsForIdMap = new Map<string, any[]>()
+      for (const { categoryId, post } of allPosts) {
+        const bucket = postsForIdMap.get(categoryId)
+        if (bucket) bucket.push(post)
+        else postsForIdMap.set(categoryId, [post])
+      }
+
       for (const id of ids) {
-        const postsForId = allPosts
-          .filter((p) => p.categoryId === id)
-          .map((p) => p.post)
+        const postsForId = postsForIdMap.get(id) ?? []
         if (joint) {
           map[id] = postsForId
         } else {
-          const catObj = categoryObjects.find((c) => c.id === id)?.cat
+          const catObj = categoryObjects.get(id)
           map[id] = { ...catObj, children: postsForId }
         }
       }

--- a/apps/core/src/modules/comment/comment-country.service.ts
+++ b/apps/core/src/modules/comment/comment-country.service.ts
@@ -49,7 +49,11 @@ export class CommentCountryService {
     if (cached !== undefined) return cached
 
     const fetched = await this.fetchFromUpstream(trimmed)
-    await this.writeCache(trimmed, fetched).catch(() => {})
+    await this.writeCache(trimmed, fetched).catch((err) => {
+      this.logger.warn(
+        `geoip cache write failed for ${trimmed}: ${err instanceof Error ? err.message : String(err)}`,
+      )
+    })
     return fetched
   }
 

--- a/apps/core/src/modules/comment/comment.service.ts
+++ b/apps/core/src/modules/comment/comment.service.ts
@@ -676,10 +676,7 @@ export class CommentService {
    */
   async invalidateTabCountsCache(): Promise<void> {
     try {
-      const client = this.redisService.getClient()
-      const keys = await client.keys(`${TAB_COUNTS_KEY_PREFIX}*`)
-      if (keys.length === 0) return
-      await Promise.all(keys.map((key) => client.del(key)))
+      await this.redisService.deleteKeysByPattern(`${TAB_COUNTS_KEY_PREFIX}*`)
     } catch (err) {
       this.logger.warn(
         `tab-counts cache invalidation failed: ${err instanceof Error ? err.message : err}`,

--- a/apps/core/src/modules/comment/comment.spam-filter.ts
+++ b/apps/core/src/modules/comment/comment.spam-filter.ts
@@ -31,8 +31,17 @@ export type SpamFilter = (
   ctx: SpamFilterContext,
 ) => Promise<SpamFilterResult> | SpamFilterResult
 
+// Keywords were historically regex patterns; matching is now literal substring
+// (ReDoS-safe), but `|` alternation was the common legacy form — split on it so
+// existing `foo|bar` configs keep matching.
 function testKeywords(text: string, keywords: string[]): boolean {
-  return keywords.some((kw) => new RegExp(kw, 'gi').test(text))
+  const lowered = text.toLowerCase()
+  return keywords.some((kw) =>
+    kw.split('|').some((part) => {
+      const needle = part.trim().toLowerCase()
+      return needle.length > 0 && lowered.includes(needle)
+    }),
+  )
 }
 
 const meaninglessWordsSet = new Set(
@@ -54,9 +63,7 @@ const builtinKeywordsFilter: SpamFilter = ({ doc }) => {
 
 const systemSettingsFilter: SpamFilter = ({ doc, commentOptions }) => {
   if (commentOptions.blockIps?.length && doc.ip) {
-    const blocked = commentOptions.blockIps.some((ip) =>
-      new RegExp(ip, 'gi').test(doc.ip!),
-    )
+    const blocked = commentOptions.blockIps.includes(doc.ip)
     if (blocked) return { isSpam: true, reason: 'blocked-ip' }
   }
 

--- a/apps/core/src/modules/cron-task/cron-business.service.ts
+++ b/apps/core/src/modules/cron-task/cron-business.service.ts
@@ -73,8 +73,8 @@ export class CronBusinessService {
 
     const allKeys = (
       await Promise.all([
-        redis.keys(getRedisKey(RedisKeys.Like, '*')),
-        redis.keys(getRedisKey(RedisKeys.Read, '*')),
+        this.redisService.scanKeys(getRedisKey(RedisKeys.Like, '*')),
+        this.redisService.scanKeys(getRedisKey(RedisKeys.Read, '*')),
       ])
     ).flat()
     await Promise.all(allKeys.map((key) => redis.del(key)))
@@ -187,26 +187,26 @@ export class CronBusinessService {
     const redis = this.redisService.getClient()
     const storeKey = getRedisKey(RedisKeys.JWTStore)
     const keys = await redis.hkeys(storeKey)
-    let deleteCount = 0
-    await Promise.all(
+    const results = await Promise.all(
       keys.map(async (key) => {
         const value = await redis.hget(storeKey, key)
-        if (!value) return
+        if (!value) return 0
         const parsed = JSON.safeParse(value) as StoreJWTPayload
-        if (!parsed) return
+        if (!parsed) return 0
 
         const date = dayjs(new Date(parsed.date))
         if (date.add(JWTService.expiresDay, 'd').diff(new Date(), 'd') >= 0) {
-          return
+          return 0
         }
 
         this.logger.debug(
           `--> Deleting expired token: ${key}, issued at ${date.format('YYYY-MM-DD H:mm:ss')}`,
         )
         await redis.hdel(storeKey, key)
-        deleteCount += 1
+        return 1
       }),
     )
+    const deleteCount = results.reduce((a, b) => a + b, 0)
 
     this.logger.log(`--> Deleted ${deleteCount} expired tokens`)
     return { deletedCount: deleteCount }

--- a/apps/core/src/modules/init/init.controller.ts
+++ b/apps/core/src/modules/init/init.controller.ts
@@ -65,6 +65,7 @@ export class InitController {
 
   @Post('/restore')
   async uploadAndRestore(@Req() req: FastifyRequest) {
+    await this.assertNotInitialized()
     const data = await this.uploadService.getAndValidMultipartField(req, {
       maxFileSize: 1024 * 1024 * 100,
     })

--- a/apps/core/src/modules/link/link-avatar.service.ts
+++ b/apps/core/src/modules/link/link-avatar.service.ts
@@ -2,6 +2,7 @@ import { Readable } from 'node:stream'
 import { URL } from 'node:url'
 
 import { Injectable, Logger } from '@nestjs/common'
+import type { AxiosResponse } from 'axios'
 import { customAlphabet } from 'nanoid'
 
 import { AppErrorCode, createAppException } from '~/common/errors'
@@ -9,6 +10,7 @@ import { alphabet } from '~/constants/other.constant'
 import { HttpService } from '~/processors/helper/helper.http.service'
 import { validateImageBuffer } from '~/utils/image.util'
 import { AsyncQueue } from '~/utils/queue.util'
+import { assertPublicHttpUrl } from '~/utils/ssrf.util'
 
 import { ConfigsService } from '../configs/configs.service'
 import { FileService } from '../file/file.service'
@@ -88,15 +90,36 @@ export class LinkAvatarService {
       return webUrl
     })()
 
-    const response = await this.http.axiosRef.get<ArrayBuffer>(avatar, {
-      responseType: 'arraybuffer',
-      timeout: 10_000,
-      headers: {
-        'user-agent':
-          'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/142.0.0.0 Safari/537.36',
-        referer: refererHeader,
-      },
-    })
+    // SSRF guard: the avatar URL is applicant-controlled. Reject targets that
+    // resolve to internal/metadata addresses before issuing the request, and
+    // disable redirect following so a public host cannot 30x us into one.
+    try {
+      await assertPublicHttpUrl(avatar, { allowHttp: true })
+    } catch (error: any) {
+      this.logger.warn(
+        `Friend link ${doc.id} avatar URL was rejected by the SSRF guard; skipping internalization: ${error?.message || String(error)}`,
+      )
+      return false
+    }
+
+    let response: AxiosResponse<ArrayBuffer>
+    try {
+      response = await this.http.axiosRef.get<ArrayBuffer>(avatar, {
+        responseType: 'arraybuffer',
+        timeout: 10_000,
+        maxRedirects: 0,
+        headers: {
+          'user-agent':
+            'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/142.0.0.0 Safari/537.36',
+          referer: refererHeader,
+        },
+      })
+    } catch (error: any) {
+      this.logger.warn(
+        `Failed to fetch friend link ${doc.id} avatar; skipping internalization: ${error?.message || String(error)}`,
+      )
+      return false
+    }
 
     const buffer = Buffer.from(response.data as any)
     const contentType = (response.headers['content-type'] ||

--- a/apps/core/src/modules/markdown/markdown.service.ts
+++ b/apps/core/src/modules/markdown/markdown.service.ts
@@ -6,6 +6,7 @@ import {
 import { omit } from 'es-toolkit/compat'
 import { dump } from 'js-yaml'
 import JSZip from 'jszip'
+import { escapeHtml } from 'xss'
 
 import { AppErrorCode, createAppException } from '~/common/errors'
 import { CollectionRefTypes } from '~/constants/db.constant'
@@ -247,7 +248,7 @@ ${text.trim()}
       { encoding: 'utf-8' },
     )
     return {
-      body: [`<article><h1>${title}</h1>${html}</article>`],
+      body: [`<article><h1>${escapeHtml(title)}</h1>${html}</article>`],
       extraScripts: [
         '<script src="https://lf26-cdn-tos.bytecdntp.com/cdn/expire-1-M/mermaid/8.9.0/mermaid.min.js"></script>',
         '<script src="https://lf26-cdn-tos.bytecdntp.com/cdn/expire-1-M/prism/1.23.0/components/prism-core.min.js"></script>',

--- a/apps/core/src/modules/markdown/markdown.util.ts
+++ b/apps/core/src/modules/markdown/markdown.util.ts
@@ -1,5 +1,5 @@
 import { marked } from 'marked'
-import xss from 'xss'
+import xss, { FilterXSS, getDefaultWhiteList } from 'xss'
 
 marked.use({
   extensions: [
@@ -16,7 +16,7 @@ marked.use({
         )}\n</span>`
       },
       tokenizer(src) {
-        const rule = /^\|\|([\s\S]+?)\|\|(?!\|)/
+        const rule = /^\|\|(.+?)\|\|(?!\|)/s
         const match = rule.exec(src)
         if (match) {
           return {
@@ -39,7 +39,7 @@ marked.use({
         return `<span class="katex-render">${token.text}</span>`
       },
       tokenizer(src) {
-        const rule = /^\$([\s\S]+?)\$(?!\$)/
+        const rule = /^\$(.+?)\$(?!\$)/s
         const match = rule.exec(src)
         if (match) {
           return {
@@ -70,6 +70,7 @@ marked.use({
         return `<a target="_blank" class="mention" rel="noreferrer nofollow" href="${urlPrefix}${username}">${username}</a>`
       },
       tokenizer(src) {
+        // eslint-disable-next-line unicorn/better-regex -- its autofix (`\]` -> `]`) conflicts with regexp/strict
         const rule = /^(?<prefix>GH|TW|TG)@(?<name>\w+)\s?(?!\[.*?\])/
         const match = rule.exec(src)
         if (match) {
@@ -94,14 +95,16 @@ marked.use({
         const { params, name } = groups
 
         switch (name) {
-          case 'gallery':
+          case 'gallery': {
             return `<div class="container">${this.parser.parseInline(
               images,
             )}</div>`
-          case 'banner':
+          }
+          case 'banner': {
             return `<div class="container ${name} ${params}">${this.parser.parse(
               paragraph,
             )}</div>`
+          }
         }
         return ''
       },
@@ -112,7 +115,8 @@ marked.use({
           /* 'carousel', */
         ].join('|')
         const match = new RegExp(
-          `^\\s*::: *(?<name>(${shouldCatchContainerName})) *({(?<params>(.*?))})? *\n(?<content>[\\s\\S]+?)\\s*::: *(?:\n *)+\n?`,
+          `^\\s*::: *(?<name>${shouldCatchContainerName})(?: *\\{(?<params>[^}\n]*)\\})? *\n(?<content>.+?)\n[^\\S\n]*::: *(?:\n *)+`,
+          's',
         ).exec(src)
         if (match) {
           const { groups } = match
@@ -160,6 +164,61 @@ marked.use({
   },
 })
 
+const withCommonAttrs = (...extra: string[]) => [
+  'class',
+  'style',
+  'id',
+  ...extra,
+]
+
+// Sanitizer for the full HTML output of the marked pipeline. The renderer can
+// emit untrusted user content unescaped (notably the katex extension, which
+// inlines `token.text` verbatim into `<span class="katex-render">`), so the
+// whole rendered document is filtered before it is templated or served.
+// `css: false` keeps the renderer's own constant inline styles (e.g. the
+// spoiler `filter: invert(25%)`) intact; no user-controlled value reaches a
+// `style` attribute in this pipeline.
+const defaultWhiteList = getDefaultWhiteList()
+const htmlSanitizer = new FilterXSS({
+  css: false,
+  whiteList: {
+    ...defaultWhiteList,
+    a: [...(defaultWhiteList.a ?? []), 'rel', 'class', 'style', 'id'],
+    img: [...(defaultWhiteList.img ?? []), 'class', 'style', 'id'],
+    span: withCommonAttrs(),
+    div: withCommonAttrs(),
+    figure: withCommonAttrs(),
+    figcaption: withCommonAttrs(),
+    pre: withCommonAttrs(),
+    code: withCommonAttrs(),
+    p: withCommonAttrs(),
+    h1: withCommonAttrs(),
+    h2: withCommonAttrs(),
+    h3: withCommonAttrs(),
+    h4: withCommonAttrs(),
+    h5: withCommonAttrs(),
+    h6: withCommonAttrs(),
+    ul: withCommonAttrs(),
+    ol: withCommonAttrs(),
+    li: withCommonAttrs(),
+    blockquote: withCommonAttrs(),
+    table: withCommonAttrs(),
+    thead: withCommonAttrs(),
+    tbody: withCommonAttrs(),
+    tr: withCommonAttrs(),
+    td: withCommonAttrs('colspan', 'rowspan', 'align'),
+    th: withCommonAttrs('colspan', 'rowspan', 'align'),
+    hr: withCommonAttrs(),
+    br: withCommonAttrs(),
+    em: withCommonAttrs(),
+    strong: withCommonAttrs(),
+    del: withCommonAttrs(),
+  },
+})
+
+export const sanitizeRenderedHtml = (html: string) =>
+  htmlSanitizer.process(html)
+
 export const markdownToHtml = (markdown: string) => {
-  return marked(markdown, { gfm: true }) as string
+  return sanitizeRenderedHtml(marked(markdown, { gfm: true }) as string)
 }

--- a/apps/core/src/modules/note/note.repository.ts
+++ b/apps/core/src/modules/note/note.repository.ts
@@ -8,6 +8,7 @@ import {
   gte,
   ilike,
   inArray,
+  isNull,
   lt,
   lte,
   ne,
@@ -217,6 +218,7 @@ const defaultVisibleNoteListSql = `
     from notes
     where is_published = true
       and (public_at is null or public_at <= now())
+      and password is null
     order by created_at desc nulls last
     limit 10
     offset 0
@@ -227,6 +229,7 @@ const defaultVisibleNoteListSql = `
     from notes
     where is_published = true
       and (public_at is null or public_at <= now())
+      and password is null
   ) c
   order by n.created_at desc nulls last
 `
@@ -268,6 +271,7 @@ const latestVisiblePairSql = `
     left join topics t on t.id = n.topic_id
     where n.is_published = true
       and (n.public_at is null or n.public_at <= now())
+      and n.password is null
     order by n.created_at desc nulls last
     limit 1
   ),
@@ -307,6 +311,7 @@ const latestVisiblePairSql = `
     left join topics t on t.id = n.topic_id
     where n.is_published = true
       and (n.public_at is null or n.public_at <= now())
+      and n.password is null
       and n.created_at < (select "createdAt" from latest)
     order by n.created_at desc nulls last
     limit 1
@@ -379,12 +384,15 @@ export class NoteRepository extends BaseRepository {
 
   /**
    * Visibility predicate matching service behavior: only published notes
-   * whose `publicAt` (if set) is in the past.
+   * whose `publicAt` (if set) is in the past, and which are not
+   * password-protected (password-protected notes must never leak through
+   * public list/feed/sitemap/timeline surfaces).
    */
   private visibleClause(): SQL {
     return and(
       eq(notes.isPublished, true),
       or(sql`${notes.publicAt} is null`, lte(notes.publicAt, new Date()))!,
+      isNull(notes.password),
     )!
   }
 
@@ -408,7 +416,7 @@ export class NoteRepository extends BaseRepository {
     const pool = this.pgPool
     if (!pool) return null
     const result = await pool.query<RawNoteWithTopic>({
-      name: 'notes_default_visible_list_v1',
+      name: 'notes_default_visible_list_v2',
       text: defaultVisibleNoteListSql,
     })
     const count = result.rows[0]?.totalCount ?? 0
@@ -762,7 +770,7 @@ export class NoteRepository extends BaseRepository {
     const pool = this.pgPool
     const result = pool
       ? await pool.query<RawNoteWithTopic>({
-          name: 'notes_latest_visible_pair_v1',
+          name: 'notes_latest_visible_pair_v2',
           text: latestVisiblePairSql,
         })
       : await this.db.execute<RawNoteWithTopic>(sql.raw(latestVisiblePairSql))

--- a/apps/core/src/modules/post/post.repository.ts
+++ b/apps/core/src/modules/post/post.repository.ts
@@ -360,6 +360,38 @@ export class PostRepository extends BaseRepository {
     return this.attachCategories(mapped)
   }
 
+  async listByCategoryIds(
+    categoryIds: ReadonlyArray<EntityId | string>,
+    options: Omit<PostListByCategoryOptions, 'limit'> = {},
+  ): Promise<Map<string, PostRow[]>> {
+    const grouped = new Map<string, PostRow[]>()
+    if (categoryIds.length === 0) return grouped
+
+    const parsedIds = categoryIds.map((id) => parseEntityId(id))
+    const filters: SQL[] = [inArray(posts.categoryId, parsedIds)]
+    if (options.publishedOnly) filters.push(eq(posts.isPublished, true))
+
+    const rows = await this.db
+      .select()
+      .from(posts)
+      .where(and(...filters))
+      .orderBy(pinAtDescNullsLast, desc(posts.createdAt))
+
+    const mapped = rows.map(mapBase)
+    const withCategory =
+      options.includeCategory === false
+        ? mapped
+        : await this.attachCategories(mapped)
+
+    for (const post of withCategory) {
+      const key = String(post.categoryId)
+      const bucket = grouped.get(key)
+      if (bucket) bucket.push(post)
+      else grouped.set(key, [post])
+    }
+    return grouped
+  }
+
   async findByCategoryAndSlug(
     categoryId: EntityId | string,
     slug: string,

--- a/apps/core/src/modules/post/post.service.ts
+++ b/apps/core/src/modules/post/post.service.ts
@@ -125,6 +125,16 @@ export class PostService implements OnApplicationBootstrap {
     return this.postRepository.listByCategory(categoryId, options)
   }
 
+  async listByCategoryIds(
+    categoryIds: ReadonlyArray<string>,
+    options: {
+      includeCategory?: boolean
+      publishedOnly?: boolean
+    } = {},
+  ) {
+    return this.postRepository.listByCategoryIds(categoryIds, options)
+  }
+
   async findByCategoryId(categoryId: string) {
     return this.listByCategory(categoryId)
   }

--- a/apps/core/src/modules/recently/recently.controller.ts
+++ b/apps/core/src/modules/recently/recently.controller.ts
@@ -74,6 +74,19 @@ export class RecentlyController {
     return res
   }
 
+  @Post('/attitude/:id')
+  async attitudePost(
+    @Param() { id }: EntityIdDto,
+    @Query() { attitude }: RecentlyAttitudeDto,
+    @IpLocation() { ip }: IpRecord,
+  ) {
+    return this.attitude({ id }, { attitude }, { ip } as IpRecord)
+  }
+
+  /**
+   * @deprecated state-changing GET kept as an alias for legacy clients
+   * (@mx-space/api-client calls this as GET). Prefer POST /attitude/:id.
+   */
   @Get('/attitude/:id')
   async attitude(
     @Param() { id }: EntityIdDto,

--- a/apps/core/src/modules/render/render.controller.ts
+++ b/apps/core/src/modules/render/render.controller.ts
@@ -11,7 +11,7 @@ import {
 import dayjs from 'dayjs'
 import ejs from 'ejs'
 import { isNil } from 'es-toolkit/compat'
-import xss from 'xss'
+import xss, { escapeAttrValue, escapeHtml } from 'xss'
 
 import { RequestContext } from '~/common/contexts/request.context'
 import { Auth } from '~/common/decorators/auth.decorator'
@@ -97,16 +97,16 @@ export class RenderEjsController {
       ...structure,
       info: isPrivateOrEncrypt ? 'This article is not yet public.' : undefined,
 
-      title: document.title,
+      title: xss(document.title),
       footer: `<div>Rendered on ${getShortDateTime(
         new Date(),
       )} by marked.js, in ${(performance.now() - now).toFixed(2)}ms</div>
-      <div>Author: ${username}, written on ${dayjs(document.createdAt).format(
-        'llll',
-      )}</div>
-        <div>Original URL: <a href="${url}">${decodeURIComponent(
+      <div>Author: ${escapeHtml(username)}, written on ${dayjs(
+        document.createdAt,
+      ).format('llll')}</div>
+        <div>Original URL: <a href="${escapeAttrValue(
           url.toString(),
-        )}</a></div>
+        )}">${escapeHtml(decodeURIComponent(url.toString()))}</a></div>
         `,
     })
 

--- a/apps/core/src/modules/search/search.repository.ts
+++ b/apps/core/src/modules/search/search.repository.ts
@@ -28,6 +28,11 @@ import type {
   SearchDocumentUpsertInput,
 } from './search-document.types'
 
+// Escape LIKE/ILIKE wildcards so user keywords match literally. Postgres treats
+// backslash as the default LIKE escape char, so `\%`, `\_`, `\\` are literal.
+const escapeLikePattern = (value: string): string =>
+  value.replaceAll('\\', '\\\\').replaceAll('%', '\\%').replaceAll('_', '\\_')
+
 const mapRow = (
   row: typeof searchDocuments.$inferSelect,
 ): SearchDocumentRow => ({
@@ -188,7 +193,7 @@ export class SearchRepository extends BaseRepository {
     limit = 100,
   ): Promise<SearchDocumentRow[]> {
     if (!keyword.trim()) return []
-    const pattern = `%${keyword.trim()}%`
+    const pattern = `%${escapeLikePattern(keyword.trim())}%`
     const filters: SQL[] = [
       or(
         ilike(searchDocuments.title, pattern),
@@ -408,7 +413,7 @@ export class SearchRepository extends BaseRepository {
     if (query.refType) filters.push(eq(searchDocuments.refType, query.refType))
     if (query.lang) filters.push(eq(searchDocuments.lang, query.lang))
     if (query.keyword?.trim()) {
-      const pattern = `%${query.keyword.trim()}%`
+      const pattern = `%${escapeLikePattern(query.keyword.trim())}%`
       filters.push(
         or(
           ilike(searchDocuments.title, pattern),

--- a/apps/core/src/modules/subscribe/subscribe.service.ts
+++ b/apps/core/src/modules/subscribe/subscribe.service.ts
@@ -1,4 +1,5 @@
 import cluster from 'node:cluster'
+import { randomBytes } from 'node:crypto'
 
 import type { CoAction } from '@innei/next-async'
 import { Co } from '@innei/next-async'
@@ -6,7 +7,6 @@ import type { OnModuleDestroy, OnModuleInit } from '@nestjs/common'
 import { Injectable } from '@nestjs/common'
 import ejs from 'ejs'
 import { LRUCache } from 'lru-cache'
-import { nanoid } from 'nanoid'
 import type Mail from 'nodemailer/lib/mailer'
 
 import { AppErrorCode, createAppException } from '~/common/errors'
@@ -18,7 +18,6 @@ import type { IEventManagerHandlerDisposer } from '~/processors/helper/helper.ev
 import { EventManagerService } from '~/processors/helper/helper.event.service'
 import { UrlBuilderService } from '~/processors/helper/helper.url-builder.service'
 import { truncateAtBoundary } from '~/utils/text-summary.util'
-import { hashString, md5 } from '~/utils/tool.util'
 
 import { ConfigsService } from '../configs/configs.service'
 import type { NoteModel } from '../note/note.types'
@@ -129,7 +128,7 @@ export class SubscribeService implements OnModuleInit, OnModuleDestroy {
         { subscribe, cancelToken },
       ] of self.subscribeMap.entries()) {
         if (!(subscribe & subscribeBit)) continue
-        const unsubscribeLink = `${serverUrl}/subscribe/unsubscribe?email=${email}&cancelToken=${cancelToken}`
+        const unsubscribeLink = `${serverUrl}/subscribe/unsubscribe?email=${encodeURIComponent(email)}&cancelToken=${encodeURIComponent(cancelToken)}`
         self.sendEmail(
           email,
           {
@@ -230,8 +229,8 @@ export class SubscribeService implements OnModuleInit, OnModuleDestroy {
     return count
   }
 
-  createCancelToken(email: string) {
-    return hashString(md5(email) + nanoid(8))
+  createCancelToken(_email: string) {
+    return randomBytes(32).toString('hex')
   }
 
   subscribeTypeToBit(type: keyof typeof SubscribeTypeToBitMap) {

--- a/apps/core/src/modules/webhook/webhook.service.ts
+++ b/apps/core/src/modules/webhook/webhook.service.ts
@@ -1,4 +1,6 @@
 import { createHmac } from 'node:crypto'
+import { lookup as dnsLookup } from 'node:dns/promises'
+import { isIP } from 'node:net'
 
 import type { OnModuleDestroy, OnModuleInit } from '@nestjs/common'
 import { Injectable } from '@nestjs/common'
@@ -10,6 +12,7 @@ import { EventManagerService } from '~/processors/helper/helper.event.service'
 import { EventPayloadEnricherService } from '~/processors/helper/helper.event-payload.service'
 import { HttpService } from '~/processors/helper/helper.http.service'
 import type { BasicPagerInput } from '~/shared/dto/pager.dto'
+import { isPrivateIp } from '~/utils/ssrf.util'
 
 import { WebhookRepository } from './webhook.repository'
 import type { WebhookRow } from './webhook.types'
@@ -54,6 +57,7 @@ export class WebhookService implements OnModuleInit, OnModuleDestroy {
   }
 
   async createWebhook(model: WebhookModel) {
+    await this.assertWebhookUrlAllowed(model.payloadUrl)
     const document = await this.webhookRepository.create({
       payloadUrl: model.payloadUrl,
       events: model.events,
@@ -71,6 +75,19 @@ export class WebhookService implements OnModuleInit, OnModuleDestroy {
     )
   }
 
+  // Best-effort early rejection of obviously-internal targets. The real gate is
+  // the delivery-time check in `sendWebhookEvent`, since DNS can change/rebind
+  // between persistence and dispatch.
+  private async assertWebhookUrlAllowed(payloadUrl: string) {
+    try {
+      await assertWebhookTargetIsPublic(payloadUrl)
+    } catch (error: any) {
+      throw createAppException(AppErrorCode.INVALID_PARAMETER, {
+        message: error?.message ?? 'Webhook URL is not allowed',
+      })
+    }
+  }
+
   transformEvents(events: string[]) {
     if (events.includes('all')) return ['all']
     return events.filter((event) => ACCEPT_EVENTS.has(event as any))
@@ -82,6 +99,9 @@ export class WebhookService implements OnModuleInit, OnModuleDestroy {
   }
 
   async updateWebhook(id: string, model: Partial<WebhookModel>) {
+    if (model.payloadUrl !== undefined) {
+      await this.assertWebhookUrlAllowed(model.payloadUrl)
+    }
     await this.webhookRepository.update(id, model)
     const document = await this.webhookRepository.findById(id)
     if (document)
@@ -121,6 +141,9 @@ export class WebhookService implements OnModuleInit, OnModuleDestroy {
     webhook: WebhookRow & { secret: string },
     source: WebhookEventSource = 'system',
   ) {
+    // One stringify for HMAC signing; the dispatched body is parsed back from
+    // that same string so the signed bytes and the sent body never diverge, and
+    // a non-cloneable value can never throw here.
     const stringifyPayload = JSON.stringify(payload)
     const clonedPayload = JSON.parse(stringifyPayload)
 
@@ -147,11 +170,26 @@ export class WebhookService implements OnModuleInit, OnModuleDestroy {
       response: null,
     })
     try {
+      await assertWebhookTargetIsPublic(webhook.payloadUrl)
+    } catch (error: any) {
+      await this.webhookRepository.updateEvent(webhookEvent.id, {
+        response: {
+          error: 'SSRF_BLOCKED',
+          message: error?.message ?? 'Webhook target rejected',
+          timestamp: Date.now(),
+        },
+        status: 0,
+        success: false,
+      })
+      return
+    }
+    try {
       const response = await this.httpService.axiosRef.post(
         webhook.payloadUrl,
         clonedPayload,
         {
           headers,
+          maxRedirects: 0,
           'axios-retry': {
             retries: 10,
           },
@@ -211,6 +249,85 @@ export class WebhookService implements OnModuleInit, OnModuleDestroy {
   clearDispatchEvents(hookId: string) {
     return this.webhookRepository.deleteEventsByHookId(hookId)
   }
+}
+
+const ALLOWED_PROTOCOLS = new Set(['http:', 'https:'])
+
+class WebhookTargetRejectedError extends Error {}
+
+// Range checks delegate to the shared SSRF guard (url-guard.ts) so the blocked
+// CIDR list has a single source of truth across webhook / link-avatar / agent-browser.
+function isBlockedIP(rawIp: string): boolean {
+  const zoneIdx = rawIp.indexOf('%')
+  const ip = zoneIdx === -1 ? rawIp : rawIp.slice(0, zoneIdx)
+  const family = isIP(ip)
+  if (family === 0) return true
+  return isPrivateIp(ip, family)
+}
+
+/**
+ * SSRF guard. Validates protocol and resolves the hostname, rejecting any
+ * webhook target that points at loopback / link-local / private / metadata
+ * addresses. Returns the resolved IP that the request will actually hit.
+ *
+ * NOTE: this is checked at delivery time (the real gate). A DNS-rebinding
+ * attacker can still pass this check and then re-point the hostname before the
+ * HTTP socket connects; `maxRedirects: 0` removes the redirect-based bypass but
+ * not rebinding. Pinning the connection to `resolvedIp` would be needed to
+ * fully close that window.
+ */
+async function assertWebhookTargetIsPublic(rawUrl: string): Promise<string> {
+  let url: URL
+  try {
+    url = new URL(rawUrl)
+  } catch {
+    throw new WebhookTargetRejectedError(`Invalid webhook URL: ${rawUrl}`)
+  }
+  if (!ALLOWED_PROTOCOLS.has(url.protocol)) {
+    throw new WebhookTargetRejectedError(
+      `Webhook protocol not allowed: ${url.protocol}`,
+    )
+  }
+  let hostname = url.hostname
+  if (hostname.startsWith('[') && hostname.endsWith(']')) {
+    hostname = hostname.slice(1, -1)
+  }
+
+  // Hostname is already a literal IP — validate directly.
+  if (isIP(hostname)) {
+    if (isBlockedIP(hostname)) {
+      throw new WebhookTargetRejectedError(
+        `Webhook target resolves to a blocked address: ${hostname}`,
+      )
+    }
+    return hostname
+  }
+
+  if (hostname.toLowerCase() === 'localhost') {
+    throw new WebhookTargetRejectedError('Webhook target localhost is blocked')
+  }
+
+  let resolved: { address: string }[]
+  try {
+    resolved = await dnsLookup(hostname, { all: true })
+  } catch {
+    throw new WebhookTargetRejectedError(
+      `Webhook target hostname could not be resolved: ${hostname}`,
+    )
+  }
+  if (resolved.length === 0) {
+    throw new WebhookTargetRejectedError(
+      `Webhook target hostname did not resolve: ${hostname}`,
+    )
+  }
+  for (const { address } of resolved) {
+    if (isBlockedIP(address)) {
+      throw new WebhookTargetRejectedError(
+        `Webhook target resolves to a blocked address: ${address}`,
+      )
+    }
+  }
+  return resolved[0].address
 }
 
 function generateSha1Signature(secret: string, payload: string): string {

--- a/apps/core/src/processors/agent-browser/url-guard.ts
+++ b/apps/core/src/processors/agent-browser/url-guard.ts
@@ -106,7 +106,8 @@ function isPrivateIpv4(addr: string): boolean {
 function isPrivateIpv6(addr: string): boolean {
   const lower = addr.toLowerCase()
   if (lower === '::' || lower === '::1') return true
-  const v4mapped = /^:{2}f{4}:((?:\d+\.){3}\d+)$/i.exec(addr)
+  // IPv4-mapped (::ffff:a.b.c.d) and IPv4-compatible (::a.b.c.d) forms
+  const v4mapped = /^::(?:ffff:)?((?:\d+\.){3}\d+)$/i.exec(addr)
   if (v4mapped) return isPrivateIpv4(v4mapped[1])
   if (lower.startsWith('fe8') || lower.startsWith('fe9')) return true
   if (lower.startsWith('fea') || lower.startsWith('feb')) return true

--- a/apps/core/src/processors/helper/helper.image.service.ts
+++ b/apps/core/src/processors/helper/helper.image.service.ts
@@ -7,6 +7,7 @@ import { ConfigsService } from '~/modules/configs/configs.service'
 import type { ImageModel } from '~/shared/types/legacy-model.type'
 import { pickImagesFromMarkdown } from '~/utils/pic.util'
 import { AsyncQueue } from '~/utils/queue.util'
+import { assertPublicHttpUrl } from '~/utils/ssrf.util'
 import { requireDepsWithInstall } from '~/utils/tool.util'
 
 import { HttpService } from './helper.http.service'
@@ -112,8 +113,13 @@ export class ImageService implements OnModuleInit {
     const {
       url: { webUrl },
     } = await this.configsService.waitForConfigReady()
+    // Markdown image URLs are author-supplied; guard the outbound fetch and
+    // disable redirect following so a public host cannot 30x us into one.
+    await assertPublicHttpUrl(image, { allowHttp: true })
     const { data, headers } = await this.httpService.axiosRef.get<any>(image, {
       responseType: 'arraybuffer',
+      timeout: 10_000,
+      maxRedirects: 0,
       headers: {
         'user-agent':
           'Mozilla/5.0 (Macintosh; Intel Mac OS X 11_1_0) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/87.0.4280.88 Safari/537.36',

--- a/apps/core/src/processors/redis/redis.service.ts
+++ b/apps/core/src/processors/redis/redis.service.ts
@@ -135,10 +135,58 @@ export class RedisService {
     return this._emitter
   }
 
-  public async cleanCatch() {
+  /**
+   * Iterate the keyspace with a non-blocking cursor (`SCAN`) instead of the
+   * O(N) blocking `KEYS`. Collects every key matching `pattern`. Use this on
+   * hot/scheduled/public paths where `KEYS` would stall the whole Redis.
+   */
+  public async scanKeys(
+    pattern: string,
+    count = 100,
+    client: IORedis = this.redisClient,
+  ): Promise<string[]> {
+    const keys: string[] = []
+    const stream = client.scanStream({ match: pattern, count })
+    for await (const batch of stream) {
+      if ((batch as string[]).length > 0) keys.push(...(batch as string[]))
+    }
+    return keys
+  }
+
+  /**
+   * Delete every key matching `pattern` using a cursor scan, deleting in
+   * batches with `UNLINK` (non-blocking reclaim) to avoid stalling Redis on
+   * large key sets.
+   */
+  public async deleteKeysByPattern(
+    pattern: string,
+    options: { count?: number; batchSize?: number } = {},
+  ): Promise<number> {
+    const { count = 100, batchSize = 500 } = options
     const redis = this.getClient()
-    const keys: string[] = await redis.keys(`${API_CACHE_PREFIX}*`)
-    await Promise.all(keys.map((key) => redis.del(key)))
+    let deleted = 0
+    let buffer: string[] = []
+
+    const flush = async () => {
+      if (buffer.length === 0) return
+      deleted += await redis.unlink(...buffer)
+      buffer = []
+    }
+
+    const stream = redis.scanStream({ match: pattern, count })
+    for await (const batch of stream) {
+      const keys = batch as string[]
+      if (keys.length === 0) continue
+      buffer.push(...keys)
+      if (buffer.length >= batchSize) await flush()
+    }
+    await flush()
+
+    return deleted
+  }
+
+  public async cleanCatch() {
+    await this.deleteKeysByPattern(`${API_CACHE_PREFIX}*`)
 
     return
   }
@@ -151,10 +199,7 @@ export class RedisService {
   }
 
   public async cleanAllRedisKey() {
-    const redis = this.getClient()
-    const keys: string[] = await redis.keys(getRedisKey('*'))
-
-    await Promise.all(keys.map((key) => redis.del(key)))
+    await this.deleteKeysByPattern(getRedisKey('*'))
 
     return
   }

--- a/apps/core/src/utils/ip.util.ts
+++ b/apps/core/src/utils/ip.util.ts
@@ -6,29 +6,37 @@ import type { IncomingMessage } from 'node:http'
 
 import type { FastifyRequest } from 'fastify'
 
+const headerValue = (v: unknown): string | undefined =>
+  (Array.isArray(v) ? v[0] : v) as string | undefined
+
 export const getIp = (request: FastifyRequest | IncomingMessage) => {
   const req = request as any
 
   const headers = request.headers
 
-  let ip: string =
-    headers['True-Client-IP'] ||
-    headers['true-client-ip'] ||
-    headers['CF-Connecting-IP'] ||
-    headers['cf-connecting-ip'] ||
-    headers['cf-connecting-ipv6'] ||
-    headers['CF-Connecting-IPv6'] ||
-    headers['x-forwarded-for'] ||
-    headers['X-Forwarded-For'] ||
-    headers['X-Real-IP'] ||
-    headers['x-real-ip'] ||
+  // Trust model: Fastify is configured with `trustProxy` (see fastify.adapter),
+  // so `request.ip` already resolves to the proxy-attested client IP by walking
+  // only the trusted tail of `X-Forwarded-For`. Prefer it. We do NOT read the
+  // leftmost XFF segment (the part fully under client control). Raw `True-Client-IP`
+  // / `CF-Connecting-IP` are demoted below `request.ip` because they are only
+  // trustworthy when the deployment actually sits behind Cloudflare — an
+  // operator-specific assumption we don't bake in.
+  const forwardedFor = headerValue(headers['x-forwarded-for'])
+
+  const ip: string =
     req?.ip ||
+    headerValue(headers['true-client-ip']) ||
+    headerValue(headers['cf-connecting-ip']) ||
+    headerValue(headers['cf-connecting-ipv6']) ||
+    // When falling back to a raw XFF header (no framework-resolved ip), the
+    // rightmost entry is the hop closest to our trusted proxy, hence the least
+    // spoofable.
+    forwardedFor?.split(',').at(-1)?.trim() ||
+    headerValue(headers['x-real-ip']) ||
     req?.ips?.[0] ||
     req?.raw?.connection?.remoteAddress ||
     req?.raw?.socket?.remoteAddress ||
-    undefined
-  if (ip && ip.split(',').length > 0) {
-    ip = ip.split(',')[0]
-  }
+    ''
+
   return ip
 }

--- a/apps/core/src/utils/sandbox/sandbox-worker-code.ts
+++ b/apps/core/src/utils/sandbox/sandbox-worker-code.ts
@@ -28,6 +28,206 @@ if (!parentPort) {
 const port = parentPort;
 const pendingRequests = new Map();
 
+const dnsPromises = require('node:dns').promises;
+const net = require('node:net');
+
+// ===== SSRF egress guard (self-contained; the Worker runs as eval'd string
+// code and cannot import app modules) =====
+// Mirrors the range checks in apps/core/src/processors/agent-browser/url-guard.ts.
+
+function ipv4ToParts(ip) {
+  const parts = ip.split('.').map((p) => Number(p));
+  if (parts.length !== 4 || parts.some((p) => !Number.isInteger(p) || p < 0 || p > 255)) {
+    return null;
+  }
+  return parts;
+}
+
+function isPrivateIpv4(ip) {
+  const p = ipv4ToParts(ip);
+  if (!p) return false;
+  const [a, b] = p;
+  if (a === 0) return true;                 // 0.0.0.0/8
+  if (a === 10) return true;                // 10.0.0.0/8 RFC1918
+  if (a === 127) return true;               // 127.0.0.0/8 loopback
+  if (a === 169 && b === 254) return true;  // 169.254.0.0/16 link-local (+ metadata 169.254.169.254)
+  if (a === 172 && b >= 16 && b <= 31) return true; // 172.16.0.0/12 RFC1918
+  if (a === 192 && b === 168) return true;  // 192.168.0.0/16 RFC1918
+  if (a === 100 && b >= 64 && b <= 127) return true; // 100.64.0.0/10 CGNAT
+  if (a >= 224) return true;                // 224.0.0.0/4 multicast + 240.0.0.0/4 reserved
+  return false;
+}
+
+function isPrivateIpv6(ip) {
+  let addr = ip.toLowerCase();
+  if (addr.startsWith('[') && addr.endsWith(']')) addr = addr.slice(1, -1);
+  // strip zone id
+  const pct = addr.indexOf('%');
+  if (pct !== -1) addr = addr.slice(0, pct);
+  if (addr === '::1' || addr === '::') return true;                 // loopback / unspecified
+  if (addr.startsWith('fe8') || addr.startsWith('fe9') ||
+      addr.startsWith('fea') || addr.startsWith('feb')) return true; // fe80::/10 link-local
+  if (addr.startsWith('fc') || addr.startsWith('fd')) return true;   // fc00::/7 ULA
+  if (addr.startsWith('ff')) return true;                            // ff00::/8 multicast
+  // IPv4-mapped / -compatible: ::ffff:a.b.c.d or ::a.b.c.d
+  const mapped = addr.match(/(?:::ffff:|::)(\\d+\\.\\d+\\.\\d+\\.\\d+)$/);
+  if (mapped) return isPrivateIpv4(mapped[1]);
+  return false;
+}
+
+function isPrivateIp(ip) {
+  const kind = net.isIP(ip);
+  if (kind === 4) return isPrivateIpv4(ip);
+  if (kind === 6) return isPrivateIpv6(ip);
+  // Not a literal IP — be conservative if it somehow reaches here.
+  return false;
+}
+
+async function assertEgressUrlSafe(input) {
+  let url;
+  try {
+    url = input instanceof URL ? input : new URL(String(input && input.url ? input.url : input));
+  } catch {
+    throw new Error('SSRF guard: invalid URL');
+  }
+  const protocol = url.protocol;
+  if (protocol !== 'http:' && protocol !== 'https:') {
+    throw new Error('SSRF guard: disallowed protocol "' + protocol + '"');
+  }
+  let hostname = url.hostname;
+  if (hostname.startsWith('[') && hostname.endsWith(']')) hostname = hostname.slice(1, -1);
+
+  // Literal IP target — check directly (no DNS).
+  if (net.isIP(hostname)) {
+    if (isPrivateIp(hostname)) {
+      throw new Error('SSRF guard: blocked private/loopback address ' + hostname);
+    }
+    return url;
+  }
+
+  // Hostname — resolve every A/AAAA record and reject if ANY is private.
+  let resolved;
+  try {
+    resolved = await dnsPromises.lookup(hostname, { all: true });
+  } catch (error) {
+    throw new Error('SSRF guard: DNS lookup failed for ' + hostname + ': ' + (error && error.message));
+  }
+  if (!resolved || resolved.length === 0) {
+    throw new Error('SSRF guard: no addresses resolved for ' + hostname);
+  }
+  for (const entry of resolved) {
+    if (isPrivateIp(entry.address)) {
+      throw new Error('SSRF guard: ' + hostname + ' resolves to blocked address ' + entry.address);
+    }
+  }
+  return url;
+}
+
+// Wrap the real fetch so every sandbox egress is validated first. Redirects
+// ARE followed (so legit http→https / apex→www / canonicalization 3xx work),
+// but EVERY hop is re-validated against the egress guard to keep the
+// redirect-to-internal SSRF bypass closed.
+//
+// Implementation: we force redirect:'manual' on the underlying undici fetch so
+// each 3xx surfaces as a real response (in Node/undici, redirect:'manual'
+// returns the actual 3xx with a readable Location header and a 300-399 status,
+// unlike the browser's opaque status-0 response). We inspect Location, resolve
+// it against the current URL, re-validate, and re-issue — up to MAX_REDIRECTS.
+const MAX_REDIRECTS = 20;
+const REDIRECT_STATUSES = new Set([301, 302, 303, 307, 308]);
+
+function createGuardedFetch() {
+  const realFetch = globalThis.fetch;
+  if (typeof realFetch !== 'function') return realFetch;
+  return async function guardedFetch(input, init) {
+    const userRedirect = init && init.redirect;
+
+    // Honor an explicit non-follow choice: don't auto-follow, just validate the
+    // first target and hand back the raw response (manual: caller inspects 3xx;
+    // error: undici throws on redirect).
+    if (userRedirect === 'manual' || userRedirect === 'error') {
+      await assertEgressUrlSafe(input);
+      return realFetch(input, init);
+    }
+
+    // Auto-follow path (redirect unspecified or 'follow').
+    let currentUrl =
+      input instanceof URL
+        ? input.href
+        : input && typeof input === 'object' && input.url
+          ? input.url
+          : String(input);
+    let currentInput = input;
+    let currentInit = init ? { ...init } : {};
+    currentInit.redirect = 'manual';
+
+    for (let hop = 0; ; hop++) {
+      await assertEgressUrlSafe(currentUrl);
+      const res = await realFetch(currentInput, currentInit);
+
+      const location = res.headers.get('location');
+      if (!REDIRECT_STATUSES.has(res.status) || !location) {
+        return res;
+      }
+
+      if (hop >= MAX_REDIRECTS) {
+        throw new Error('SSRF guard: too many redirects (max ' + MAX_REDIRECTS + ')');
+      }
+
+      // Resolve the (possibly relative) Location against the current URL.
+      let nextUrl;
+      try {
+        nextUrl = new URL(location, currentUrl).href;
+      } catch {
+        throw new Error('SSRF guard: invalid redirect Location "' + location + '"');
+      }
+
+      // Drain the redirect body so the underlying socket can be reused/freed.
+      try { await res.body?.cancel(); } catch {}
+
+      // Method/body handling per fetch spec, pragmatically:
+      //   307/308 — preserve method AND body (no downgrade).
+      //   301/302/303 — follow as GET and drop the body (browser default; the
+      //     vast majority of canonicalization/apex→www redirects are 301/302).
+      const next = { ...currentInit, redirect: 'manual' };
+      if (res.status === 301 || res.status === 302 || res.status === 303) {
+        next.method = 'GET';
+        delete next.body;
+      }
+
+      currentUrl = nextUrl;
+      currentInput = nextUrl;
+      currentInit = next;
+    }
+  };
+}
+
+// Wrap WebSocket so the connection target is validated before the handshake.
+function createGuardedWebSocket() {
+  const RealWebSocket = globalThis.WebSocket;
+  if (typeof RealWebSocket !== 'function') return RealWebSocket;
+  return new Proxy(RealWebSocket, {
+    construct(target, args) {
+      const rawUrl = args[0];
+      let url;
+      try {
+        url = new URL(String(rawUrl));
+      } catch {
+        throw new Error('SSRF guard: invalid WebSocket URL');
+      }
+      let hostname = url.hostname;
+      if (hostname.startsWith('[') && hostname.endsWith(']')) hostname = hostname.slice(1, -1);
+      if (net.isIP(hostname) && isPrivateIp(hostname)) {
+        throw new Error('SSRF guard: blocked private WebSocket target ' + hostname);
+      }
+      // Async DNS resolution can't be awaited in a synchronous constructor;
+      // literal-IP targets are blocked above, hostnames pass through. The
+      // fetch path remains the fully-guarded egress channel.
+      return Reflect.construct(target, args);
+    },
+  });
+}
+
 function generateId() {
   return Math.random().toString(36).slice(2) + Date.now().toString(36);
 }
@@ -53,13 +253,57 @@ async function requestBridgeCall(method, args) {
 
 // ===== The following features are implemented directly inside the Worker =====
 
-const BANNED_MODULES = new Set([
-  'child_process', 'cluster', 'dgram', 'dns', 'fs', 'fs/promises',
-  'inspector', 'os', 'process',
-  'repl', 'sys', 'tls', 'v8', 'vm', 'worker_threads',
-  // Prevent bypassing sandbox restrictions via module.createRequire
-  'module',
+// ALLOWLIST of built-in module specifiers the snippet runtime may require.
+// A denylist is bypassable (transitive re-exports, node: prefixes, sub-path
+// requires). Anything not listed here is rejected. Keep this minimal — adding
+// a module here grants the snippet its full surface, so prefer wrappers
+// (see restrictedNetModule) for modules with dangerous capabilities.
+const ALLOWED_BUILTIN_MODULES = new Set([
+  'url',         // URL / URLSearchParams (WHATWG-overlapping, safe)
+  'querystring',
+  'string_decoder',
+  'punycode',
+  'events',
+  'util',
+  'assert',
+  'buffer',
+  'path',
+  'crypto',      // hashing / random; safe surface
+  'zlib',
+  'stream',
+  'timers',
 ]);
+
+// 'net' is needed by built-in snippets ONLY for isIP/isIPv4/isIPv6. The full
+// module exposes raw TCP sockets (Socket/createConnection/Server) which would
+// bypass the fetch SSRF egress guard entirely. Hand back a restricted facade
+// exposing only the pure address-classification helpers.
+function restrictedNetModule() {
+  const realNet = require('node:net');
+  return {
+    isIP: realNet.isIP.bind(realNet),
+    isIPv4: realNet.isIPv4.bind(realNet),
+    isIPv6: realNet.isIPv6.bind(realNet),
+  };
+}
+
+// Normalize a specifier so 'node:fs', 'fs', 'fs/promises', and 'FS' can't be
+// used to slip past the allowlist. Returns the base built-in name (lowercased,
+// node: prefix stripped, sub-path dropped) or null if it is not a bare
+// built-in specifier (relative/absolute/package paths fall through to the
+// normal resolver, which is jailed to requireBasePath).
+function normalizeBuiltinId(moduleId) {
+  let id = moduleId;
+  if (id.startsWith('node:')) id = id.slice(5);
+  // Bare specifiers only (no path separators in the first segment, no relative).
+  if (id.startsWith('.') || id.startsWith('/')) return null;
+  const base = id.split('/')[0].toLowerCase();
+  return base;
+}
+
+// Node's exhaustive built-in module list — used to reject ANY built-in that is
+// not explicitly allowlisted, regardless of node: prefix or sub-path form.
+const NODE_BUILTIN_MODULES = new Set(require('node:module').builtinModules.map((m) => m.replace(/^node:/, '')));
 
 // require runs directly inside the Worker
 function createSandboxRequire(basePath) {
@@ -70,17 +314,35 @@ function createSandboxRequire(basePath) {
       throw new Error('require: module id must be a non-empty string');
     }
 
-    const normalizedId = moduleId.startsWith('node:') ? moduleId.slice(5) : moduleId;
-
-    if (BANNED_MODULES.has(normalizedId)) {
-      throw new Error('require: module "' + moduleId + '" is not allowed');
-    }
-
     // Remote modules are loaded through the bridge
     if (moduleId.startsWith('http://') || moduleId.startsWith('https://')) {
       throw new Error('Remote modules must use async require: await require("' + moduleId + '")');
     }
 
+    const builtinBase = normalizeBuiltinId(moduleId);
+
+    if (builtinBase !== null) {
+      if (builtinBase === 'net') {
+        return restrictedNetModule();
+      }
+      if (ALLOWED_BUILTIN_MODULES.has(builtinBase)) {
+        // Resolve via the canonical node: name so an attacker-shadowed local
+        // package of the same name under requireBasePath cannot be loaded.
+        return baseRequire('node:' + builtinBase);
+      }
+      // A Node built-in that is NOT allowlisted (covers every node: prefix and
+      // sub-path form, e.g. 'fs', 'node:fs', 'fs/promises') — always rejected.
+      if (NODE_BUILTIN_MODULES.has(builtinBase)) {
+        throw new Error('require: built-in module "' + moduleId + '" is not allowed');
+      }
+      // Otherwise it is a bare third-party package specifier (e.g. 'axios',
+      // '@mx-space/extra'). Requiring user-installed packages from the data
+      // dir's node_modules is a documented snippet feature, so resolve it
+      // through the normal resolver jailed to requireBasePath.
+      return baseRequire(moduleId);
+    }
+
+    // Relative / absolute paths resolve against requireBasePath as before.
     return baseRequire(moduleId);
   };
 }
@@ -136,8 +398,9 @@ function createSandboxConsole(namespace) {
 
 // Create the HTTP service (implemented directly inside the Worker)
 function createHttpService() {
+  const guardedFetch = createGuardedFetch();
   const request = async (url, options = {}) => {
-    const res = await fetch(url, options);
+    const res = await guardedFetch(url, options);
     const contentType = res.headers.get('content-type') || '';
     let data;
     if (contentType.includes('application/json')) {
@@ -302,7 +565,9 @@ async function executeCode(payload) {
       __filename: '',
 
       // ===== Network APIs =====
-      fetch: globalThis.fetch,
+      // fetch/WebSocket are wrapped with an SSRF egress guard that blocks
+      // private/loopback/link-local/metadata targets (see createGuardedFetch).
+      fetch: createGuardedFetch(),
       URL: globalThis.URL,
       URLSearchParams: globalThis.URLSearchParams,
       Headers: globalThis.Headers,
@@ -311,7 +576,7 @@ async function executeCode(payload) {
       Blob: globalThis.Blob,
       File: globalThis.File,
       FormData: globalThis.FormData,
-      WebSocket: globalThis.WebSocket,
+      WebSocket: createGuardedWebSocket(),
 
       // ===== Encoding APIs =====
       TextEncoder: globalThis.TextEncoder,

--- a/apps/core/src/utils/ssrf.util.ts
+++ b/apps/core/src/utils/ssrf.util.ts
@@ -1,0 +1,48 @@
+import {
+  assertHostnameSafe,
+  parseAndValidateUrl,
+  UnsafeUrlError,
+} from '~/processors/agent-browser/url-guard'
+
+export {
+  isPrivateIp,
+  UnsafeUrlError,
+} from '~/processors/agent-browser/url-guard'
+
+export interface AssertPublicHttpUrlOptions {
+  /**
+   * Allow `http:` targets. Defaults to `false` — only `https:` is accepted.
+   * Outbound fetches of remote, attacker-influenced URLs (friend-link avatars)
+   * should stay on https; flip this on only for callers that legitimately need
+   * cleartext.
+   */
+  allowHttp?: boolean
+}
+
+/**
+ * SSRF guard for outbound fetches of user/applicant-supplied URLs.
+ *
+ * Validates the scheme, then resolves the hostname via `dns.lookup({ all:true })`
+ * and rejects any target that points at loopback / link-local (incl.
+ * 169.254.169.254 cloud metadata) / RFC1918 / CGNAT / IPv6 ULA + link-local /
+ * IPv4-mapped addresses. Delegates the range checks to `url-guard.ts` so there
+ * is a single source of truth shared with the agent-browser and Open Graph
+ * fetchers.
+ *
+ * NOTE (DNS rebinding): this is a TOCTOU check. A rebinding attacker can pass
+ * the lookup here and then re-point the hostname before the HTTP socket
+ * connects. Callers MUST additionally disable redirect following
+ * (`maxRedirects: 0`) to remove the redirect-based bypass. Fully closing the
+ * rebinding window would require pinning the connection to the resolved IP.
+ */
+export async function assertPublicHttpUrl(
+  rawUrl: string,
+  options: AssertPublicHttpUrlOptions = {},
+): Promise<URL> {
+  const url = parseAndValidateUrl(rawUrl)
+  if (!options.allowHttp && url.protocol !== 'https:') {
+    throw new UnsafeUrlError(`Disallowed protocol: ${url.protocol}`)
+  }
+  await assertHostnameSafe(url.hostname)
+  return url
+}

--- a/apps/core/src/utils/system.util.ts
+++ b/apps/core/src/utils/system.util.ts
@@ -1,6 +1,5 @@
 import cdp, { exec } from 'node:child_process'
 import { existsSync } from 'node:fs'
-import os from 'node:os'
 import path from 'node:path'
 import { promisify } from 'node:util'
 
@@ -83,14 +82,10 @@ export const installPKG = async (name: string, cwd: string) => {
       throw new Error('No package manager found')
     }
   }
-  process.chdir(cwd)
-  // await $`${manager} ${INSTALL_COMMANDS[manager]} ${name}`
-  const shell = os.platform() === 'win32' ? 'powershell.exe' : 'bash'
-  const pty = spawnShell(
-    shell,
-    ['-c', `${manager} ${INSTALL_COMMANDS[manager]} ${name}`],
-    {},
-  )
+  const names = name.split(/\s+/).filter(Boolean)
+  const pty = spawnShell(manager, [INSTALL_COMMANDS[manager], ...names], {
+    cwd,
+  })
 
   return pty
 }

--- a/apps/core/test/helper/pg-testcontainer.ts
+++ b/apps/core/test/helper/pg-testcontainer.ts
@@ -71,6 +71,53 @@ export async function startPgTestContainer(): Promise<PgTestDatabase> {
   return container
 }
 
+// In CI every vitest worker shares one external PG (PG_VERIFY_URL), and the
+// per-file afterAll in setupFiles/lifecycle.ts truncates ALL public tables.
+// Specs that assert cross-statement state on real PG must run in their own
+// database or a concurrently finishing file wipes their rows mid-test.
+export async function createIsolatedPgDatabase(): Promise<{
+  getConnectionUri: () => string
+  drop: () => Promise<void>
+}> {
+  const base = await startPgTestContainer()
+  const baseUri = base.getConnectionUri()
+  const dbName = `mx_isolated_${process.pid}_${Date.now()}`
+
+  const admin = new Pool({ connectionString: baseUri, max: 1 })
+  try {
+    await admin.query(`CREATE DATABASE ${dbName}`)
+  } finally {
+    await admin.end()
+  }
+
+  const url = new URL(baseUri)
+  url.pathname = `/${dbName}`
+  const connectionUri = url.toString()
+
+  const migrationsFolder = path.resolve(
+    __dirname,
+    '../../src/database/migrations',
+  )
+  const pool = new Pool({ connectionString: connectionUri, max: 2 })
+  try {
+    await runSchemaMigrationFiles(pool, migrationsFolder)
+  } finally {
+    await pool.end()
+  }
+
+  return {
+    getConnectionUri: () => connectionUri,
+    drop: async () => {
+      const cleaner = new Pool({ connectionString: baseUri, max: 1 })
+      try {
+        await cleaner.query(`DROP DATABASE IF EXISTS ${dbName} WITH (FORCE)`)
+      } finally {
+        await cleaner.end()
+      }
+    },
+  }
+}
+
 export async function stopPgTestContainer() {
   if (!container) {
     externalDatabase = undefined

--- a/apps/core/test/src/contracts/category.contract.spec.ts
+++ b/apps/core/test/src/contracts/category.contract.spec.ts
@@ -68,6 +68,9 @@ const postServiceProvider = {
     async listByCategory() {
       return []
     },
+    async listByCategoryIds() {
+      return new Map()
+    },
   },
 }
 

--- a/apps/core/test/src/modules/ai/ai-summary.faux.e2e.spec.ts
+++ b/apps/core/test/src/modules/ai/ai-summary.faux.e2e.spec.ts
@@ -3,6 +3,7 @@ import { afterEach, describe, expect, it, vi } from 'vitest'
 
 import { withFauxAi } from '@/helper/faux-ai.helper'
 import { createPgRepositoryMock, now } from '@/helper/pg-repository-mock'
+import { CollectionRefTypes } from '~/constants/db.constant'
 import { AIProviderType } from '~/modules/ai/ai.types'
 import type { AiStreamEvent } from '~/modules/ai/ai-inflight/ai-inflight.types'
 import type { AiSummaryRepository } from '~/modules/ai/ai-summary/ai-summary.repository'
@@ -45,7 +46,13 @@ function createService(runtime: PiRuntimeAdapter) {
   const databaseService = {
     findGlobalById: vi.fn(async () => ({
       id: 'post-1',
-      document: { id: 'post-1', text: 'source text', title: 'Title' },
+      type: CollectionRefTypes.Post,
+      document: {
+        id: 'post-1',
+        text: 'source text',
+        title: 'Title',
+        isPublished: true,
+      },
     })),
     findGlobalByIds: vi.fn(),
   }

--- a/apps/core/test/src/modules/ai/ai-translation.repository.pg.e2e.spec.ts
+++ b/apps/core/test/src/modules/ai/ai-translation.repository.pg.e2e.spec.ts
@@ -1,9 +1,6 @@
 import { drizzle } from 'drizzle-orm/node-postgres'
 import { Pool } from 'pg'
-import {
-  startPgTestContainer,
-  stopPgTestContainer,
-} from 'test/helper/pg-testcontainer'
+import { createIsolatedPgDatabase } from 'test/helper/pg-testcontainer'
 import { afterAll, beforeAll, describe, expect, it } from 'vitest'
 
 import {
@@ -15,12 +12,13 @@ import { SnowflakeService } from '~/shared/id/snowflake.service'
 
 describe('ai-translation repositories upsert (real PG, ON CONFLICT)', () => {
   let pool: Pool
+  let database: Awaited<ReturnType<typeof createIsolatedPgDatabase>>
   let translationRepo: AiTranslationRepository
   let entryRepo: TranslationEntryRepository
 
   beforeAll(async () => {
-    const container = await startPgTestContainer()
-    pool = new Pool({ connectionString: container.getConnectionUri() })
+    database = await createIsolatedPgDatabase()
+    pool = new Pool({ connectionString: database.getConnectionUri() })
     const db = drizzle(pool) as unknown as AppDatabase
     const snowflake = new SnowflakeService()
     translationRepo = new AiTranslationRepository(db, snowflake)
@@ -29,7 +27,7 @@ describe('ai-translation repositories upsert (real PG, ON CONFLICT)', () => {
 
   afterAll(async () => {
     await pool?.end()
-    await stopPgTestContainer()
+    await database?.drop()
   })
 
   it('inserts then updates an ai_translations row on the same (refId, refType, lang)', async () => {

--- a/apps/core/test/src/modules/auth/auth.controller.e2e-spec.ts
+++ b/apps/core/test/src/modules/auth/auth.controller.e2e-spec.ts
@@ -7,7 +7,9 @@ import { AuthController } from '~/modules/auth/auth.controller'
 const createController = () => {
   const authService = {
     verifyCustomToken: vi.fn().mockResolvedValue([true, { userId: 'owner-1' }]),
-    getTokenSecret: vi.fn().mockResolvedValue({ id: 'token-1' }),
+    getTokenSecret: vi
+      .fn()
+      .mockResolvedValue({ id: 'token-1', token: 'txo-token' }),
     getAllAccessToken: vi
       .fn()
       .mockResolvedValue([
@@ -57,7 +59,7 @@ describe('AuthController', () => {
 
   it('rejects deletion when the token id is not found', async () => {
     const { authService, controller } = createController()
-    authService.getAllAccessToken.mockResolvedValue([])
+    authService.getTokenSecret.mockResolvedValue(null)
 
     await expect(controller.deleteToken({ id: 'missing' })).rejects.toThrow(
       AppException,

--- a/apps/core/test/src/modules/auth/auth.service.spec.ts
+++ b/apps/core/test/src/modules/auth/auth.service.spec.ts
@@ -71,18 +71,15 @@ describe('AuthService', () => {
     ).rejects.toThrow(AppException)
   })
 
-  it('extracts API keys from current and deprecated request locations', () => {
+  it('extracts API keys from the x-api-key header only', () => {
     const { service } = createService()
 
     expect(
       service.getApiKeyFromRequest({ headers: { 'x-api-key': 'current' } }),
-    ).toEqual({ key: 'current', deprecated: false })
-    expect(service.getApiKeyFromRequest({ query: { token: 'query' } })).toEqual(
-      {
-        key: 'query',
-        deprecated: true,
-      },
-    )
+    ).toEqual({ key: 'current' })
+    expect(
+      service.getApiKeyFromRequest({ query: { token: 'query' } } as any),
+    ).toBeNull()
   })
 
   it('ignores Authorization: Bearer api-key fallback after narrowing', () => {

--- a/apps/core/test/src/modules/category/category.controller.spec.ts
+++ b/apps/core/test/src/modules/category/category.controller.spec.ts
@@ -77,6 +77,16 @@ const createController = (
     listByCategory: vi.fn().mockImplementation(async (id: string) => {
       return (posts[id] ?? []).map((p) => ({ ...p }))
     }),
+    listByCategoryIds: vi.fn().mockImplementation(async (ids: string[]) => {
+      const grouped = new Map<string, any[]>()
+      for (const id of ids) {
+        grouped.set(
+          id,
+          (posts[id] ?? []).map((p) => ({ ...p })),
+        )
+      }
+      return grouped
+    }),
     countByCategoryId: vi.fn().mockResolvedValue(0),
   }
 


### PR DESCRIPTION
## Summary

Codebase-wide security and performance hardening across `apps/core` business modules, found via an audit of public-input, auth, dangerous-capability, and AI modules. All changes type-check clean (`tsc --noEmit`) and were reviewed by independent passes; behavior-breaking regressions surfaced in review were fixed before commit.

No DB migrations. No API contract removals (the `recently` attitude GET is kept as a deprecated alias alongside a new POST).

## Security

- **ai**: gate public summary / insights / translation-stream endpoints behind article visibility so drafts and password-protected content stop leaking (shared `isGlobalArticleVisible` util; admin task paths untouched).
- **note**: add `password IS NULL` to the visibility clause *and* the two raw-SQL prepared statements (with bumped statement names) — protected notes were leaking full content via RSS / sitemap / timeline. The password-unlock read path does not use this clause, so unlocking still works.
- **render/markdown**: sanitize the full `marked()` HTML output and escape titles on the public render route (stored XSS). Verified katex / mermaid / code / mention links / spoilers / tables still render.
- **auth**: gate Better Auth CORS reflection on the configured allowlist instead of echoing arbitrary `Origin` with credentials; drop the `?token=` query API-key path (header only now); mask API keys on list responses (reveal endpoint still returns the secret on demand).
- **webhook**: SSRF guard (DNS resolve + private-IP block, `maxRedirects: 0`) before *every* delivery; validate `payloadUrl` at create/update.
- **link**: SSRF guard on the applicant-controlled avatar fetch (http allowed, no redirects).
- **backup**: replace shell `unzip` with JSZip + zip-slip/symlink containment; drop auto dependency install (RCE via install scripts) in favor of a logged warning; quote restore-path shell args.
- **serverless sandbox**: egress allowlist on `fetch`/`WebSocket` with **per-redirect-hop** revalidation; `require` builtin allowlist with `node:` normalization. (`node:vm` remains not a true boundary — see follow-ups.)
- **ip**: configurable `trustProxy` (default `1`, `TRUST_PROXY` env override) + rightmost-XFF parsing to stop client IP spoofing that defeated the throttler and per-IP dedup.
- **subscribe**: cryptographically strong unsubscribe token (`randomBytes(32)`) + URL encoding.
- **dependency install**: spawn with an arg array (no shell, no `process.chdir`).
- **search**: escape `LIKE` wildcards. **comment spam filter**: literal substring/exact match (removes ReDoS surface).
- **init**: assert-not-initialized inside `/restore`. **analyze**: cap pagination via `BasicPagerSchema`.

## Performance / logic

- **redis**: replace blocking `KEYS` with `SCAN`/`UNLINK` helpers on the comment-invalidation hot path, the public analyze endpoint, the cron reset task, and cleanup.
- **category**: collapse the per-category post N+1 into one `inArray` query + Map grouping (ordering, field shape, and empty-category results preserved).
- **webhook**: reuse the signed JSON string for the dispatched body (signature/body can't diverge).
- **cron**: atomic delete counting. **aggregate**: UTC month window for the 12-month trend.
- **activity / comment-country**: log broadcast/cache failures instead of swallowing them.

## Operator notes (verify before deploy)

- `TRUST_PROXY` must match the real proxy hop count (e.g. Cloudflare + Dokploy = `2`), otherwise client IPs collapse to the proxy IP.
- Existing cross-origin admin/frontend origins must be in `CROSS_DOMAIN.allowedOrigins`.
- Admin token list now shows masked values; the UI must read the secret via the reveal endpoint.
- Webhooks that rely on 3xx redirects will now fail delivery (`maxRedirects: 0`).
- Existing subscribers keep their old weak unsubscribe tokens until re-subscribe (optional one-off backfill).

## Accepted follow-ups (not in this PR)

- API key at-rest hashing (needs expand-contract migration; would remove the reveal-secret feature).
- Scoped / limited-permission API keys (every key is currently full-owner).
- `transferOwnerRole` step-up re-auth.
- Real sandbox isolation (`isolated-vm` / out-of-process jail).
- DNS-rebinding pinning for webhook/link fetches.
- Migrate `recently` attitude client to POST, then remove the GET alias.

## Test plan

- `tsc --noEmit` passes; changed files lint clean.
- Not yet run: e2e suites (testcontainers). Recommend `pnpm -C apps/core test` for auth / note / comment / subscribe before merge.
