### PR TITLE
feat(cli): mxs ai management surface

### DIFF
--- a/docs/superpowers/specs/2026-06-17-mxs-ai-v2-design.md
+++ b/docs/superpowers/specs/2026-06-17-mxs-ai-v2-design.md
@@ -1,0 +1,226 @@
+# `mxs ai` — v2 Wave 1 Design
+
+Status: approved
+Author: cc@innei.in
+Date: 2026-06-17
+Package: `@mx-space/cli` (`packages/cli`)
+
+## Summary
+
+Add a new top-level command group `mxs ai` to the CLI. This first wave of v2 ships three async generation commands backed by the existing core AI task queue:
+
+- `mxs ai summary regen <id> [--to <lang>...]` — regenerate an article's AI summary.
+- `mxs ai translate <id> --to <lang>... ` — translate an article into one or more target languages.
+- `mxs ai insights refresh <id> [--to <lang>...]` — regenerate an article's AI insights.
+
+A second wave (`mxs ai tokens`, plus any read commands) is deferred and is out of scope for this spec.
+
+## Goals
+
+- Bring the first slice of the ROADMAP v2 AI section online.
+- Match the existing `mxs <resource> <verb>` command shape so the surface is predictable.
+- Wait for task completion by default, so a CLI run that "returns 0" really means the AI artifact was produced.
+- Surface task progress (`pending → running → succeeded/failed`) through `stderr` without polluting `stdout` (so `--json` and `--llm` outputs stay clean).
+- Reuse the existing `Resolver` so users can pass a slug, title, or Snowflake id (same as `mxs post` / `mxs note`).
+
+## Non-goals
+
+- No `mxs ai tokens` / usage aggregation in this wave. Tracked separately.
+- No read commands (`ai summary list`, `ai translate get`, etc.). Tracked separately.
+- No provider/key/config management (`ai config`, `ai key add/rm`). Not on the v2 roadmap.
+- No agent chat (`ai agent invoke`). Not on the v2 roadmap.
+- No new core endpoints. The CLI consumes endpoints that already exist.
+
+## Server contract (existing)
+
+All three commands target existing core endpoints. No core changes are required for this wave.
+
+| Command | Method | Path | Body |
+|---|---|---|---|
+| `ai summary regen` | `POST` | `/ai/summaries/task` | `{ refId, targetLanguages?: string[] }` |
+| `ai translate` | `POST` | `/ai/translations/task` | `{ refId, targetLanguages: string[] }` |
+| `ai insights refresh` | `POST` | `/ai/insights/task` | `{ refId, targetLanguages?: string[] }` |
+
+Each endpoint responds with `{ taskId: string, created: boolean }`. `created: false` means a deduplicated in-flight task already exists for `(type, payload)` — the CLI MUST treat this as a non-error and follow the existing `taskId` instead of creating a new one.
+
+Polling uses the existing task controller:
+
+- `GET /tasks/:id` — returns the full task record, including `status`, `totalCost`, and any `resultIds`.
+
+Terminal task statuses are `succeeded`, `failed`, `cancelled`. The CLI polls until one of these is reached or the user aborts.
+
+## User-facing commands
+
+### `mxs ai summary regen <id> [--to <lang>...] [--no-wait]`
+
+- `<id>` — article id, slug, or title. Resolved through `Resolver` (post / note / page).
+- `--to <lang>` — optional, repeatable. Passed to the server as `targetLanguages`.
+- `--no-wait` — fire-and-forget; print `taskId` and exit.
+
+### `mxs ai translate <id> --to <lang>... [--no-wait]`
+
+- `<id>` — article id, slug, or title.
+- `--to <lang>` — **required**, repeatable. At least one value.
+- `--no-wait` — fire-and-forget.
+
+### `mxs ai insights refresh <id> [--to <lang>...] [--no-wait]`
+
+- `<id>` — article id, slug, or title.
+- `--to <lang>` — optional, repeatable. Defaults to the server's default language when omitted.
+- `--no-wait` — fire-and-forget.
+
+Global flags (`--json`, `--llm`, `--readable`, `--api-url`, `--token`, `--api-key`, `--profile`, `--dry-run`) follow the existing `runtime-flags` pre-parser. None of these flags are declared on the new subcommands.
+
+## Output
+
+All three commands emit a single `AiTaskView` value via `Renderer.emit`:
+
+```ts
+type AiTaskView = {
+  taskId: string
+  status: 'pending' | 'running' | 'succeeded' | 'failed' | 'cancelled'
+  type: 'summary' | 'translation' | 'insights'
+  refId: string
+  targetLanguages?: string[]
+  totalTokens?: number
+  totalCost?: number     // cents, matching core's totalCost field
+  resultIds?: string[]   // present on succeeded
+  error?: { message: string }  // present on failed
+}
+```
+
+- `readable` (default): a single-line summary plus a key/value block, e.g.
+  ```
+  ai summary task succeeded
+    taskId        01H...
+    refId         01H...
+    totalTokens   1284
+    totalCost     0.42 ¢
+    resultIds     01H...
+  ```
+- `json` / `pretty-json`: the `AiTaskView` wrapped in the standard `{ ok, data }` envelope.
+- `llm`: terse single-line `succeeded summary refId=... taskId=... tokens=... cost=...`.
+
+Progress (when not `--no-wait`) is written to `stderr` as plain text:
+```
+[ai] task pending… taskId=01H...
+[ai] task running…
+[ai] task succeeded (4.8s)
+```
+
+`stderr` lines are suppressed when `--json` is given AND the process is non-TTY, to keep CI logs clean — same convention used by `mxs post create`.
+
+## Exit codes
+
+- `0` — task reached `succeeded` (wait mode), or task was created (`--no-wait`).
+- `1` — task reached `failed` or `cancelled`. The view still emits with `status` and `error` populated; the renderer reports the failure as a non-zero exit by mapping it to a new tagged error `AiTaskFailed`.
+- Other existing tags map per `exitCodeForTag` — auth errors, network errors, resolver errors are unchanged.
+
+## Architecture
+
+### Service: `src/services/Ai.ts`
+
+The v0.3 placeholder (`AiService = {}`, `Layer.effect(Ai, Effect.die(...))`) is replaced with a real interface and `.Default` layer wired through `Api` and `Resolver` (which are already constructed in `bin/mxs.ts` after `parseGlobalFlags`).
+
+```ts
+export interface AiService {
+  readonly regenSummary: (
+    input: { refId: string; targetLanguages?: string[] },
+  ) => Effect.Effect<CreateTaskResult, AiTaskCreateFailed | ApiError>
+  readonly translate: (
+    input: { refId: string; targetLanguages: string[] },
+  ) => Effect.Effect<CreateTaskResult, AiTaskCreateFailed | ApiError>
+  readonly refreshInsights: (
+    input: { refId: string; targetLanguages?: string[] },
+  ) => Effect.Effect<CreateTaskResult, AiTaskCreateFailed | ApiError>
+  readonly waitForTask: (
+    taskId: string,
+    opts?: { pollMs?: number; type: 'summary' | 'translation' | 'insights' },
+  ) => Effect.Effect<AiTaskView, AiTaskFailed | ApiError>
+}
+
+type CreateTaskResult = { taskId: string; created: boolean }
+```
+
+`.Default` is `Layer.effect(Ai, Effect.gen(function*() { const api = yield* Api; ... }))`. It is registered in `bin/mxs.ts` alongside the other flag-dependent layers via `Layer.provideMerge`, NOT in `layers/App.ts`. Polling cadence defaults to 1000 ms and is overridable via a `MXS_AI_POLL_MS` env var (for tests).
+
+### Commands: `src/cli/ai/`
+
+```
+src/cli/ai/
+  index.ts           # withSubcommands('summary', 'translate', 'insights')
+  summary/
+    index.ts         # withSubcommands('regen')
+    regen.ts
+  translate.ts       # single verb directly under `ai translate`
+  insights/
+    index.ts         # withSubcommands('refresh')
+    refresh.ts
+```
+
+Each handler is a thin `Effect.gen` that:
+
+1. `yield*`s `Resolver` to turn `<id>` into a Snowflake id.
+2. `yield*`s `Ai` to create the task.
+3. If `--no-wait`: emit `{ status: 'pending', taskId, ... }` and return.
+4. Else: `yield*` `Ai.waitForTask(taskId, { type })` and emit the resulting `AiTaskView`.
+
+`bin/mxs.ts#rootCmd` registers the new aggregator. `src/cli/help/` group metadata and help data builders are updated for the `ai` group (title, one-line description, verb list).
+
+### Errors: `src/domain/errors.ts`
+
+Two new `Data.TaggedError` classes:
+
+- `AiTaskCreateFailed` — wraps a non-2xx response from `/ai/.../task`. Exit code `1`.
+- `AiTaskFailed` — terminal `failed` / `cancelled` status during `waitForTask`. Carries `{ taskId, status, message? }`. Exit code `1`.
+
+Both are added to `exitCodeForTag`. The top-level `catchAll` shim in `bin/mxs.ts` already renders tagged errors through `emitError` — no changes there.
+
+### Views: `src/cli/ai/views.ts`
+
+Single `AiTaskView` schema (Zod, matching the other `*.views.ts` files in `src/cli/`). The view is parsed from a normalized in-memory object the service constructs from the task record — the CLI does NOT pass server task records through to the renderer untransformed, so future server-side field renames stay contained.
+
+### Resolver reuse
+
+`Resolver` already exposes the post/note/page lookup that `mxs post`, `mxs note`, etc. use. The AI commands call `Resolver.resolveArticle(idOrSlugOrTitle)` (existing) and pass the resulting Snowflake id through to the server. Pages are not currently in scope for any AI generation endpoint, so the resolver call is constrained to post + note in the handler — pages produce a `RefNotResolvable` error at the resolver layer.
+
+## Polling behavior
+
+`waitForTask` polls `GET /tasks/:id` every `pollMs` (default 1000) and:
+
+- Logs `[ai] task <status>…` to stderr when the status changes.
+- Aborts on `SIGINT` — the in-flight HTTP request is cancelled; the task on the server is NOT cancelled (matches existing `mxs` behavior elsewhere). Exit code is the standard 130.
+- Treats a non-2xx response as `ApiError` and surfaces it through the existing error envelope.
+- Has no hard timeout. Long-running tasks (translation across many locales) are normal; the user can `--no-wait` or ^C.
+
+If the initial create returned `created: false` (deduplicated), the CLI logs `[ai] joining existing task taskId=...` and follows it the same way.
+
+## Testing
+
+Unit tests under `test/cli/ai/`:
+
+- `summary-regen.test.ts`, `translate.test.ts`, `insights-refresh.test.ts` — `it.effect` with canned `test-http.ts` layer asserting:
+  - happy path: create returns `{taskId, created: true}`, two polls return `pending` then `succeeded`, view shape is correct.
+  - dedup path: create returns `{taskId, created: false}`, stderr contains `joining existing task`.
+  - failed path: poll returns `failed` with `error.message`; handler exits with `AiTaskFailed`.
+  - `--no-wait`: no `/tasks/:id` request is made; output is `pending`.
+  - resolver miss: unknown slug → `RefNotResolvable`, no `/ai` request is made.
+- `ai-views.test.ts` — view parsing rejects invalid status / missing fields.
+
+Integration test under `test/integration/`:
+
+- `ai-task-flow.test.ts` — spawns `mxs ai summary regen <id>` against a tiny canned HTTP server, asserts stderr progress lines, stdout JSON envelope, exit code.
+
+Existing test helpers (`test-fs`, `test-http`) cover everything required.
+
+## Documentation
+
+`packages/cli/README.md` gains an `mxs ai` section under the command reference, with one usage example per verb. `ROADMAP.md` v2 entry is updated: the three commands move to a new "Shipped in v0.7" (or current next-version) block; `mxs ai tokens` stays under v2 with a note that read/usage commands are pending.
+
+## Open questions
+
+None. The deferred items (`tokens`, read commands, agent invoke) are explicitly out of scope and tracked separately on the roadmap.
+
+## Rollout
+
+Single PR. No core changes, no migration, no config flag. The placeholder `AiService = {}` in `src/services/Ai.ts` is replaced atomically with the new interface; the only callers are the new command files, so the swap is local to this change set.

--- a/docs/superpowers/specs/2026-06-17-mxs-ai-v2-design.md
+++ b/docs/superpowers/specs/2026-06-17-mxs-ai-v2-design.md
@@ -7,220 +7,287 @@ Package: `@mx-space/cli` (`packages/cli`)
 
 ## Summary
 
-Add a new top-level command group `mxs ai` to the CLI. This first wave of v2 ships three async generation commands backed by the existing core AI task queue:
+Add a new top-level command group `mxs ai` to the CLI covering the three AI artifact families that the core server already exposes: `summary`, `translate`, and `insights`. Each family ships full management — generate, list, read by id, read by article, edit, delete — plus the translation-entries (i18n dictionary) sub-tree under `ai translate entries`. No new core endpoints are introduced.
 
-- `mxs ai summary regen <id> [--to <lang>...]` — regenerate an article's AI summary.
-- `mxs ai translate <id> --to <lang>... ` — translate an article into one or more target languages.
-- `mxs ai insights refresh <id> [--to <lang>...]` — regenerate an article's AI insights.
-
-A second wave (`mxs ai tokens`, plus any read commands) is deferred and is out of scope for this spec.
+A later wave will add `mxs ai tokens` (usage aggregation) and any agent / provider / key commands. Those are out of scope here.
 
 ## Goals
 
-- Bring the first slice of the ROADMAP v2 AI section online.
-- Match the existing `mxs <resource> <verb>` command shape so the surface is predictable.
-- Wait for task completion by default, so a CLI run that "returns 0" really means the AI artifact was produced.
-- Surface task progress (`pending → running → succeeded/failed`) through `stderr` without polluting `stdout` (so `--json` and `--llm` outputs stay clean).
-- Reuse the existing `Resolver` so users can pass a slug, title, or Snowflake id (same as `mxs post` / `mxs note`).
+- Bring the AI module under the same management surface as `mxs post`, `mxs project`, `mxs snippet`: every artifact is reachable from the CLI for listing, inspection, editing, and deletion.
+- Match the existing `mxs <resource> <verb>` shape — every action is a subcommand of its resource group, never a positional argument on the resource itself.
+- Make async generate commands actually wait for the AI task to finish by default, so a CLI run that returns 0 means the artifact exists.
+- Reuse the existing `Resolver` so users can pass an article id, slug, or title (same as `mxs post` / `mxs note`).
 
 ## Non-goals
 
-- No `mxs ai tokens` / usage aggregation in this wave. Tracked separately.
-- No read commands (`ai summary list`, `ai translate get`, etc.). Tracked separately.
-- No provider/key/config management (`ai config`, `ai key add/rm`). Not on the v2 roadmap.
-- No agent chat (`ai agent invoke`). Not on the v2 roadmap.
-- No new core endpoints. The CLI consumes endpoints that already exist.
+- No `mxs ai tokens` / usage aggregation. Tracked separately on the roadmap.
+- No provider / key / config management (`ai config`, `ai key add/rm`). Not on v2.
+- No agent chat (`ai agent invoke`). Not on v2.
+- No new core endpoints. Everything below targets routes that already exist.
+- No streaming SSE consumption. The CLI uses the task queue path (`POST /ai/.../task` + `GET /tasks/:id`), not `/ai/.../article/:id/generate`. Streaming is admin-UI shaped, not CLI shaped.
 
 ## Server contract (existing)
 
-All three commands target existing core endpoints. No core changes are required for this wave.
+### Summary
+- `POST /ai/summaries/task` — `{ refId, targetLanguages?: string[] }` → `{ taskId, created }`.
+- `GET  /ai/summaries/` — paginated; query: `BasicPagerDto`.
+- `GET  /ai/summaries/grouped` — paginated, grouped per article.
+- `GET  /ai/summaries/ref/:id` — array of summaries for one article.
+- `GET  /ai/summaries/article/:id?lang=&onlyDb=` — single summary; will generate on miss unless `onlyDb=true`.
+- `PATCH /ai/summaries/:id` — `{ summary: string }`.
+- `DELETE /ai/summaries/:id`.
 
-| Command | Method | Path | Body |
-|---|---|---|---|
-| `ai summary regen` | `POST` | `/ai/summaries/task` | `{ refId, targetLanguages?: string[] }` |
-| `ai translate` | `POST` | `/ai/translations/task` | `{ refId, targetLanguages: string[] }` |
-| `ai insights refresh` | `POST` | `/ai/insights/task` | `{ refId, targetLanguages?: string[] }` |
+### Translation
+- `POST /ai/translations/task` — `{ refId, targetLanguages?: string[] }` → `{ taskId, created }`.
+- `GET  /ai/translations/grouped` — paginated, grouped per article. (There is no flat `GET /` for translations — by design.)
+- `GET  /ai/translations/ref/:id` — array of translations for one article.
+- `GET  /ai/translations/article/:id?lang=` — single translation for an article + lang.
+- `GET  /ai/translations/article/:id/languages` — list of languages a given article has.
+- `PATCH /ai/translations/:id` — `UpdateTranslationDto`.
+- `DELETE /ai/translations/:id`.
 
-Each endpoint responds with `{ taskId: string, created: boolean }`. `created: false` means a deduplicated in-flight task already exists for `(type, payload)` — the CLI MUST treat this as a non-error and follow the existing `taskId` instead of creating a new one.
+### Translation entries (i18n dictionary)
+- `POST   /ai/translations/entries/generate` — `{ keyPaths?: string[], targetLangs?: string[] }`.
+- `GET    /ai/translations/entries/` — paginated; query: `{ keyPath?, lang?, page, size }`.
+- `PATCH  /ai/translations/entries/:id` — `{ translatedText: string }`.
+- `DELETE /ai/translations/entries/:id`.
 
-Polling uses the existing task controller:
+### Insights
+- `POST /ai/insights/task` — `{ refId, targetLanguages?: string[] }` → `{ taskId, created }`.
+- `GET  /ai/insights/` — paginated; query: `BasicPagerDto`.
+- `GET  /ai/insights/grouped` — paginated, grouped per article.
+- `GET  /ai/insights/ref/:id` — array of insights for one article.
+- `GET  /ai/insights/article/:id?lang=&onlyDb=` — single insights doc; will generate on miss unless `onlyDb=true`.
+- `PATCH /ai/insights/:id` — `{ content: string }`.
+- `DELETE /ai/insights/:id`.
 
-- `GET /tasks/:id` — returns the full task record, including `status`, `totalCost`, and any `resultIds`.
-
-Terminal task statuses are `succeeded`, `failed`, `cancelled`. The CLI polls until one of these is reached or the user aborts.
+### Task polling (shared)
+- `GET /tasks/:id` — full task record including `status`, `totalCost`, `resultIds`. Terminal statuses: `succeeded | failed | cancelled`.
 
 ## User-facing commands
 
-### `mxs ai summary regen <id> [--to <lang>...] [--no-wait]`
+Global flags (`--json`, `--llm`, `--readable`, `--api-url`, `--token`, `--api-key`, `--profile`, `--dry-run`) are pre-parsed by `runtime-flags` and never declared on subcommands. `<id>` arguments accept article id, slug, or title and go through `Resolver`. `<record-id>` (summary/translation/insights/entry primary key) is always a raw Snowflake.
 
-- `<id>` — article id, slug, or title. Resolved through `Resolver` (post / note / page).
-- `--to <lang>` — optional, repeatable. Passed to the server as `targetLanguages`.
-- `--no-wait` — fire-and-forget; print `taskId` and exit.
+### `mxs ai summary`
 
-### `mxs ai translate <id> --to <lang>... [--no-wait]`
+| Verb | Signature | Backed by |
+|---|---|---|
+| `regen` | `<id> [--to <lang>...] [--no-wait]` | `POST /ai/summaries/task` + poll |
+| `list`  | `[--page N] [--size N] [--grouped]` | `GET /ai/summaries/` or `/grouped` |
+| `get`   | `<record-id>` | derived: `list` filter (see note) |
+| `by-article` | `<id> [--lang <l>] [--only-db]` | `GET /ai/summaries/article/:id` or `/ref/:id` |
+| `edit`  | `<record-id>` | `PATCH /ai/summaries/:id` via `$EDITOR` |
+| `delete`| `<record-id>` | `DELETE /ai/summaries/:id` |
 
-- `<id>` — article id, slug, or title.
-- `--to <lang>` — **required**, repeatable. At least one value.
-- `--no-wait` — fire-and-forget.
+> **`get` note:** core does not expose `GET /ai/summaries/:id`. The CLI implements `get <record-id>` by paging `/grouped` (or `/ref/:id` when the caller also supplies `--ref`) and matching client-side. Same applies to translation `get` and insights `get`. If this proves slow in practice we add `GET /ai/<resource>/:id` server-side in a later patch — out of scope for this spec.
 
-### `mxs ai insights refresh <id> [--to <lang>...] [--no-wait]`
+### `mxs ai translate`
 
-- `<id>` — article id, slug, or title.
-- `--to <lang>` — optional, repeatable. Defaults to the server's default language when omitted.
-- `--no-wait` — fire-and-forget.
+| Verb | Signature | Backed by |
+|---|---|---|
+| `run` | `<id> --to <lang>... [--no-wait]` | `POST /ai/translations/task` + poll |
+| `list` | `[--page N] [--size N]` (always grouped) | `GET /ai/translations/grouped` |
+| `get` | `<record-id>` | derived; see `summary get` note |
+| `by-article` | `<id> [--lang <l>]` | `GET /ai/translations/article/:id` or `/ref/:id` |
+| `languages` | `<id>` | `GET /ai/translations/article/:id/languages` |
+| `edit` | `<record-id>` | `PATCH /ai/translations/:id` via `$EDITOR` (JSON envelope) |
+| `delete` | `<record-id>` | `DELETE /ai/translations/:id` |
 
-Global flags (`--json`, `--llm`, `--readable`, `--api-url`, `--token`, `--api-key`, `--profile`, `--dry-run`) follow the existing `runtime-flags` pre-parser. None of these flags are declared on the new subcommands.
+`run` replaces the original `ai translate <id>` shape — verbs are subcommands, not positional args on the resource (convention `2b`).
 
-## Output
+### `mxs ai translate entries`
 
-All three commands emit a single `AiTaskView` value via `Renderer.emit`:
+| Verb | Signature | Backed by |
+|---|---|---|
+| `list` | `[--page N] [--size N] [--key-path <p>] [--lang <l>]` | `GET /ai/translations/entries/` |
+| `generate` | `[--key-path <p>...] [--to <lang>...]` | `POST /ai/translations/entries/generate` |
+| `edit` | `<record-id>` | `PATCH /ai/translations/entries/:id` via `$EDITOR` |
+| `delete` | `<record-id>` | `DELETE /ai/translations/entries/:id` |
 
-```ts
-type AiTaskView = {
-  taskId: string
-  status: 'pending' | 'running' | 'succeeded' | 'failed' | 'cancelled'
-  type: 'summary' | 'translation' | 'insights'
-  refId: string
-  targetLanguages?: string[]
-  totalTokens?: number
-  totalCost?: number     // cents, matching core's totalCost field
-  resultIds?: string[]   // present on succeeded
-  error?: { message: string }  // present on failed
-}
-```
+`--key-path` accepts the server-enforced set only (`category.name`, `topic.name`, `topic.introduce`, `topic.description`, `note.mood`, `note.weather`). The CLI does **not** re-enumerate these — it forwards verbatim and lets the server reject unknown values. The README lists them once for discoverability.
 
-- `readable` (default): a single-line summary plus a key/value block, e.g.
-  ```
-  ai summary task succeeded
-    taskId        01H...
-    refId         01H...
-    totalTokens   1284
-    totalCost     0.42 ¢
-    resultIds     01H...
-  ```
-- `json` / `pretty-json`: the `AiTaskView` wrapped in the standard `{ ok, data }` envelope.
-- `llm`: terse single-line `succeeded summary refId=... taskId=... tokens=... cost=...`.
+### `mxs ai insights`
 
-Progress (when not `--no-wait`) is written to `stderr` as plain text:
+| Verb | Signature | Backed by |
+|---|---|---|
+| `refresh` | `<id> [--to <lang>...] [--no-wait]` | `POST /ai/insights/task` + poll |
+| `list`    | `[--page N] [--size N] [--grouped]` | `GET /ai/insights/` or `/grouped` |
+| `get`     | `<record-id>` | derived; see `summary get` note |
+| `by-article` | `<id> [--lang <l>] [--only-db]` | `GET /ai/insights/article/:id` or `/ref/:id` |
+| `edit`    | `<record-id>` | `PATCH /ai/insights/:id` via `$EDITOR` |
+| `delete`  | `<record-id>` | `DELETE /ai/insights/:id` |
+
+## Generate / wait UX
+
+`summary regen`, `translate run`, `insights refresh` all share the same flow:
+
+1. Resolve `<id>` to a Snowflake via `Resolver`.
+2. `POST` to the task endpoint with `{ refId, targetLanguages? }`.
+3. Receive `{ taskId, created }`.
+4. If `--no-wait`: emit the view at `status: 'pending'` and return.
+5. Else: poll `GET /tasks/:id` every `MXS_AI_POLL_MS` (default `1000`) until terminal.
+6. Emit the final `AiTaskView`. Terminal `failed`/`cancelled` raises `AiTaskFailed`, exit 1.
+
+`created: false` means a deduplicated in-flight task already exists. The CLI joins it (`[ai] joining existing task taskId=...` on stderr) and follows the existing `taskId` — never an error.
+
+Progress lines (stderr only, suppressed when `--json` AND non-TTY):
 ```
 [ai] task pending… taskId=01H...
 [ai] task running…
 [ai] task succeeded (4.8s)
 ```
 
-`stderr` lines are suppressed when `--json` is given AND the process is non-TTY, to keep CI logs clean — same convention used by `mxs post create`.
+`^C` aborts the in-flight HTTP request but does NOT cancel the server-side task (matches existing `mxs` behavior). Exit 130.
+
+## `edit` UX
+
+`edit` mirrors the existing `mxs project edit` flow:
+
+1. Fetch current record. Summary uses `{ summary }`, insights uses `{ content }`, translation uses the `UpdateTranslationDto` envelope, entry uses `{ translatedText }`.
+2. Write a minimal JSON envelope to a temp file, launch `$EDITOR`.
+3. On editor exit with non-empty diff, parse JSON, PATCH the changed fields.
+4. No-op when diff is empty.
+
+Editor envelope shape is per-resource and lives in `src/cli/ai/<resource>/edit.ts`. JSON, not raw text — symmetric with `mxs project edit`.
+
+## Output
+
+A single view file `src/cli/ai/views.ts` defines five Zod-parsed views:
+
+```ts
+AiTaskView           // for regen / run / refresh
+AiSummaryView        // for list / get / by-article
+AiTranslationView    // for list / get / by-article
+AiInsightsView       // for list / get / by-article
+AiTranslationEntryView
+```
+
+All views are normalized in the CLI service layer — server records are NOT forwarded raw. This keeps a future server-side field rename contained.
+
+Renderer modes follow existing conventions:
+
+- `readable` (default): per-view tabular block or single-line summary.
+- `json` / `pretty-json`: standard `{ ok, data }` envelope; list endpoints carry `pagination` in `meta`.
+- `llm`: terse one-line per record.
 
 ## Exit codes
 
-- `0` — task reached `succeeded` (wait mode), or task was created (`--no-wait`).
-- `1` — task reached `failed` or `cancelled`. The view still emits with `status` and `error` populated; the renderer reports the failure as a non-zero exit by mapping it to a new tagged error `AiTaskFailed`.
-- Other existing tags map per `exitCodeForTag` — auth errors, network errors, resolver errors are unchanged.
+- `0` — task `succeeded` or read/edit/delete completed.
+- `1` — `AiTaskFailed`, `AiTaskCreateFailed`, or any other tagged failure per `exitCodeForTag`.
+- `130` — user ^C.
+
+Resolver / network / auth errors are unchanged from the rest of the CLI.
 
 ## Architecture
 
 ### Service: `src/services/Ai.ts`
 
-The v0.3 placeholder (`AiService = {}`, `Layer.effect(Ai, Effect.die(...))`) is replaced with a real interface and `.Default` layer wired through `Api` and `Resolver` (which are already constructed in `bin/mxs.ts` after `parseGlobalFlags`).
+The v0.3 placeholder (`AiService = {}`, `Layer.effect(Ai, Effect.die(...))`) is replaced with a real interface. The `.Default` layer depends on `Api` and `Resolver`, both of which are already constructed in `bin/mxs.ts` after `parseGlobalFlags`. `Ai.Default` is registered alongside them via `Layer.provideMerge`, NOT in `layers/App.ts`.
 
 ```ts
 export interface AiService {
-  readonly regenSummary: (
-    input: { refId: string; targetLanguages?: string[] },
-  ) => Effect.Effect<CreateTaskResult, AiTaskCreateFailed | ApiError>
-  readonly translate: (
-    input: { refId: string; targetLanguages: string[] },
-  ) => Effect.Effect<CreateTaskResult, AiTaskCreateFailed | ApiError>
-  readonly refreshInsights: (
-    input: { refId: string; targetLanguages?: string[] },
-  ) => Effect.Effect<CreateTaskResult, AiTaskCreateFailed | ApiError>
-  readonly waitForTask: (
-    taskId: string,
-    opts?: { pollMs?: number; type: 'summary' | 'translation' | 'insights' },
-  ) => Effect.Effect<AiTaskView, AiTaskFailed | ApiError>
-}
+  // generate
+  readonly regenSummary:      (in: { refId; targetLanguages? }) => Effect<CreateTaskResult, ...>
+  readonly translate:         (in: { refId; targetLanguages }) => Effect<CreateTaskResult, ...>
+  readonly refreshInsights:   (in: { refId; targetLanguages? }) => Effect<CreateTaskResult, ...>
+  readonly waitForTask:       (taskId, opts) => Effect<AiTaskView, AiTaskFailed | ApiError>
 
-type CreateTaskResult = { taskId: string; created: boolean }
+  // summary read/manage
+  readonly listSummaries:     (q) => Effect<Paginated<AiSummaryView>, ApiError>
+  readonly getSummary:        (id) => Effect<AiSummaryView, AiRecordNotFound | ApiError>
+  readonly getSummariesByArticle: (refId, opts) => Effect<AiSummaryView | AiSummaryView[], ApiError>
+  readonly updateSummary:     (id, patch) => Effect<AiSummaryView, ApiError>
+  readonly deleteSummary:     (id) => Effect<void, ApiError>
+
+  // translation read/manage — same shape
+  readonly listTranslations, getTranslation, getTranslationsByArticle,
+           getTranslationLanguages, updateTranslation, deleteTranslation
+
+  // insights read/manage — same shape
+  readonly listInsights, getInsights, getInsightsByArticle,
+           updateInsights, deleteInsights
+
+  // translation entries
+  readonly listEntries, generateEntries, updateEntry, deleteEntry
+}
 ```
 
-`.Default` is `Layer.effect(Ai, Effect.gen(function*() { const api = yield* Api; ... }))`. It is registered in `bin/mxs.ts` alongside the other flag-dependent layers via `Layer.provideMerge`, NOT in `layers/App.ts`. Polling cadence defaults to 1000 ms and is overridable via a `MXS_AI_POLL_MS` env var (for tests).
+Polling cadence defaults to 1000 ms and is overridable via `MXS_AI_POLL_MS` (for tests).
 
 ### Commands: `src/cli/ai/`
 
 ```
 src/cli/ai/
-  index.ts           # withSubcommands('summary', 'translate', 'insights')
+  index.ts                # withSubcommands('summary', 'translate', 'insights')
+  views.ts                # all AI views in one file
+  shared/
+    edit-envelope.ts      # JSON-editor helper (re-used by every edit verb)
+    poll-task.ts          # waitForTask handler wiring + stderr progress
+    resolve-article.ts    # wrap Resolver, restrict to post/note (no page)
+
   summary/
-    index.ts         # withSubcommands('regen')
-    regen.ts
-  translate.ts       # single verb directly under `ai translate`
+    index.ts              # regen, list, get, by-article, edit, delete
+    regen.ts list.ts get.ts by-article.ts edit.ts delete.ts
+
+  translate/
+    index.ts              # run, list, get, by-article, languages, edit, delete, entries
+    run.ts list.ts get.ts by-article.ts languages.ts edit.ts delete.ts
+    entries/
+      index.ts            # list, generate, edit, delete
+      list.ts generate.ts edit.ts delete.ts
+
   insights/
-    index.ts         # withSubcommands('refresh')
-    refresh.ts
+    index.ts              # refresh, list, get, by-article, edit, delete
+    refresh.ts list.ts get.ts by-article.ts edit.ts delete.ts
 ```
 
-Each handler is a thin `Effect.gen` that:
+Every handler is a thin `Effect.gen` that `yield*`s `Ai` (and `Resolver` for `<id>`-bearing verbs), then `emit`s a parsed view. No business logic in handlers.
 
-1. `yield*`s `Resolver` to turn `<id>` into a Snowflake id.
-2. `yield*`s `Ai` to create the task.
-3. If `--no-wait`: emit `{ status: 'pending', taskId, ... }` and return.
-4. Else: `yield*` `Ai.waitForTask(taskId, { type })` and emit the resulting `AiTaskView`.
-
-`bin/mxs.ts#rootCmd` registers the new aggregator. `src/cli/help/` group metadata and help data builders are updated for the `ai` group (title, one-line description, verb list).
+`bin/mxs.ts#rootCmd` registers the `ai` aggregator. `src/cli/help/` group metadata gains an `ai` entry; help-data builders enumerate the verb tree.
 
 ### Errors: `src/domain/errors.ts`
 
-Two new `Data.TaggedError` classes:
+Three new `Data.TaggedError` classes added to `exitCodeForTag`:
 
-- `AiTaskCreateFailed` — wraps a non-2xx response from `/ai/.../task`. Exit code `1`.
-- `AiTaskFailed` — terminal `failed` / `cancelled` status during `waitForTask`. Carries `{ taskId, status, message? }`. Exit code `1`.
-
-Both are added to `exitCodeForTag`. The top-level `catchAll` shim in `bin/mxs.ts` already renders tagged errors through `emitError` — no changes there.
-
-### Views: `src/cli/ai/views.ts`
-
-Single `AiTaskView` schema (Zod, matching the other `*.views.ts` files in `src/cli/`). The view is parsed from a normalized in-memory object the service constructs from the task record — the CLI does NOT pass server task records through to the renderer untransformed, so future server-side field renames stay contained.
+- `AiTaskCreateFailed` — non-2xx from a `/ai/.../task` POST. Exit 1.
+- `AiTaskFailed` — terminal `failed` / `cancelled` during `waitForTask`. Carries `{ taskId, status, message? }`. Exit 1.
+- `AiRecordNotFound` — `get`/`edit`/`delete` referencing a missing record id. Exit 1.
 
 ### Resolver reuse
 
-`Resolver` already exposes the post/note/page lookup that `mxs post`, `mxs note`, etc. use. The AI commands call `Resolver.resolveArticle(idOrSlugOrTitle)` (existing) and pass the resulting Snowflake id through to the server. Pages are not currently in scope for any AI generation endpoint, so the resolver call is constrained to post + note in the handler — pages produce a `RefNotResolvable` error at the resolver layer.
+`<id>` arguments go through `Resolver`. The shared `shared/resolve-article.ts` constrains to post + note (pages have no AI generation surface) and surfaces `RefNotResolvable` on miss. `<record-id>` arguments skip the resolver — they are raw Snowflakes.
 
-## Polling behavior
+## File-size budget
 
-`waitForTask` polls `GET /tasks/:id` every `pollMs` (default 1000) and:
-
-- Logs `[ai] task <status>…` to stderr when the status changes.
-- Aborts on `SIGINT` — the in-flight HTTP request is cancelled; the task on the server is NOT cancelled (matches existing `mxs` behavior elsewhere). Exit code is the standard 130.
-- Treats a non-2xx response as `ApiError` and surfaces it through the existing error envelope.
-- Has no hard timeout. Long-running tasks (translation across many locales) are normal; the user can `--no-wait` or ^C.
-
-If the initial create returned `created: false` (deduplicated), the CLI logs `[ai] joining existing task taskId=...` and follows it the same way.
+The verb fan-out is wide but each file stays tiny. Each verb is 30–80 lines of `Effect.gen`. The service file is the only one that may push toward the 500-line ceiling; if it does, split per-family (`Ai.summary.ts`, `Ai.translation.ts`, `Ai.insights.ts`) under one `Ai.ts` aggregator. Same pattern as `Auth.ts`.
 
 ## Testing
 
-Unit tests under `test/cli/ai/`:
+Unit tests under `test/cli/ai/` mirror the directory layout. For each verb:
 
-- `summary-regen.test.ts`, `translate.test.ts`, `insights-refresh.test.ts` — `it.effect` with canned `test-http.ts` layer asserting:
-  - happy path: create returns `{taskId, created: true}`, two polls return `pending` then `succeeded`, view shape is correct.
-  - dedup path: create returns `{taskId, created: false}`, stderr contains `joining existing task`.
-  - failed path: poll returns `failed` with `error.message`; handler exits with `AiTaskFailed`.
-  - `--no-wait`: no `/tasks/:id` request is made; output is `pending`.
-  - resolver miss: unknown slug → `RefNotResolvable`, no `/ai` request is made.
-- `ai-views.test.ts` — view parsing rejects invalid status / missing fields.
+- happy path against `test-http.ts` canned responses.
+- error path (404, 5xx, deduped task, failed task).
+- resolver miss for `<id>` verbs.
+- view shape rejection for malformed server payloads.
 
-Integration test under `test/integration/`:
+`waitForTask` gets its own test file: polling cadence, transition logging, ^C abort, terminal failure tagging.
 
-- `ai-task-flow.test.ts` — spawns `mxs ai summary regen <id>` against a tiny canned HTTP server, asserts stderr progress lines, stdout JSON envelope, exit code.
+Integration tests under `test/integration/`:
 
-Existing test helpers (`test-fs`, `test-http`) cover everything required.
+- `ai-task-flow.test.ts` — `mxs ai summary regen <id>` end-to-end against a canned HTTP server, asserts stderr progress lines, stdout JSON envelope, exit code.
+- `ai-edit.test.ts` — `mxs ai summary edit <id>` with a mock `$EDITOR` script (existing helper from `mxs project edit` tests).
 
 ## Documentation
 
-`packages/cli/README.md` gains an `mxs ai` section under the command reference, with one usage example per verb. `ROADMAP.md` v2 entry is updated: the three commands move to a new "Shipped in v0.7" (or current next-version) block; `mxs ai tokens` stays under v2 with a note that read/usage commands are pending.
+`packages/cli/README.md` gains an `mxs ai` section listing every verb under each family with one example per verb. `ROADMAP.md` v2 entry is updated:
+
+- The full `mxs ai summary|translate|insights` surface moves to "Shipped in v0.7" (or whatever the next-version block is at PR time).
+- `mxs ai tokens` stays under v2 with a note that it is the only remaining wave-2 item.
 
 ## Open questions
 
-None. The deferred items (`tokens`, read commands, agent invoke) are explicitly out of scope and tracked separately on the roadmap.
+None. Deferred items (`tokens`, agent / provider / key) are explicitly out of scope.
 
 ## Rollout
 
-Single PR. No core changes, no migration, no config flag. The placeholder `AiService = {}` in `src/services/Ai.ts` is replaced atomically with the new interface; the only callers are the new command files, so the swap is local to this change set.
+Single PR, no core changes, no migration, no config flag. Placeholder `AiService = {}` is swapped atomically — the only callers are the new command files.

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -447,6 +447,65 @@ echo '{"a":1}' | mxs snippet create --name config
 mxs snippet edit web/theme
 ```
 
+## AI
+
+Manage AI artifacts (summary, translation, insights) produced by the core AI module. Article references accept Snowflake id, post slug, or note nid — the CLI resolves to an article id via post-then-note lookup. Record references (`<recordId>`) are raw Snowflakes.
+
+Generate verbs (`summary regen`, `translate run`, `insights refresh`) enqueue a task on the server, then poll `GET /tasks/:id` until the task reaches a terminal status (`completed`, `partial_failed`, `failed`, `cancelled`). Progress lines write to stderr. Pass `--no-wait` to return immediately with `status: pending` after the task is created. If the server reports `created: false`, an in-flight deduplicated task already exists and the CLI joins it instead of erroring. The polling cadence is 1000 ms by default; override via `MXS_AI_POLL_MS=<n>` for tests.
+
+### Summary
+
+| Command                                            | Description                                                       |
+| -------------------------------------------------- | ----------------------------------------------------------------- |
+| `mxs ai summary regen <id> [--to <lang>...]`       | Regenerate an article's summary (optionally for given languages). |
+| `mxs ai summary list [--page <n>] [--size <n>] [--grouped]` | List summaries (flat or grouped by article).             |
+| `mxs ai summary get <recordId>`                    | Get one summary by record id.                                     |
+| `mxs ai summary by-article <id> [--lang <l>] [--only-db]` | Show an article's summary; `--only-db` skips auto-generate. |
+| `mxs ai summary edit <recordId>`                   | Edit the `summary` field via `$EDITOR` (JSON envelope).           |
+| `mxs ai summary delete <recordId> [--force]`       | Delete a summary record.                                          |
+
+### Translate
+
+| Command                                                  | Description                                                   |
+| -------------------------------------------------------- | ------------------------------------------------------------- |
+| `mxs ai translate run <id> --to <lang>... [--no-wait]`   | Translate an article into one or more languages (`--to` required, repeatable). |
+| `mxs ai translate list [--page <n>] [--size <n>]`        | List translations (always grouped by article — no flat list server-side). |
+| `mxs ai translate get <recordId>`                        | Get one translation by record id.                             |
+| `mxs ai translate by-article <id> [--lang <l>]`          | Show an article's translations (single lang or all).          |
+| `mxs ai translate languages <id>`                        | List languages an article has been translated into.           |
+| `mxs ai translate edit <recordId>`                       | Edit translation fields via `$EDITOR` (JSON envelope).        |
+| `mxs ai translate delete <recordId> [--force]`           | Delete a translation record.                                  |
+
+### Translation Entries
+
+The i18n dictionary entries layer used by category / topic / note metadata. `--key-path` accepts only the server-validated set: `category.name`, `topic.name`, `topic.introduce`, `topic.description`, `note.mood`, `note.weather`.
+
+| Command                                                                       | Description                                            |
+| ----------------------------------------------------------------------------- | ------------------------------------------------------ |
+| `mxs ai translate entries list [--page <n>] [--size <n>] [--key-path <p>] [--lang <l>]` | List entries with optional filters.       |
+| `mxs ai translate entries generate [--key-path <p>...] [--to <lang>...]`      | Trigger regeneration of entries.                       |
+| `mxs ai translate entries edit <recordId>`                                    | Edit `translatedText` via `$EDITOR` (JSON envelope).   |
+| `mxs ai translate entries delete <recordId> [--force]`                        | Delete an entry.                                       |
+
+### Insights
+
+| Command                                                | Description                                                         |
+| ------------------------------------------------------ | ------------------------------------------------------------------- |
+| `mxs ai insights refresh <id> [--no-wait]`             | Refresh AI insights for an article.                                 |
+| `mxs ai insights list [--page <n>] [--size <n>] [--grouped]` | List insights (flat or grouped by article).                   |
+| `mxs ai insights get <recordId>`                       | Get one insights record by record id.                               |
+| `mxs ai insights by-article <id> [--lang <l>] [--only-db]` | Show an article's insights; `--only-db` skips auto-generate.    |
+| `mxs ai insights edit <recordId>`                      | Edit the `content` field via `$EDITOR` (JSON envelope).             |
+| `mxs ai insights delete <recordId> [--force]`          | Delete an insights record.                                          |
+
+```bash
+mxs ai summary regen my-post --to en --to ja
+mxs ai translate run my-post --to en
+mxs ai insights refresh my-post
+mxs ai summary list --grouped
+mxs ai translate languages my-post
+```
+
 ## Configuration
 
 | Command                        | Description                                                    |

--- a/packages/cli/ROADMAP.md
+++ b/packages/cli/ROADMAP.md
@@ -24,15 +24,18 @@
 
 State map: `unread=0`, `read=1`, `junk=2`. Routes single-id verbs through the server's batch endpoints (`PATCH /comments/batch/state`, `DELETE /comments/batch`) for one unified path.
 
-## v2 — AI
+## Shipped in v0.13
 
-> **Note (v0.3):** Service interface placeholders for AI, Backup, and Cache are reserved in `src/services/{Ai,Backup,Cache}.ts` and threaded through the layer composition. Implementation is pending.
+- `mxs ai` — full management surface for AI artifacts.
+  - `mxs ai summary {regen,list,get,by-article,edit,delete}`
+  - `mxs ai translate {run,list,get,by-article,languages,edit,delete}`
+  - `mxs ai translate entries {list,generate,edit,delete}`
+  - `mxs ai insights {refresh,list,get,by-article,edit,delete}`
+  - Generate verbs enqueue a task on the server and poll `GET /tasks/:id` until terminal; `--no-wait` returns the `taskId` immediately. Dedup-aware: `created: false` joins the in-flight task.
 
-- AI module commands
-  - `mxs ai summary regen <id>`
-  - `mxs ai translate <id> --to <locale>`
-  - `mxs ai insights refresh`
-  - `mxs ai tokens`
+## v2 — AI tokens / usage
+
+- `mxs ai tokens` — aggregate `totalCost` and `totalTokens` across recent AI tasks. Pending a final decision on client-side aggregation vs. a dedicated `/ai/usage` endpoint on the server.
 
 ## v3
 

--- a/packages/cli/skills/commands-ai.md
+++ b/packages/cli/skills/commands-ai.md
@@ -1,0 +1,115 @@
+---
+slug: commands-ai
+title: AI commands
+description: mxs ai — manage AI summary / translation / insights artifacts
+order: 45
+---
+
+# AI commands
+
+`mxs ai` manages every AI artifact the core server produces: per-article **summary**, per-article **translation**, per-article **insights**, plus the i18n **translation entries** dictionary used for category / topic / note metadata.
+
+Article references (`<id>`) accept a Snowflake id, a post slug, or a numeric note nid. The CLI resolves through post first, then note. Record references (`<recordId>`) are raw Snowflakes — they are NOT resolved.
+
+## Generate verbs (async)
+
+`summary regen`, `translate run`, `insights refresh` enqueue a task and poll `GET /tasks/:id` until terminal (`succeeded` / `failed` / `cancelled`, or the spec-2 `completed` / `partial_failed` aliases). Progress lines write to stderr. `--no-wait` returns immediately with `status: pending`. If the server reports `created: false`, an in-flight deduplicated task already exists; the CLI joins it instead of erroring. Polling cadence is 1000 ms by default; override with `MXS_AI_POLL_MS=<ms>` for tests.
+
+| Command                                              | Purpose                                                         |
+| ---------------------------------------------------- | --------------------------------------------------------------- |
+| `mxs ai summary regen <id> [--to <lang>...]`         | Regenerate an article's AI summary.                             |
+| `mxs ai translate run <id> --to <lang>...`           | Translate an article into one or more languages (`--to` required, repeatable). |
+| `mxs ai insights refresh <id> [--to <lang>...]`      | Refresh AI insights for an article.                             |
+
+Common flags on the three generate verbs:
+
+| Flag             | Effect                                                             |
+| ---------------- | ------------------------------------------------------------------ |
+| `--to <lang>`    | Target language code (repeatable). Forwarded as `targetLanguages`. |
+| `--no-wait`      | Return after task creation; print `status: pending` and exit 0.    |
+
+On success the CLI emits an `ai-task` view: `taskId`, `status`, `refId`, `targetLanguages`, `totalTokens`, `totalCost` (cents), `resultIds`.
+
+## Summary read / manage
+
+| Command                                                       | Purpose                                                       |
+| ------------------------------------------------------------- | ------------------------------------------------------------- |
+| `mxs ai summary list [--page <n>] [--size <n>] [--grouped]`   | List summaries (flat or grouped by article).                  |
+| `mxs ai summary get <recordId>`                               | Get one summary by record id.                                 |
+| `mxs ai summary by-article <id> [--lang <l>] [--only-db]`     | Show an article's summary; `--only-db` skips auto-generation. |
+| `mxs ai summary edit <recordId>`                              | Edit the `summary` field via `$EDITOR` (JSON envelope).       |
+| `mxs ai summary delete <recordId> [--force]`                  | Delete a summary record. `--force` required in non-TTY.       |
+
+## Translation read / manage
+
+There is no flat list endpoint for translations server-side. `mxs ai translate list` is always grouped by article.
+
+| Command                                                  | Purpose                                                  |
+| -------------------------------------------------------- | -------------------------------------------------------- |
+| `mxs ai translate list [--page <n>] [--size <n>]`        | List translations (grouped by article).                  |
+| `mxs ai translate get <recordId>`                        | Get one translation by record id.                        |
+| `mxs ai translate by-article <id> [--lang <l>]`          | Show an article's translations (single lang or all).     |
+| `mxs ai translate languages <id>`                        | List languages an article has been translated into.      |
+| `mxs ai translate edit <recordId>`                       | Edit translation fields via `$EDITOR` (JSON envelope).   |
+| `mxs ai translate delete <recordId> [--force]`           | Delete a translation record.                             |
+
+Edit envelope keys: `title`, `text`, `subtitle` (nullable), `summary`, `tags`, `content`. Only included keys are PATCHed.
+
+## Translation entries (i18n dictionary)
+
+The dictionary layer used for category / topic / note metadata translations. `--key-path` accepts ONLY the server-validated set: `category.name`, `topic.name`, `topic.introduce`, `topic.description`, `note.mood`, `note.weather`.
+
+| Command                                                                                     | Purpose                                                |
+| ------------------------------------------------------------------------------------------- | ------------------------------------------------------ |
+| `mxs ai translate entries list [--page <n>] [--size <n>] [--key-path <p>] [--lang <l>]`     | List entries with optional filters.                    |
+| `mxs ai translate entries generate [--key-path <p>...] [--to <lang>...]`                    | Regenerate entries (synchronous on the server).        |
+| `mxs ai translate entries edit <recordId>`                                                  | Edit `translatedText` via `$EDITOR` (JSON envelope).   |
+| `mxs ai translate entries delete <recordId> [--force]`                                      | Delete an entry.                                       |
+
+## Insights read / manage
+
+| Command                                                       | Purpose                                                        |
+| ------------------------------------------------------------- | -------------------------------------------------------------- |
+| `mxs ai insights list [--page <n>] [--size <n>] [--grouped]`  | List insights (flat or grouped by article).                    |
+| `mxs ai insights get <recordId>`                              | Get one insights record by record id.                          |
+| `mxs ai insights by-article <id> [--lang <l>] [--only-db]`    | Show an article's insights; `--only-db` skips auto-generation. |
+| `mxs ai insights edit <recordId>`                             | Edit the `content` field via `$EDITOR` (JSON envelope).        |
+| `mxs ai insights delete <recordId> [--force]`                 | Delete an insights record.                                     |
+
+## Exit codes specific to `ai`
+
+| Code   | When                                                                                     |
+| ------ | ---------------------------------------------------------------------------------------- |
+| `0`    | Task reached `succeeded`/`completed`; or `--no-wait`; or read/edit/delete completed.     |
+| `1`    | `AiTaskCreateFailed` (no `taskId` in response) or `AiTaskFailed` (terminal `failed`/`cancelled`/`partial_failed`). |
+| `7`    | `AiRecordNotFound` (`get`/`edit`/`delete` against a missing record).                     |
+
+Network / auth / validation errors map per the global table — see `safety`.
+
+## Examples
+
+```bash
+# Regenerate an article's summary and wait for it
+mxs ai summary regen my-post --to en --to ja
+
+# Translate to Japanese, fire and forget
+mxs ai translate run my-post --to ja --no-wait
+
+# Refresh insights, then read the result
+mxs ai insights refresh my-post
+mxs ai insights by-article my-post --only-db
+
+# Inventory
+mxs ai summary list --grouped --output json | jq .
+mxs ai translate languages my-post
+
+# Patch a translation record through $EDITOR
+mxs ai translate edit 01HXXX...
+```
+
+## Notes for agents
+
+- Always pass `--output json` (or `--json`) for machine-parseable output. The default `readable` mode is for humans.
+- `created: false` is a normal join-existing path, NOT an error. Do not retry on it.
+- The polling loop has no hard timeout. For very long translation runs across many languages, prefer `--no-wait` plus periodic `mxs ai translate by-article` polls.
+- Edit envelopes are typed per resource. Unknown keys are rejected client-side before any PATCH is sent.

--- a/packages/cli/skills/overview.md
+++ b/packages/cli/skills/overview.md
@@ -25,6 +25,7 @@ The audience is **AI agents**. Pass `--output llm` for raw markdown suitable for
 | Categories                                    | `commands-category`              |
 | Topics                                        | `commands-topic`                 |
 | Snippets (server data / functions)            | `commands-snippet`               |
+| AI summary / translation / insights / entries | `commands-ai`                    |
 | Server-side options                           | `commands-config`                |
 | Authentication                                | `commands-auth`                  |
 | Local profile management                      | `commands-profile`               |

--- a/packages/cli/src/bin/mxs.ts
+++ b/packages/cli/src/bin/mxs.ts
@@ -5,6 +5,7 @@ import { Command } from '@effect/cli'
 import { NodeContext, NodeHttpClient, NodeRuntime } from '@effect/platform-node'
 import { Effect, Layer } from 'effect'
 
+import { aiCmd } from '../cli/ai'
 import { authCmd } from '../cli/auth'
 import { categoryCmd } from '../cli/category'
 import { commentCmd } from '../cli/comment'
@@ -46,6 +47,7 @@ import {
   parseGlobalFlags,
 } from '../domain/runtime-flags'
 import { AppLayer } from '../layers/App'
+import { Ai } from '../services/Ai'
 import { Api } from '../services/Api'
 import { Comment } from '../services/Comment'
 import {
@@ -128,6 +130,7 @@ const rootCmd = Command.make('mxs', {}, () =>
     topicCmd,
     commentCmd,
     snippetCmd,
+    aiCmd,
     configCmd,
     fileCmd,
     skillCmd,
@@ -337,7 +340,8 @@ export const run = (argv: readonly string[]): Promise<void> => {
   const resolverWithDeps = Resolver.Default.pipe(
     Layer.provideMerge(commentWithDeps),
   )
-  const fullAppLayer = resolverWithDeps
+  const aiWithDeps = Ai.Default.pipe(Layer.provideMerge(resolverWithDeps))
+  const fullAppLayer = aiWithDeps
 
   const cli = Command.run(rootCmd, { name: 'mxs', version: CLI_VERSION })
 

--- a/packages/cli/src/cli/ai/_poll.ts
+++ b/packages/cli/src/cli/ai/_poll.ts
@@ -1,0 +1,58 @@
+import { Effect } from 'effect'
+
+import type { AiTaskFailed } from '../../domain/errors'
+import {
+  type AiService,
+  type AiTaskCreateResult,
+  type AiTaskFinalView,
+  type AiTaskType,
+} from '../../services/Ai'
+import type { ApiError } from '../../services/Api'
+import { Renderer, type RendererService } from '../../services/Renderer'
+
+const synthesizePending = (created: AiTaskCreateResult): AiTaskFinalView => ({
+  type: created.type,
+  taskId: created.taskId,
+  status: 'pending',
+  refId: created.refId,
+  targetLanguages: created.targetLanguages,
+})
+
+/**
+ * Drive a freshly-created task to a terminal state, emitting progress to
+ * stderr via the renderer. With `noWait`, returns a synthetic pending view.
+ */
+export const followTask = (
+  ai: AiService,
+  renderer: RendererService,
+  created: AiTaskCreateResult,
+  noWait: boolean,
+): Effect.Effect<AiTaskFinalView, AiTaskFailed | ApiError> =>
+  Effect.gen(function* () {
+    if (!created.created) {
+      yield* renderer.emitInfo(
+        `[ai] joining existing task taskId=${created.taskId}`,
+      )
+    } else {
+      yield* renderer.emitInfo(`[ai] task pending… taskId=${created.taskId}`)
+    }
+    if (noWait) return synthesizePending(created)
+    const final = yield* ai.waitForTask(created.taskId, {
+      type: created.type,
+      onProgress: (msg) => {
+        // Fire-and-forget; stderr write is sync.
+        // We intentionally don't await the Effect — onProgress runs inside
+        // the polling loop and must stay sync.
+        process.stderr.write(`${msg}\n`)
+      },
+    })
+    return {
+      ...final,
+      refId: final.refId ?? created.refId,
+      targetLanguages: final.targetLanguages ?? created.targetLanguages,
+    }
+  })
+
+// Re-export for convenience.
+export type { AiTaskType }
+export { Renderer }

--- a/packages/cli/src/cli/ai/_resolve.ts
+++ b/packages/cli/src/cli/ai/_resolve.ts
@@ -1,0 +1,32 @@
+import { Effect } from 'effect'
+
+import { ResourceNotFound } from '../../domain/errors'
+import { isSnowflakeId, type ResolverService } from '../../services/Resolver'
+
+/**
+ * Resolve an article reference (snowflake id, slug, or title) to a Snowflake.
+ * Tries post first, then note. AI generation has no page surface.
+ */
+export const resolveArticleId = (
+  resolver: ResolverService,
+  ref: string,
+): Effect.Effect<string, ResourceNotFound> =>
+  Effect.gen(function* () {
+    if (isSnowflakeId(ref)) return ref
+    const asPost = yield* resolver
+      .resolvePostId(ref)
+      .pipe(Effect.catchAll(() => Effect.succeed<string | null>(null)))
+    if (asPost) return asPost
+    const asNote = yield* resolver
+      .resolveNoteId(ref)
+      .pipe(Effect.catchAll(() => Effect.succeed<string | null>(null)))
+    if (asNote) return asNote
+    return yield* Effect.fail(
+      new ResourceNotFound({
+        message: `article not found: ${ref}`,
+        kind: 'article',
+        ref,
+        hint: 'pass a snowflake id, a post slug, or a numeric note nid',
+      }),
+    )
+  })

--- a/packages/cli/src/cli/ai/index.ts
+++ b/packages/cli/src/cli/ai/index.ts
@@ -1,0 +1,36 @@
+import { Command } from '@effect/cli'
+
+import { registerCommandHelp } from '../help/registry'
+import { insightsCmd } from './insights'
+import { summaryCmd } from './summary'
+import { translateCmd } from './translate'
+
+const help = registerCommandHelp({
+  name: 'ai',
+  description: 'manage AI artifacts (summary, translation, insights)',
+  verbs: [
+    {
+      name: 'summary',
+      args: ['<verb>', '...'],
+      description:
+        'manage AI summaries (regen, list, get, by-article, edit, delete)',
+    },
+    {
+      name: 'translate',
+      args: ['<verb>', '...'],
+      description:
+        'manage AI translations (run, list, get, by-article, languages, edit, delete, entries)',
+    },
+    {
+      name: 'insights',
+      args: ['<verb>', '...'],
+      description:
+        'manage AI insights (refresh, list, get, by-article, edit, delete)',
+    },
+  ],
+})
+
+export const aiCmd = Command.make('ai').pipe(
+  Command.withDescription(help.description),
+  Command.withSubcommands([summaryCmd, translateCmd, insightsCmd]),
+)

--- a/packages/cli/src/cli/ai/index.ts
+++ b/packages/cli/src/cli/ai/index.ts
@@ -8,6 +8,7 @@ import { translateCmd } from './translate'
 const help = registerCommandHelp({
   name: 'ai',
   description: 'manage AI artifacts (summary, translation, insights)',
+  skillChapter: 'commands-ai',
   verbs: [
     {
       name: 'summary',

--- a/packages/cli/src/cli/ai/insights/by-article.ts
+++ b/packages/cli/src/cli/ai/insights/by-article.ts
@@ -1,0 +1,33 @@
+import { Args, Command, Options } from '@effect/cli'
+import { Effect, Option } from 'effect'
+
+import { Ai } from '../../../services/Ai'
+import { Renderer } from '../../../services/Renderer'
+import { Resolver } from '../../../services/Resolver'
+import { resolveArticleId } from '../_resolve'
+
+const id = Args.text({ name: 'idOrSlug' })
+const lang = Options.text('lang').pipe(Options.optional)
+const onlyDb = Options.boolean('only-db').pipe(
+  Options.withDescription('do not auto-generate on miss'),
+)
+
+const unwrap = <A>(value: Option.Option<A>): A | undefined =>
+  Option.getOrUndefined(value)
+
+export const byArticle = Command.make(
+  'by-article',
+  { id, lang, onlyDb },
+  ({ id, lang, onlyDb }) =>
+    Effect.gen(function* () {
+      const ai = yield* Ai
+      const renderer = yield* Renderer
+      const resolver = yield* Resolver
+      const refId = yield* resolveArticleId(resolver, id)
+      const res = yield* ai.getInsightsByArticle(refId, {
+        lang: unwrap(lang),
+        onlyDb,
+      })
+      yield* renderer.emitSuccess(res)
+    }),
+).pipe(Command.withDescription("show an article's AI insights"))

--- a/packages/cli/src/cli/ai/insights/delete.ts
+++ b/packages/cli/src/cli/ai/insights/delete.ts
@@ -1,0 +1,30 @@
+import { Args, Command, Options } from '@effect/cli'
+import { Effect } from 'effect'
+
+import { ValidationFailed } from '../../../domain/errors'
+import { Ai } from '../../../services/Ai'
+import { Renderer } from '../../../services/Renderer'
+
+const recordId = Args.text({ name: 'recordId' })
+const force = Options.boolean('force').pipe(
+  Options.withDescription('skip the non-TTY guard'),
+)
+
+export const del = Command.make(
+  'delete',
+  { recordId, force },
+  ({ recordId, force }) =>
+    Effect.gen(function* () {
+      if (!force && !process.stdin.isTTY) {
+        return yield* Effect.fail(
+          new ValidationFailed({
+            message: 'refusing to delete without --force in non-TTY context',
+          }),
+        )
+      }
+      const ai = yield* Ai
+      const renderer = yield* Renderer
+      yield* ai.deleteInsights(recordId)
+      yield* renderer.emitSuccess({ deleted: recordId })
+    }),
+).pipe(Command.withDescription('delete an AI insights record'))

--- a/packages/cli/src/cli/ai/insights/edit.ts
+++ b/packages/cli/src/cli/ai/insights/edit.ts
@@ -1,0 +1,67 @@
+import { Args, Command } from '@effect/cli'
+import { Effect } from 'effect'
+
+import { ValidationJson } from '../../../domain/errors'
+import { Ai } from '../../../services/Ai'
+import { Editor } from '../../../services/Editor'
+import { Renderer } from '../../../services/Renderer'
+
+const recordId = Args.text({ name: 'recordId' })
+
+interface InsightsEnvelope {
+  content: string
+}
+
+const formatJson = (value: InsightsEnvelope): string =>
+  `${JSON.stringify(value, null, 2)}\n`
+
+const parseEnvelope = (raw: string): InsightsEnvelope => {
+  const parsed = JSON.parse(raw) as unknown
+  if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
+    throw new Error('expected a JSON object')
+  }
+  const obj = parsed as Record<string, unknown>
+  if (typeof obj.content !== 'string') {
+    throw new Error('expected `content` field of type string')
+  }
+  return { content: obj.content }
+}
+
+const unwrapDoc = (raw: unknown): Record<string, unknown> => {
+  if (!raw || typeof raw !== 'object') return {}
+  const r = raw as Record<string, unknown>
+  if (r.data && typeof r.data === 'object' && !Array.isArray(r.data)) {
+    return r.data as Record<string, unknown>
+  }
+  return r
+}
+
+export const edit = Command.make('edit', { recordId }, ({ recordId }) =>
+  Effect.gen(function* () {
+    const ai = yield* Ai
+    const editor = yield* Editor
+    const renderer = yield* Renderer
+    const current = unwrapDoc(yield* ai.getInsights(recordId))
+    const initial = formatJson({
+      content: typeof current.content === 'string' ? current.content : '',
+    })
+    const next = yield* editor.openEditor({
+      filename: `ai-insights-${recordId}.json`,
+      initialContent: initial,
+    })
+    if (next.trim() === initial.trim()) {
+      yield* renderer.emitInfo('no changes')
+      return
+    }
+    const parsed = yield* Effect.try({
+      try: () => parseEnvelope(next),
+      catch: (err) =>
+        new ValidationJson({
+          message: err instanceof Error ? err.message : String(err),
+          cause: err,
+        }),
+    })
+    const res = yield* ai.updateInsights(recordId, parsed)
+    yield* renderer.emitSuccess(res)
+  }),
+).pipe(Command.withDescription('edit AI insights via $EDITOR'))

--- a/packages/cli/src/cli/ai/insights/get.ts
+++ b/packages/cli/src/cli/ai/insights/get.ts
@@ -1,0 +1,16 @@
+import { Args, Command } from '@effect/cli'
+import { Effect } from 'effect'
+
+import { Ai } from '../../../services/Ai'
+import { Renderer } from '../../../services/Renderer'
+
+const recordId = Args.text({ name: 'recordId' })
+
+export const get = Command.make('get', { recordId }, ({ recordId }) =>
+  Effect.gen(function* () {
+    const ai = yield* Ai
+    const renderer = yield* Renderer
+    const res = yield* ai.getInsights(recordId)
+    yield* renderer.emitSuccess(res)
+  }),
+).pipe(Command.withDescription('get AI insights by record id'))

--- a/packages/cli/src/cli/ai/insights/index.ts
+++ b/packages/cli/src/cli/ai/insights/index.ts
@@ -1,0 +1,13 @@
+import { Command } from '@effect/cli'
+
+import { byArticle } from './by-article'
+import { del } from './delete'
+import { edit } from './edit'
+import { get } from './get'
+import { list } from './list'
+import { refresh } from './refresh'
+
+export const insightsCmd = Command.make('insights').pipe(
+  Command.withDescription('manage AI insights'),
+  Command.withSubcommands([refresh, list, get, byArticle, edit, del]),
+)

--- a/packages/cli/src/cli/ai/insights/list.ts
+++ b/packages/cli/src/cli/ai/insights/list.ts
@@ -1,0 +1,30 @@
+import { Command, Options } from '@effect/cli'
+import { Effect, Option } from 'effect'
+
+import { Ai } from '../../../services/Ai'
+import { Renderer } from '../../../services/Renderer'
+
+const page = Options.integer('page').pipe(Options.optional)
+const size = Options.integer('size').pipe(Options.optional)
+const grouped = Options.boolean('grouped').pipe(
+  Options.withDescription('group rows by article'),
+)
+
+const unwrap = <A>(value: Option.Option<A>): A | undefined =>
+  Option.getOrUndefined(value)
+
+export const list = Command.make(
+  'list',
+  { page, size, grouped },
+  ({ page, size, grouped }) =>
+    Effect.gen(function* () {
+      const ai = yield* Ai
+      const renderer = yield* Renderer
+      const res = yield* ai.listInsights({
+        page: unwrap(page),
+        size: unwrap(size),
+        grouped,
+      })
+      yield* renderer.emitSuccess(res)
+    }),
+).pipe(Command.withDescription('list AI insights'))

--- a/packages/cli/src/cli/ai/insights/refresh.ts
+++ b/packages/cli/src/cli/ai/insights/refresh.ts
@@ -1,0 +1,29 @@
+import { Args, Command, Options } from '@effect/cli'
+import { Effect } from 'effect'
+
+import { Ai } from '../../../services/Ai'
+import { Renderer } from '../../../services/Renderer'
+import { Resolver } from '../../../services/Resolver'
+import { followTask } from '../_poll'
+import { resolveArticleId } from '../_resolve'
+import { aiTaskView } from '../views'
+
+const id = Args.text({ name: 'idOrSlug' })
+const noWait = Options.boolean('no-wait').pipe(
+  Options.withDescription('return immediately after creating the task'),
+)
+
+export const refresh = Command.make(
+  'refresh',
+  { id, noWait },
+  ({ id, noWait }) =>
+    Effect.gen(function* () {
+      const ai = yield* Ai
+      const renderer = yield* Renderer
+      const resolver = yield* Resolver
+      const refId = yield* resolveArticleId(resolver, id)
+      const created = yield* ai.refreshInsights({ refId })
+      const final = yield* followTask(ai, renderer, created, noWait)
+      yield* renderer.emit(aiTaskView, final)
+    }),
+).pipe(Command.withDescription('refresh AI insights for an article'))

--- a/packages/cli/src/cli/ai/summary/by-article.ts
+++ b/packages/cli/src/cli/ai/summary/by-article.ts
@@ -1,0 +1,33 @@
+import { Args, Command, Options } from '@effect/cli'
+import { Effect, Option } from 'effect'
+
+import { Ai } from '../../../services/Ai'
+import { Renderer } from '../../../services/Renderer'
+import { Resolver } from '../../../services/Resolver'
+import { resolveArticleId } from '../_resolve'
+
+const id = Args.text({ name: 'idOrSlug' })
+const lang = Options.text('lang').pipe(Options.optional)
+const onlyDb = Options.boolean('only-db').pipe(
+  Options.withDescription('do not auto-generate on miss'),
+)
+
+const unwrap = <A>(value: Option.Option<A>): A | undefined =>
+  Option.getOrUndefined(value)
+
+export const byArticle = Command.make(
+  'by-article',
+  { id, lang, onlyDb },
+  ({ id, lang, onlyDb }) =>
+    Effect.gen(function* () {
+      const ai = yield* Ai
+      const renderer = yield* Renderer
+      const resolver = yield* Resolver
+      const refId = yield* resolveArticleId(resolver, id)
+      const res = yield* ai.getSummariesByArticle(refId, {
+        lang: unwrap(lang),
+        onlyDb,
+      })
+      yield* renderer.emitSuccess(res)
+    }),
+).pipe(Command.withDescription("show an article's AI summary"))

--- a/packages/cli/src/cli/ai/summary/delete.ts
+++ b/packages/cli/src/cli/ai/summary/delete.ts
@@ -1,0 +1,30 @@
+import { Args, Command, Options } from '@effect/cli'
+import { Effect } from 'effect'
+
+import { ValidationFailed } from '../../../domain/errors'
+import { Ai } from '../../../services/Ai'
+import { Renderer } from '../../../services/Renderer'
+
+const recordId = Args.text({ name: 'recordId' })
+const force = Options.boolean('force').pipe(
+  Options.withDescription('skip the non-TTY guard'),
+)
+
+export const del = Command.make(
+  'delete',
+  { recordId, force },
+  ({ recordId, force }) =>
+    Effect.gen(function* () {
+      if (!force && !process.stdin.isTTY) {
+        return yield* Effect.fail(
+          new ValidationFailed({
+            message: 'refusing to delete without --force in non-TTY context',
+          }),
+        )
+      }
+      const ai = yield* Ai
+      const renderer = yield* Renderer
+      yield* ai.deleteSummary(recordId)
+      yield* renderer.emitSuccess({ deleted: recordId })
+    }),
+).pipe(Command.withDescription('delete an AI summary'))

--- a/packages/cli/src/cli/ai/summary/edit.ts
+++ b/packages/cli/src/cli/ai/summary/edit.ts
@@ -1,0 +1,67 @@
+import { Args, Command } from '@effect/cli'
+import { Effect } from 'effect'
+
+import { ValidationJson } from '../../../domain/errors'
+import { Ai } from '../../../services/Ai'
+import { Editor } from '../../../services/Editor'
+import { Renderer } from '../../../services/Renderer'
+
+const recordId = Args.text({ name: 'recordId' })
+
+interface SummaryEnvelope {
+  summary: string
+}
+
+const formatJson = (value: SummaryEnvelope): string =>
+  `${JSON.stringify(value, null, 2)}\n`
+
+const parseEnvelope = (raw: string): SummaryEnvelope => {
+  const parsed = JSON.parse(raw) as unknown
+  if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
+    throw new Error('expected a JSON object')
+  }
+  const obj = parsed as Record<string, unknown>
+  if (typeof obj.summary !== 'string') {
+    throw new Error('expected `summary` field of type string')
+  }
+  return { summary: obj.summary }
+}
+
+const unwrapDoc = (raw: unknown): Record<string, unknown> => {
+  if (!raw || typeof raw !== 'object') return {}
+  const r = raw as Record<string, unknown>
+  if (r.data && typeof r.data === 'object' && !Array.isArray(r.data)) {
+    return r.data as Record<string, unknown>
+  }
+  return r
+}
+
+export const edit = Command.make('edit', { recordId }, ({ recordId }) =>
+  Effect.gen(function* () {
+    const ai = yield* Ai
+    const editor = yield* Editor
+    const renderer = yield* Renderer
+    const current = unwrapDoc(yield* ai.getSummary(recordId))
+    const initial = formatJson({
+      summary: typeof current.summary === 'string' ? current.summary : '',
+    })
+    const next = yield* editor.openEditor({
+      filename: `ai-summary-${recordId}.json`,
+      initialContent: initial,
+    })
+    if (next.trim() === initial.trim()) {
+      yield* renderer.emitInfo('no changes')
+      return
+    }
+    const parsed = yield* Effect.try({
+      try: () => parseEnvelope(next),
+      catch: (err) =>
+        new ValidationJson({
+          message: err instanceof Error ? err.message : String(err),
+          cause: err,
+        }),
+    })
+    const res = yield* ai.updateSummary(recordId, parsed)
+    yield* renderer.emitSuccess(res)
+  }),
+).pipe(Command.withDescription('edit an AI summary via $EDITOR'))

--- a/packages/cli/src/cli/ai/summary/get.ts
+++ b/packages/cli/src/cli/ai/summary/get.ts
@@ -1,0 +1,16 @@
+import { Args, Command } from '@effect/cli'
+import { Effect } from 'effect'
+
+import { Ai } from '../../../services/Ai'
+import { Renderer } from '../../../services/Renderer'
+
+const recordId = Args.text({ name: 'recordId' })
+
+export const get = Command.make('get', { recordId }, ({ recordId }) =>
+  Effect.gen(function* () {
+    const ai = yield* Ai
+    const renderer = yield* Renderer
+    const res = yield* ai.getSummary(recordId)
+    yield* renderer.emitSuccess(res)
+  }),
+).pipe(Command.withDescription('get an AI summary by record id'))

--- a/packages/cli/src/cli/ai/summary/index.ts
+++ b/packages/cli/src/cli/ai/summary/index.ts
@@ -1,0 +1,13 @@
+import { Command } from '@effect/cli'
+
+import { byArticle } from './by-article'
+import { del } from './delete'
+import { edit } from './edit'
+import { get } from './get'
+import { list } from './list'
+import { regen } from './regen'
+
+export const summaryCmd = Command.make('summary').pipe(
+  Command.withDescription('manage AI summaries'),
+  Command.withSubcommands([regen, list, get, byArticle, edit, del]),
+)

--- a/packages/cli/src/cli/ai/summary/list.ts
+++ b/packages/cli/src/cli/ai/summary/list.ts
@@ -1,0 +1,30 @@
+import { Command, Options } from '@effect/cli'
+import { Effect, Option } from 'effect'
+
+import { Ai } from '../../../services/Ai'
+import { Renderer } from '../../../services/Renderer'
+
+const page = Options.integer('page').pipe(Options.optional)
+const size = Options.integer('size').pipe(Options.optional)
+const grouped = Options.boolean('grouped').pipe(
+  Options.withDescription('group rows by article'),
+)
+
+const unwrap = <A>(value: Option.Option<A>): A | undefined =>
+  Option.getOrUndefined(value)
+
+export const list = Command.make(
+  'list',
+  { page, size, grouped },
+  ({ page, size, grouped }) =>
+    Effect.gen(function* () {
+      const ai = yield* Ai
+      const renderer = yield* Renderer
+      const res = yield* ai.listSummaries({
+        page: unwrap(page),
+        size: unwrap(size),
+        grouped,
+      })
+      yield* renderer.emitSuccess(res)
+    }),
+).pipe(Command.withDescription('list AI summaries'))

--- a/packages/cli/src/cli/ai/summary/regen.ts
+++ b/packages/cli/src/cli/ai/summary/regen.ts
@@ -1,0 +1,36 @@
+import { Args, Command, Options } from '@effect/cli'
+import { Effect } from 'effect'
+
+import { Ai } from '../../../services/Ai'
+import { Renderer } from '../../../services/Renderer'
+import { Resolver } from '../../../services/Resolver'
+import { followTask } from '../_poll'
+import { resolveArticleId } from '../_resolve'
+import { aiTaskView } from '../views'
+
+const id = Args.text({ name: 'idOrSlug' })
+const to = Options.text('to').pipe(
+  Options.repeated,
+  Options.withDescription('target language code (repeatable)'),
+)
+const noWait = Options.boolean('no-wait').pipe(
+  Options.withDescription('return immediately after creating the task'),
+)
+
+export const regen = Command.make(
+  'regen',
+  { id, to, noWait },
+  ({ id, to, noWait }) =>
+    Effect.gen(function* () {
+      const ai = yield* Ai
+      const renderer = yield* Renderer
+      const resolver = yield* Resolver
+      const refId = yield* resolveArticleId(resolver, id)
+      const created = yield* ai.regenSummary({
+        refId,
+        targetLanguages: to.length ? to : undefined,
+      })
+      const final = yield* followTask(ai, renderer, created, noWait)
+      yield* renderer.emit(aiTaskView, final)
+    }),
+).pipe(Command.withDescription('regenerate the AI summary for an article'))

--- a/packages/cli/src/cli/ai/translate/by-article.ts
+++ b/packages/cli/src/cli/ai/translate/by-article.ts
@@ -1,0 +1,29 @@
+import { Args, Command, Options } from '@effect/cli'
+import { Effect, Option } from 'effect'
+
+import { Ai } from '../../../services/Ai'
+import { Renderer } from '../../../services/Renderer'
+import { Resolver } from '../../../services/Resolver'
+import { resolveArticleId } from '../_resolve'
+
+const id = Args.text({ name: 'idOrSlug' })
+const lang = Options.text('lang').pipe(Options.optional)
+
+const unwrap = <A>(value: Option.Option<A>): A | undefined =>
+  Option.getOrUndefined(value)
+
+export const byArticle = Command.make(
+  'by-article',
+  { id, lang },
+  ({ id, lang }) =>
+    Effect.gen(function* () {
+      const ai = yield* Ai
+      const renderer = yield* Renderer
+      const resolver = yield* Resolver
+      const refId = yield* resolveArticleId(resolver, id)
+      const res = yield* ai.getTranslationsByArticle(refId, {
+        lang: unwrap(lang),
+      })
+      yield* renderer.emitSuccess(res)
+    }),
+).pipe(Command.withDescription("show an article's translations"))

--- a/packages/cli/src/cli/ai/translate/delete.ts
+++ b/packages/cli/src/cli/ai/translate/delete.ts
@@ -1,0 +1,30 @@
+import { Args, Command, Options } from '@effect/cli'
+import { Effect } from 'effect'
+
+import { ValidationFailed } from '../../../domain/errors'
+import { Ai } from '../../../services/Ai'
+import { Renderer } from '../../../services/Renderer'
+
+const recordId = Args.text({ name: 'recordId' })
+const force = Options.boolean('force').pipe(
+  Options.withDescription('skip the non-TTY guard'),
+)
+
+export const del = Command.make(
+  'delete',
+  { recordId, force },
+  ({ recordId, force }) =>
+    Effect.gen(function* () {
+      if (!force && !process.stdin.isTTY) {
+        return yield* Effect.fail(
+          new ValidationFailed({
+            message: 'refusing to delete without --force in non-TTY context',
+          }),
+        )
+      }
+      const ai = yield* Ai
+      const renderer = yield* Renderer
+      yield* ai.deleteTranslation(recordId)
+      yield* renderer.emitSuccess({ deleted: recordId })
+    }),
+).pipe(Command.withDescription('delete an AI translation'))

--- a/packages/cli/src/cli/ai/translate/edit.ts
+++ b/packages/cli/src/cli/ai/translate/edit.ts
@@ -1,0 +1,109 @@
+import { Args, Command } from '@effect/cli'
+import { Effect } from 'effect'
+
+import { ValidationJson } from '../../../domain/errors'
+import { Ai, type AiTranslationPatch } from '../../../services/Ai'
+import { Editor } from '../../../services/Editor'
+import { Renderer } from '../../../services/Renderer'
+
+const recordId = Args.text({ name: 'recordId' })
+
+const PATCH_KEYS = [
+  'title',
+  'text',
+  'subtitle',
+  'summary',
+  'tags',
+  'content',
+] as const
+
+const editableFieldsOf = (
+  doc: Record<string, unknown>,
+): Record<string, unknown> => {
+  const out: Record<string, unknown> = {}
+  for (const key of PATCH_KEYS) {
+    if (doc[key] !== undefined) out[key] = doc[key]
+  }
+  return out
+}
+
+const formatJson = (value: Record<string, unknown>): string =>
+  `${JSON.stringify(value, null, 2)}\n`
+
+const parseEnvelope = (raw: string): AiTranslationPatch => {
+  const parsed = JSON.parse(raw) as unknown
+  if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
+    throw new Error('expected a JSON object')
+  }
+  const obj = parsed as Record<string, unknown>
+  const patch: Record<string, unknown> = {}
+  if ('title' in obj) {
+    if (typeof obj.title !== 'string') throw new Error('title must be a string')
+    patch.title = obj.title
+  }
+  if ('text' in obj) {
+    if (typeof obj.text !== 'string') throw new Error('text must be a string')
+    patch.text = obj.text
+  }
+  if ('subtitle' in obj) {
+    if (obj.subtitle !== null && typeof obj.subtitle !== 'string')
+      throw new Error('subtitle must be a string or null')
+    patch.subtitle = obj.subtitle
+  }
+  if ('summary' in obj) {
+    if (typeof obj.summary !== 'string')
+      throw new Error('summary must be a string')
+    patch.summary = obj.summary
+  }
+  if ('tags' in obj) {
+    if (
+      !Array.isArray(obj.tags) ||
+      !obj.tags.every((t) => typeof t === 'string')
+    )
+      throw new Error('tags must be an array of strings')
+    patch.tags = obj.tags
+  }
+  if ('content' in obj) {
+    if (typeof obj.content !== 'string')
+      throw new Error('content must be a string')
+    patch.content = obj.content
+  }
+  return patch as AiTranslationPatch
+}
+
+const unwrapDoc = (raw: unknown): Record<string, unknown> => {
+  if (!raw || typeof raw !== 'object') return {}
+  const r = raw as Record<string, unknown>
+  if (r.data && typeof r.data === 'object' && !Array.isArray(r.data)) {
+    return r.data as Record<string, unknown>
+  }
+  return r
+}
+
+export const edit = Command.make('edit', { recordId }, ({ recordId }) =>
+  Effect.gen(function* () {
+    const ai = yield* Ai
+    const editor = yield* Editor
+    const renderer = yield* Renderer
+    const current = unwrapDoc(yield* ai.getTranslation(recordId))
+    const initial = formatJson(editableFieldsOf(current))
+    const next = yield* editor.openEditor({
+      filename: `ai-translation-${recordId}.json`,
+      initialContent: initial,
+    })
+    if (next.trim() === initial.trim()) {
+      yield* renderer.emitInfo('no changes')
+      return
+    }
+    const parsed = yield* Effect.try({
+      try: () => parseEnvelope(next),
+      catch: (err) =>
+        new ValidationJson({
+          message: err instanceof Error ? err.message : String(err),
+          cause: err,
+        }),
+    })
+    const res = yield* ai.updateTranslation(recordId, parsed)
+    yield* renderer.emitSuccess(res)
+  }),
+).pipe(Command.withDescription('edit an AI translation via $EDITOR'))

--- a/packages/cli/src/cli/ai/translate/entries/delete.ts
+++ b/packages/cli/src/cli/ai/translate/entries/delete.ts
@@ -1,0 +1,30 @@
+import { Args, Command, Options } from '@effect/cli'
+import { Effect } from 'effect'
+
+import { ValidationFailed } from '../../../../domain/errors'
+import { Ai } from '../../../../services/Ai'
+import { Renderer } from '../../../../services/Renderer'
+
+const recordId = Args.text({ name: 'recordId' })
+const force = Options.boolean('force').pipe(
+  Options.withDescription('skip the non-TTY guard'),
+)
+
+export const del = Command.make(
+  'delete',
+  { recordId, force },
+  ({ recordId, force }) =>
+    Effect.gen(function* () {
+      if (!force && !process.stdin.isTTY) {
+        return yield* Effect.fail(
+          new ValidationFailed({
+            message: 'refusing to delete without --force in non-TTY context',
+          }),
+        )
+      }
+      const ai = yield* Ai
+      const renderer = yield* Renderer
+      yield* ai.deleteEntry(recordId)
+      yield* renderer.emitSuccess({ deleted: recordId })
+    }),
+).pipe(Command.withDescription('delete a translation entry'))

--- a/packages/cli/src/cli/ai/translate/entries/edit.ts
+++ b/packages/cli/src/cli/ai/translate/entries/edit.ts
@@ -1,0 +1,90 @@
+import { Args, Command } from '@effect/cli'
+import { Effect } from 'effect'
+
+import { ValidationJson } from '../../../../domain/errors'
+import { Ai, type AiService } from '../../../../services/Ai'
+import { Editor } from '../../../../services/Editor'
+import { Renderer } from '../../../../services/Renderer'
+
+const recordId = Args.text({ name: 'recordId' })
+
+const formatJson = (value: { translatedText: string }): string =>
+  `${JSON.stringify(value, null, 2)}\n`
+
+const parseEnvelope = (raw: string): { translatedText: string } => {
+  const parsed = JSON.parse(raw) as unknown
+  if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
+    throw new Error('expected a JSON object')
+  }
+  const obj = parsed as Record<string, unknown>
+  if (typeof obj.translatedText !== 'string' || !obj.translatedText) {
+    throw new Error('expected non-empty `translatedText` string')
+  }
+  return { translatedText: obj.translatedText }
+}
+
+const asRows = (raw: unknown): ReadonlyArray<Record<string, unknown>> => {
+  if (Array.isArray(raw))
+    return raw.filter(
+      (r): r is Record<string, unknown> => !!r && typeof r === 'object',
+    )
+  if (raw && typeof raw === 'object') {
+    const data = (raw as { data?: unknown }).data
+    if (Array.isArray(data))
+      return data.filter(
+        (r): r is Record<string, unknown> => !!r && typeof r === 'object',
+      )
+  }
+  return []
+}
+
+const fetchEntry = (
+  ai: AiService,
+  id: string,
+): Effect.Effect<Record<string, unknown> | null> =>
+  Effect.gen(function* () {
+    const MAX = 20
+    for (let page = 1; page <= MAX; page++) {
+      const raw = yield* ai
+        .listEntries({ page, size: 50 })
+        .pipe(Effect.catchAll(() => Effect.succeed<unknown>(null)))
+      if (!raw) return null
+      const rows = asRows(raw)
+      for (const row of rows) {
+        if (row.id === id) return row
+      }
+      if (rows.length < 50) break
+    }
+    return null
+  })
+
+export const edit = Command.make('edit', { recordId }, ({ recordId }) =>
+  Effect.gen(function* () {
+    const ai = yield* Ai
+    const editor = yield* Editor
+    const renderer = yield* Renderer
+    const found = yield* fetchEntry(ai, recordId)
+    const initial = formatJson({
+      translatedText:
+        typeof found?.translatedText === 'string' ? found.translatedText : '',
+    })
+    const next = yield* editor.openEditor({
+      filename: `ai-entry-${recordId}.json`,
+      initialContent: initial,
+    })
+    if (next.trim() === initial.trim()) {
+      yield* renderer.emitInfo('no changes')
+      return
+    }
+    const parsed = yield* Effect.try({
+      try: () => parseEnvelope(next),
+      catch: (err) =>
+        new ValidationJson({
+          message: err instanceof Error ? err.message : String(err),
+          cause: err,
+        }),
+    })
+    const res = yield* ai.updateEntry(recordId, parsed)
+    yield* renderer.emitSuccess(res)
+  }),
+).pipe(Command.withDescription('edit a translation entry via $EDITOR'))

--- a/packages/cli/src/cli/ai/translate/entries/generate.ts
+++ b/packages/cli/src/cli/ai/translate/entries/generate.ts
@@ -1,0 +1,31 @@
+import { Command, Options } from '@effect/cli'
+import { Effect } from 'effect'
+
+import { Ai } from '../../../../services/Ai'
+import { Renderer } from '../../../../services/Renderer'
+
+const keyPath = Options.text('key-path').pipe(
+  Options.repeated,
+  Options.withDescription(
+    'restrict to a server-validated key path (repeatable). Allowed: category.name, topic.name, topic.introduce, topic.description, note.mood, note.weather',
+  ),
+)
+const to = Options.text('to').pipe(
+  Options.repeated,
+  Options.withDescription('target language code (repeatable)'),
+)
+
+export const generate = Command.make(
+  'generate',
+  { keyPath, to },
+  ({ keyPath, to }) =>
+    Effect.gen(function* () {
+      const ai = yield* Ai
+      const renderer = yield* Renderer
+      const res = yield* ai.generateEntries({
+        keyPaths: keyPath.length ? keyPath : undefined,
+        targetLangs: to.length ? to : undefined,
+      })
+      yield* renderer.emitSuccess(res)
+    }),
+).pipe(Command.withDescription('regenerate translation entries'))

--- a/packages/cli/src/cli/ai/translate/entries/index.ts
+++ b/packages/cli/src/cli/ai/translate/entries/index.ts
@@ -1,0 +1,11 @@
+import { Command } from '@effect/cli'
+
+import { del } from './delete'
+import { edit } from './edit'
+import { generate } from './generate'
+import { list } from './list'
+
+export const entriesCmd = Command.make('entries').pipe(
+  Command.withDescription('manage translation entries (i18n dictionary)'),
+  Command.withSubcommands([list, generate, edit, del]),
+)

--- a/packages/cli/src/cli/ai/translate/entries/list.ts
+++ b/packages/cli/src/cli/ai/translate/entries/list.ts
@@ -1,0 +1,30 @@
+import { Command, Options } from '@effect/cli'
+import { Effect, Option } from 'effect'
+
+import { Ai } from '../../../../services/Ai'
+import { Renderer } from '../../../../services/Renderer'
+
+const page = Options.integer('page').pipe(Options.optional)
+const size = Options.integer('size').pipe(Options.optional)
+const keyPath = Options.text('key-path').pipe(Options.optional)
+const lang = Options.text('lang').pipe(Options.optional)
+
+const unwrap = <A>(value: Option.Option<A>): A | undefined =>
+  Option.getOrUndefined(value)
+
+export const list = Command.make(
+  'list',
+  { page, size, keyPath, lang },
+  ({ page, size, keyPath, lang }) =>
+    Effect.gen(function* () {
+      const ai = yield* Ai
+      const renderer = yield* Renderer
+      const res = yield* ai.listEntries({
+        page: unwrap(page),
+        size: unwrap(size),
+        keyPath: unwrap(keyPath),
+        lang: unwrap(lang),
+      })
+      yield* renderer.emitSuccess(res)
+    }),
+).pipe(Command.withDescription('list AI translation entries (i18n dictionary)'))

--- a/packages/cli/src/cli/ai/translate/get.ts
+++ b/packages/cli/src/cli/ai/translate/get.ts
@@ -1,0 +1,16 @@
+import { Args, Command } from '@effect/cli'
+import { Effect } from 'effect'
+
+import { Ai } from '../../../services/Ai'
+import { Renderer } from '../../../services/Renderer'
+
+const recordId = Args.text({ name: 'recordId' })
+
+export const get = Command.make('get', { recordId }, ({ recordId }) =>
+  Effect.gen(function* () {
+    const ai = yield* Ai
+    const renderer = yield* Renderer
+    const res = yield* ai.getTranslation(recordId)
+    yield* renderer.emitSuccess(res)
+  }),
+).pipe(Command.withDescription('get an AI translation by record id'))

--- a/packages/cli/src/cli/ai/translate/index.ts
+++ b/packages/cli/src/cli/ai/translate/index.ts
@@ -1,0 +1,24 @@
+import { Command } from '@effect/cli'
+
+import { byArticle } from './by-article'
+import { del } from './delete'
+import { edit } from './edit'
+import { entriesCmd } from './entries'
+import { get } from './get'
+import { languages } from './languages'
+import { list } from './list'
+import { run } from './run'
+
+export const translateCmd = Command.make('translate').pipe(
+  Command.withDescription('manage AI translations'),
+  Command.withSubcommands([
+    run,
+    list,
+    get,
+    byArticle,
+    languages,
+    edit,
+    del,
+    entriesCmd,
+  ]),
+)

--- a/packages/cli/src/cli/ai/translate/languages.ts
+++ b/packages/cli/src/cli/ai/translate/languages.ts
@@ -1,0 +1,22 @@
+import { Args, Command } from '@effect/cli'
+import { Effect } from 'effect'
+
+import { Ai } from '../../../services/Ai'
+import { Renderer } from '../../../services/Renderer'
+import { Resolver } from '../../../services/Resolver'
+import { resolveArticleId } from '../_resolve'
+
+const id = Args.text({ name: 'idOrSlug' })
+
+export const languages = Command.make('languages', { id }, ({ id }) =>
+  Effect.gen(function* () {
+    const ai = yield* Ai
+    const renderer = yield* Renderer
+    const resolver = yield* Resolver
+    const refId = yield* resolveArticleId(resolver, id)
+    const res = yield* ai.getTranslationLanguages(refId)
+    yield* renderer.emitSuccess(res)
+  }),
+).pipe(
+  Command.withDescription('list languages an article has been translated into'),
+)

--- a/packages/cli/src/cli/ai/translate/list.ts
+++ b/packages/cli/src/cli/ai/translate/list.ts
@@ -1,0 +1,24 @@
+import { Command, Options } from '@effect/cli'
+import { Effect, Option } from 'effect'
+
+import { Ai } from '../../../services/Ai'
+import { Renderer } from '../../../services/Renderer'
+
+const page = Options.integer('page').pipe(Options.optional)
+const size = Options.integer('size').pipe(Options.optional)
+
+const unwrap = <A>(value: Option.Option<A>): A | undefined =>
+  Option.getOrUndefined(value)
+
+export const list = Command.make('list', { page, size }, ({ page, size }) =>
+  Effect.gen(function* () {
+    const ai = yield* Ai
+    const renderer = yield* Renderer
+    const res = yield* ai.listTranslations({
+      page: unwrap(page),
+      size: unwrap(size),
+      grouped: true,
+    })
+    yield* renderer.emitSuccess(res)
+  }),
+).pipe(Command.withDescription('list AI translations (grouped by article)'))

--- a/packages/cli/src/cli/ai/translate/run.ts
+++ b/packages/cli/src/cli/ai/translate/run.ts
@@ -1,0 +1,43 @@
+import { Args, Command, Options } from '@effect/cli'
+import { Effect } from 'effect'
+
+import { ValidationFailed } from '../../../domain/errors'
+import { Ai } from '../../../services/Ai'
+import { Renderer } from '../../../services/Renderer'
+import { Resolver } from '../../../services/Resolver'
+import { followTask } from '../_poll'
+import { resolveArticleId } from '../_resolve'
+import { aiTaskView } from '../views'
+
+const id = Args.text({ name: 'idOrSlug' })
+const to = Options.text('to').pipe(
+  Options.repeated,
+  Options.withDescription('target language code (repeatable, at least one)'),
+)
+const noWait = Options.boolean('no-wait').pipe(
+  Options.withDescription('return immediately after creating the task'),
+)
+
+export const run = Command.make(
+  'run',
+  { id, to, noWait },
+  ({ id, to, noWait }) =>
+    Effect.gen(function* () {
+      if (!to.length) {
+        return yield* Effect.fail(
+          new ValidationFailed({
+            message: 'at least one --to <lang> is required',
+          }),
+        )
+      }
+      const ai = yield* Ai
+      const renderer = yield* Renderer
+      const resolver = yield* Resolver
+      const refId = yield* resolveArticleId(resolver, id)
+      const created = yield* ai.translate({ refId, targetLanguages: to })
+      const final = yield* followTask(ai, renderer, created, noWait)
+      yield* renderer.emit(aiTaskView, final)
+    }),
+).pipe(
+  Command.withDescription('translate an article into one or more languages'),
+)

--- a/packages/cli/src/cli/ai/views.ts
+++ b/packages/cli/src/cli/ai/views.ts
@@ -1,0 +1,54 @@
+import type { AiTaskFinalView } from '../../services/Ai'
+import type { View } from '../../services/Renderer/view'
+
+const formatField = (key: string, value: unknown): string =>
+  `  ${key.padEnd(15)}${value === undefined || value === null || value === '' ? '-' : String(value)}`
+
+const formatCost = (cost: number | undefined): string | undefined => {
+  if (cost === undefined) return undefined
+  // Core stores totalCost as cents; show as `<x.xx> ¢`.
+  return `${cost.toFixed(2)} ¢`
+}
+
+const formatList = (
+  values: ReadonlyArray<string> | undefined,
+): string | undefined =>
+  values && values.length ? values.join(', ') : undefined
+
+export const aiTaskView: View<AiTaskFinalView> = {
+  kind: 'ai-task',
+  modes: new Set(['readable', 'llm']),
+  readable: (data) => {
+    const lines = [`ai ${data.type} task ${data.status}`]
+    const fields: Array<[string, unknown]> = [
+      ['taskId', data.taskId],
+      ['refId', data.refId],
+      ['targetLanguages', formatList(data.targetLanguages)],
+      ['totalTokens', data.totalTokens],
+      ['totalCost', formatCost(data.totalCost)],
+      ['resultIds', formatList(data.resultIds)],
+    ]
+    for (const [k, v] of fields) {
+      if (v === undefined || v === null || v === '') continue
+      lines.push(formatField(k, v))
+    }
+    if (data.error?.message) {
+      lines.push(formatField('error', data.error.message))
+    }
+    return lines.join('\n')
+  },
+  llm: (data) =>
+    [
+      `${data.status}`,
+      `type=${data.type}`,
+      `taskId=${data.taskId}`,
+      data.refId ? `refId=${data.refId}` : null,
+      data.totalTokens !== undefined ? `tokens=${data.totalTokens}` : null,
+      data.totalCost !== undefined
+        ? `cost=${data.totalCost.toFixed(2)}c`
+        : null,
+      data.error?.message ? `error=${data.error.message}` : null,
+    ]
+      .filter((s): s is string => s !== null)
+      .join(' '),
+}

--- a/packages/cli/src/cli/auth/index.ts
+++ b/packages/cli/src/cli/auth/index.ts
@@ -9,6 +9,7 @@ import { whoami } from './whoami'
 const help = registerCommandHelp({
   name: 'auth',
   description: 'authentication',
+  skillChapter: 'commands-auth',
   verbs: [
     {
       name: 'login',

--- a/packages/cli/src/cli/category/index.ts
+++ b/packages/cli/src/cli/category/index.ts
@@ -10,6 +10,7 @@ import { update } from './update'
 const help = registerCommandHelp({
   name: 'category',
   description: 'manage categories / tags',
+  skillChapter: 'commands-category',
   verbs: [
     { name: 'list', description: 'list categories and tags' },
     {

--- a/packages/cli/src/cli/comment/index.ts
+++ b/packages/cli/src/cli/comment/index.ts
@@ -12,6 +12,7 @@ import { unread } from './unread'
 const help = registerCommandHelp({
   name: 'comment',
   description: 'list and moderate comments',
+  skillChapter: 'commands-comment',
   verbs: [
     {
       name: 'list',

--- a/packages/cli/src/cli/config/index.ts
+++ b/packages/cli/src/cli/config/index.ts
@@ -9,6 +9,7 @@ import { set } from './set'
 const help = registerCommandHelp({
   name: 'config',
   description: 'manage server options',
+  skillChapter: 'commands-config',
   verbs: [
     { name: 'list', description: 'list all server options' },
     { name: 'get', args: ['<key>'], description: 'read one server option' },

--- a/packages/cli/src/cli/help/index.ts
+++ b/packages/cli/src/cli/help/index.ts
@@ -182,6 +182,10 @@ export const renderRootHelp = (data: RootHelpData): string => {
   const lines: string[] = [
     data.description,
     '',
+    '## For AI agents — read the bundled skill first',
+    '',
+    `Run \`${data.programName} skill\` to list every bundled chapter (auth, content authoring, command syntax, AI artifacts, output modes, safety). \`${data.programName} skill get <slug>\` prints one chapter as raw markdown; \`${data.programName} skill all\` concatenates everything for a single-shot context injection. Pass \`--output llm\` for raw markdown without ANSI.`,
+    '',
     '## Usage',
     '',
     `    ${data.programName} [global-options] <command> [command-options] [args]`,

--- a/packages/cli/src/cli/help/index.ts
+++ b/packages/cli/src/cli/help/index.ts
@@ -364,6 +364,14 @@ export const renderGroupHelp = (data: GroupHelpData): string => {
     lines.push('')
   }
 
+  const chapter = `commands-${data.groupName}`
+  lines.push('## Bundled skill (for AI agents)')
+  lines.push('')
+  lines.push(
+    `For deeper reference: \`${data.programName} skill get ${chapter}\` (or \`${data.programName} skill\` for the full list).`,
+  )
+  lines.push('')
+
   return lines.join('\n')
 }
 

--- a/packages/cli/src/cli/help/index.ts
+++ b/packages/cli/src/cli/help/index.ts
@@ -287,6 +287,7 @@ export interface GroupHelpData {
   readonly verbs: readonly VerbDescriptor[]
   readonly isLeaf?: boolean
   readonly leafOptions?: readonly LeafOptionHelp[]
+  readonly skillChapter?: string
 }
 
 const renderVerbSignature = (verb: VerbDescriptor): string => {
@@ -310,6 +311,7 @@ export const groupHelpDataFor = (
     verbs: entry.verbs ?? [],
     isLeaf: entry.isLeaf,
     leafOptions: entry.leafOptions,
+    skillChapter: entry.skillChapter,
   }
 }
 
@@ -364,12 +366,17 @@ export const renderGroupHelp = (data: GroupHelpData): string => {
     lines.push('')
   }
 
-  const chapter = `commands-${data.groupName}`
   lines.push('## Bundled skill (for AI agents)')
   lines.push('')
-  lines.push(
-    `For deeper reference: \`${data.programName} skill get ${chapter}\` (or \`${data.programName} skill\` for the full list).`,
-  )
+  if (data.skillChapter) {
+    lines.push(
+      `For deeper reference: \`${data.programName} skill get ${data.skillChapter}\` (or \`${data.programName} skill\` for the full list).`,
+    )
+  } else {
+    lines.push(
+      `For deeper reference run \`${data.programName} skill\` to see the bundled chapter list.`,
+    )
+  }
   lines.push('')
 
   return lines.join('\n')

--- a/packages/cli/src/cli/help/index.ts
+++ b/packages/cli/src/cli/help/index.ts
@@ -26,6 +26,7 @@
 // through `bin/mxs.ts`.
 // ---------------------------------------------------------------------------
 
+import '../ai'
 import '../auth'
 import '../category'
 import '../comment'
@@ -81,6 +82,7 @@ export const GROUP_NAMES = [
   'topic',
   'comment',
   'snippet',
+  'ai',
   'config',
   'skill',
   'preview',

--- a/packages/cli/src/cli/help/index.ts
+++ b/packages/cli/src/cli/help/index.ts
@@ -182,9 +182,9 @@ export const renderRootHelp = (data: RootHelpData): string => {
   const lines: string[] = [
     data.description,
     '',
-    '## For AI agents — read the bundled skill first',
+    '## Bundled skill (for AI agents)',
     '',
-    `Run \`${data.programName} skill\` to list every bundled chapter (auth, content authoring, command syntax, AI artifacts, output modes, safety). \`${data.programName} skill get <slug>\` prints one chapter as raw markdown; \`${data.programName} skill all\` concatenates everything for a single-shot context injection. Pass \`--output llm\` for raw markdown without ANSI.`,
+    `Per-command \`--help\` covers most usage. For deeper context — content authoring, LiteXML envelopes, output modes, mutation safety, AI artifacts — \`${data.programName} skill\` lists bundled chapters; \`${data.programName} skill get <slug>\` prints one as raw markdown. Pass \`--output llm\` for ANSI-free output.`,
     '',
     '## Usage',
     '',

--- a/packages/cli/src/cli/help/registry.ts
+++ b/packages/cli/src/cli/help/registry.ts
@@ -34,6 +34,9 @@ export interface CommandHelp {
   // flag table for the group help renderer.
   readonly isLeaf?: boolean
   readonly leafOptions?: readonly LeafOptionHelp[]
+  // Bundled skill chapter slug, if any. Surfaces in `mxs <group> --help` as a
+  // pointer for AI agents. Leave undefined when no dedicated chapter exists.
+  readonly skillChapter?: string
 }
 
 const REGISTRY = new Map<string, CommandHelp>()

--- a/packages/cli/src/cli/note/index.ts
+++ b/packages/cli/src/cli/note/index.ts
@@ -13,6 +13,7 @@ import { update } from './update'
 const help = registerCommandHelp({
   name: 'note',
   description: 'manage notes',
+  skillChapter: 'commands-note',
   verbs: [
     {
       name: 'list',

--- a/packages/cli/src/cli/page/index.ts
+++ b/packages/cli/src/cli/page/index.ts
@@ -11,6 +11,7 @@ import { update } from './update'
 const help = registerCommandHelp({
   name: 'page',
   description: 'manage pages',
+  skillChapter: 'commands-page',
   verbs: [
     { name: 'list', description: 'list pages' },
     { name: 'get', args: ['<slugOrId>'], description: 'show a single page' },

--- a/packages/cli/src/cli/post/index.ts
+++ b/packages/cli/src/cli/post/index.ts
@@ -15,6 +15,7 @@ import { update } from './update'
 const help = registerCommandHelp({
   name: 'post',
   description: 'manage posts',
+  skillChapter: 'commands-post',
   verbs: [
     {
       name: 'list',

--- a/packages/cli/src/cli/preview/index.ts
+++ b/packages/cli/src/cli/preview/index.ts
@@ -15,6 +15,7 @@ registerCommandHelp({
   description:
     'render a LiteXML fragment or <mxpost>/<mxnote> envelope to HTML and open it in a browser',
   isLeaf: true,
+  skillChapter: 'commands-preview',
   leafOptions: [
     {
       flag: '--theme <light|dark>',

--- a/packages/cli/src/cli/profile/index.ts
+++ b/packages/cli/src/cli/profile/index.ts
@@ -10,6 +10,7 @@ import { use } from './use'
 const help = registerCommandHelp({
   name: 'profile',
   description: 'manage mxs profiles',
+  skillChapter: 'commands-profile',
   verbs: [
     { name: 'ls', description: 'list all known profiles' },
     {

--- a/packages/cli/src/cli/project/index.ts
+++ b/packages/cli/src/cli/project/index.ts
@@ -12,6 +12,7 @@ import { viewCmd } from './view-cmd'
 const help = registerCommandHelp({
   name: 'project',
   description: 'manage portfolio projects',
+  skillChapter: 'commands-project',
   verbs: [
     {
       name: 'list',

--- a/packages/cli/src/cli/snippet/index.ts
+++ b/packages/cli/src/cli/snippet/index.ts
@@ -11,6 +11,7 @@ import { update } from './update'
 const help = registerCommandHelp({
   name: 'snippet',
   description: 'manage snippets',
+  skillChapter: 'commands-snippet',
   verbs: [
     {
       name: 'list',

--- a/packages/cli/src/cli/topic/index.ts
+++ b/packages/cli/src/cli/topic/index.ts
@@ -10,6 +10,7 @@ import { update } from './update'
 const help = registerCommandHelp({
   name: 'topic',
   description: 'manage topics',
+  skillChapter: 'commands-topic',
   verbs: [
     { name: 'list', description: 'list topics' },
     { name: 'get', args: ['<slugOrId>'], description: 'show a single topic' },

--- a/packages/cli/src/domain/errors.ts
+++ b/packages/cli/src/domain/errors.ts
@@ -221,6 +221,30 @@ export class SkillCorpusEmpty extends Data.TaggedError('SkillCorpusEmpty')<{
   readonly cause?: unknown
 }> {}
 
+// ai.*
+export class AiTaskCreateFailed extends Data.TaggedError('AiTaskCreateFailed')<{
+  readonly message?: string
+  readonly details?: unknown
+  readonly hint?: string
+  readonly cause?: unknown
+}> {}
+
+export class AiTaskFailed extends Data.TaggedError('AiTaskFailed')<{
+  readonly message?: string
+  readonly taskId?: string
+  readonly status?: string
+  readonly details?: unknown
+  readonly hint?: string
+}> {}
+
+export class AiRecordNotFound extends Data.TaggedError('AiRecordNotFound')<{
+  readonly message?: string
+  readonly kind?: string
+  readonly ref?: string
+  readonly details?: unknown
+  readonly hint?: string
+}> {}
+
 // generic
 export class Generic extends Data.TaggedError('Generic')<{
   readonly message?: string
@@ -263,6 +287,9 @@ export type CliError =
   | ArgvParse
   | ChapterNotFound
   | SkillCorpusEmpty
+  | AiTaskCreateFailed
+  | AiTaskFailed
+  | AiRecordNotFound
   | Generic
 
 export type CliErrorTag = CliError['_tag']
@@ -300,6 +327,9 @@ export const tagToCode: Record<CliErrorTag, string> = {
   ArgvParse: 'argv.parse',
   ChapterNotFound: 'skill.chapter_not_found',
   SkillCorpusEmpty: 'skill.corpus_empty',
+  AiTaskCreateFailed: 'ai.task.create_failed',
+  AiTaskFailed: 'ai.task.failed',
+  AiRecordNotFound: 'ai.record.not_found',
   Generic: 'generic',
 }
 
@@ -339,7 +369,8 @@ export const exitCodeForTag = (tag: CliErrorTag): number => {
       return 6
     }
     case 'ResourceNotFound':
-    case 'ChapterNotFound': {
+    case 'ChapterNotFound':
+    case 'AiRecordNotFound': {
       return 7
     }
     case 'UpdatePmUnknown': {
@@ -405,6 +436,9 @@ const defaultMessages: Record<CliErrorTag, string> = {
   ArgvParse: 'failed to parse arguments',
   ChapterNotFound: 'skill chapter not found',
   SkillCorpusEmpty: 'skill corpus is empty',
+  AiTaskCreateFailed: 'failed to create AI task',
+  AiTaskFailed: 'AI task did not succeed',
+  AiRecordNotFound: 'AI record not found',
   Generic: 'mxs error',
 }
 

--- a/packages/cli/src/services/Ai.ts
+++ b/packages/cli/src/services/Ai.ts
@@ -1,12 +1,619 @@
 import { Context, Effect, Layer } from 'effect'
 
-// v2 placeholder — interface intentionally empty; Wave 2 / v2 commands will
-// extend this with translate / summarize / extract-tags methods.
-export interface AiService {}
+import {
+  AiRecordNotFound,
+  AiTaskCreateFailed,
+  AiTaskFailed,
+  type Generic,
+} from '../domain/errors'
+import { Api, type ApiError, type ApiService } from './Api'
+
+// ---------------------------------------------------------------------------
+// Public types
+// ---------------------------------------------------------------------------
+
+export type AiTaskType = 'summary' | 'translation' | 'insights'
+
+export type AiTaskStatus =
+  | 'pending'
+  | 'queued'
+  | 'running'
+  | 'completed'
+  | 'partial_failed'
+  | 'succeeded'
+  | 'failed'
+  | 'cancelled'
+
+export interface AiTaskCreateResult {
+  readonly taskId: string
+  readonly created: boolean
+  readonly type: AiTaskType
+  readonly refId: string
+  readonly targetLanguages?: ReadonlyArray<string>
+}
+
+export interface AiTaskFinalView {
+  readonly type: AiTaskType
+  readonly taskId: string
+  readonly status: AiTaskStatus
+  readonly refId?: string
+  readonly targetLanguages?: ReadonlyArray<string>
+  readonly totalTokens?: number
+  readonly totalCost?: number
+  readonly resultIds?: ReadonlyArray<string>
+  readonly error?: { readonly message: string }
+}
+
+export interface AiTaskCreateInput {
+  readonly refId: string
+  readonly targetLanguages?: ReadonlyArray<string>
+}
+
+export interface AiTaskTranslateInput {
+  readonly refId: string
+  readonly targetLanguages: ReadonlyArray<string>
+}
+
+export interface AiWaitOptions {
+  readonly type: AiTaskType
+  readonly pollMs?: number
+  /** Stderr progress emitter; receives a transition message per state change. */
+  readonly onProgress?: (message: string) => void
+}
+
+export interface AiListQuery {
+  readonly page?: number
+  readonly size?: number
+  readonly grouped?: boolean
+}
+
+export interface AiEntryListQuery {
+  readonly page?: number
+  readonly size?: number
+  readonly keyPath?: string
+  readonly lang?: string
+}
+
+export interface AiEntryGenerateInput {
+  readonly keyPaths?: ReadonlyArray<string>
+  readonly targetLangs?: ReadonlyArray<string>
+}
+
+export interface AiSummaryPatch {
+  readonly summary: string
+}
+
+export interface AiInsightsPatch {
+  readonly content: string
+}
+
+export interface AiTranslationPatch {
+  title?: string
+  text?: string
+  subtitle?: string | null
+  summary?: string
+  tags?: ReadonlyArray<string>
+  content?: string
+}
+
+export interface AiEntryPatch {
+  readonly translatedText: string
+}
+
+export interface AiByArticleOptions {
+  readonly lang?: string
+  readonly onlyDb?: boolean
+}
+
+export type AiServiceError =
+  | ApiError
+  | AiTaskCreateFailed
+  | AiTaskFailed
+  | AiRecordNotFound
+
+export interface AiService {
+  // -- generate ------------------------------------------------------------
+  readonly regenSummary: (
+    input: AiTaskCreateInput,
+  ) => Effect.Effect<AiTaskCreateResult, AiTaskCreateFailed | ApiError>
+  readonly translate: (
+    input: AiTaskTranslateInput,
+  ) => Effect.Effect<AiTaskCreateResult, AiTaskCreateFailed | ApiError>
+  readonly refreshInsights: (
+    input: Pick<AiTaskCreateInput, 'refId'>,
+  ) => Effect.Effect<AiTaskCreateResult, AiTaskCreateFailed | ApiError>
+  readonly waitForTask: (
+    taskId: string,
+    options: AiWaitOptions,
+  ) => Effect.Effect<AiTaskFinalView, AiTaskFailed | ApiError>
+
+  // -- summary read/manage -------------------------------------------------
+  readonly listSummaries: (q: AiListQuery) => Effect.Effect<unknown, ApiError>
+  readonly getSummary: (
+    id: string,
+  ) => Effect.Effect<unknown, AiRecordNotFound | ApiError>
+  readonly getSummariesByArticle: (
+    refId: string,
+    opts?: AiByArticleOptions,
+  ) => Effect.Effect<unknown, ApiError>
+  readonly updateSummary: (
+    id: string,
+    patch: AiSummaryPatch,
+  ) => Effect.Effect<unknown, ApiError>
+  readonly deleteSummary: (id: string) => Effect.Effect<void, ApiError>
+
+  // -- translation read/manage --------------------------------------------
+  readonly listTranslations: (
+    q: AiListQuery,
+  ) => Effect.Effect<unknown, ApiError>
+  readonly getTranslation: (
+    id: string,
+  ) => Effect.Effect<unknown, AiRecordNotFound | ApiError>
+  readonly getTranslationsByArticle: (
+    refId: string,
+    opts?: AiByArticleOptions,
+  ) => Effect.Effect<unknown, ApiError>
+  readonly getTranslationLanguages: (
+    refId: string,
+  ) => Effect.Effect<unknown, ApiError>
+  readonly updateTranslation: (
+    id: string,
+    patch: AiTranslationPatch,
+  ) => Effect.Effect<unknown, ApiError>
+  readonly deleteTranslation: (id: string) => Effect.Effect<void, ApiError>
+
+  // -- insights read/manage -----------------------------------------------
+  readonly listInsights: (q: AiListQuery) => Effect.Effect<unknown, ApiError>
+  readonly getInsights: (
+    id: string,
+  ) => Effect.Effect<unknown, AiRecordNotFound | ApiError>
+  readonly getInsightsByArticle: (
+    refId: string,
+    opts?: AiByArticleOptions,
+  ) => Effect.Effect<unknown, ApiError>
+  readonly updateInsights: (
+    id: string,
+    patch: AiInsightsPatch,
+  ) => Effect.Effect<unknown, ApiError>
+  readonly deleteInsights: (id: string) => Effect.Effect<void, ApiError>
+
+  // -- translation entries ------------------------------------------------
+  readonly listEntries: (
+    q: AiEntryListQuery,
+  ) => Effect.Effect<unknown, ApiError>
+  readonly generateEntries: (
+    input: AiEntryGenerateInput,
+  ) => Effect.Effect<unknown, ApiError>
+  readonly updateEntry: (
+    id: string,
+    patch: AiEntryPatch,
+  ) => Effect.Effect<unknown, ApiError>
+  readonly deleteEntry: (id: string) => Effect.Effect<void, ApiError>
+}
+
+// ---------------------------------------------------------------------------
+// Internal helpers
+// ---------------------------------------------------------------------------
+
+const unwrapData = (raw: unknown): unknown => {
+  if (raw && typeof raw === 'object' && !Array.isArray(raw)) {
+    const env = raw as { data?: unknown }
+    if ('data' in env) return env.data
+  }
+  return raw
+}
+
+const asRecord = (value: unknown): Record<string, unknown> =>
+  value && typeof value === 'object' && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : {}
+
+interface CreateTaskEnvelope {
+  taskId?: string
+  created?: boolean
+}
+
+const readCreateTask = (raw: unknown): CreateTaskEnvelope => {
+  const inner = asRecord(unwrapData(raw))
+  return {
+    taskId: typeof inner.taskId === 'string' ? inner.taskId : undefined,
+    created: typeof inner.created === 'boolean' ? inner.created : undefined,
+  }
+}
+
+interface TaskRecord {
+  status?: AiTaskStatus | string
+  totalCost?: number | string
+  totalTokens?: number | string
+  resultIds?: ReadonlyArray<string>
+  result?: { resultIds?: ReadonlyArray<string> }
+  payload?: { refId?: string; targetLanguages?: ReadonlyArray<string> }
+  error?: { message?: string } | string
+  errorMessage?: string
+}
+
+const readTaskRecord = (raw: unknown): TaskRecord => {
+  const inner = asRecord(unwrapData(raw))
+  const result = asRecord(inner.result)
+  const payload = asRecord(inner.payload)
+  const errField = inner.error
+  return {
+    status:
+      typeof inner.status === 'string'
+        ? (inner.status as AiTaskStatus)
+        : undefined,
+    totalCost:
+      typeof inner.totalCost === 'number' || typeof inner.totalCost === 'string'
+        ? (inner.totalCost as number | string)
+        : undefined,
+    totalTokens:
+      typeof inner.totalTokens === 'number' ||
+      typeof inner.totalTokens === 'string'
+        ? (inner.totalTokens as number | string)
+        : undefined,
+    resultIds: Array.isArray(inner.resultIds)
+      ? (inner.resultIds as ReadonlyArray<string>)
+      : Array.isArray(result.resultIds)
+        ? (result.resultIds as ReadonlyArray<string>)
+        : undefined,
+    payload: {
+      refId: typeof payload.refId === 'string' ? payload.refId : undefined,
+      targetLanguages: Array.isArray(payload.targetLanguages)
+        ? (payload.targetLanguages as ReadonlyArray<string>)
+        : undefined,
+    },
+    error:
+      typeof errField === 'string'
+        ? { message: errField }
+        : errField && typeof errField === 'object'
+          ? (errField as { message?: string })
+          : undefined,
+    errorMessage:
+      typeof inner.errorMessage === 'string' ? inner.errorMessage : undefined,
+  }
+}
+
+const toNumber = (v: number | string | undefined): number | undefined => {
+  if (typeof v === 'number' && Number.isFinite(v)) return v
+  if (typeof v === 'string' && v.trim() !== '') {
+    const n = Number(v)
+    if (Number.isFinite(n)) return n
+  }
+  return undefined
+}
+
+const TERMINAL: ReadonlySet<string> = new Set([
+  'completed',
+  'partial_failed',
+  'succeeded',
+  'failed',
+  'cancelled',
+])
+
+const DEFAULT_POLL_MS = 1000
+
+const resolvePollMs = (override?: number): number => {
+  const envRaw = process.env.MXS_AI_POLL_MS
+  if (override && override > 0) return override
+  if (envRaw) {
+    const n = Number(envRaw)
+    if (Number.isFinite(n) && n > 0) return n
+  }
+  return DEFAULT_POLL_MS
+}
+
+// ---------------------------------------------------------------------------
+// Factory
+// ---------------------------------------------------------------------------
+
+export const make = (api: ApiService): AiService => {
+  const createTask = (
+    type: AiTaskType,
+    path: string,
+    body: Record<string, unknown>,
+  ): Effect.Effect<AiTaskCreateResult, AiTaskCreateFailed | ApiError> =>
+    Effect.gen(function* () {
+      const raw = yield* api.request(path, { method: 'POST', body })
+      const env = readCreateTask(raw)
+      if (!env.taskId) {
+        return yield* Effect.fail(
+          new AiTaskCreateFailed({
+            message: 'server returned no taskId',
+            details: raw,
+          }),
+        )
+      }
+      return {
+        taskId: env.taskId,
+        created: env.created ?? true,
+        type,
+        refId: typeof body.refId === 'string' ? body.refId : '',
+        targetLanguages: Array.isArray(body.targetLanguages)
+          ? (body.targetLanguages as ReadonlyArray<string>)
+          : undefined,
+      }
+    })
+
+  const waitForTask = (
+    taskId: string,
+    options: AiWaitOptions,
+  ): Effect.Effect<AiTaskFinalView, AiTaskFailed | ApiError> =>
+    Effect.gen(function* () {
+      const pollMs = resolvePollMs(options.pollMs)
+      let lastStatus: string | undefined
+
+      const pollOnce = (): Effect.Effect<
+        { rec: TaskRecord; status: AiTaskStatus },
+        ApiError
+      > =>
+        api.request(`/tasks/${taskId}`).pipe(
+          Effect.flatMap((raw) => {
+            const rec = readTaskRecord(raw)
+            const status = (rec.status ?? 'pending') as AiTaskStatus
+            if (status !== lastStatus) {
+              lastStatus = status
+              options.onProgress?.(`[ai] task ${status}…`)
+            }
+            if (TERMINAL.has(status)) return Effect.succeed({ rec, status })
+            return Effect.sleep(`${pollMs} millis`).pipe(
+              Effect.flatMap(() => pollOnce()),
+            )
+          }),
+        )
+
+      const { rec, status } = yield* pollOnce()
+      const final: AiTaskFinalView = {
+        type: options.type,
+        taskId,
+        status,
+        refId: rec.payload?.refId,
+        targetLanguages: rec.payload?.targetLanguages,
+        totalTokens: toNumber(rec.totalTokens),
+        totalCost: toNumber(rec.totalCost),
+        resultIds: rec.resultIds,
+        error:
+          typeof rec.error === 'object'
+            ? rec.error.message
+              ? { message: rec.error.message }
+              : undefined
+            : rec.errorMessage
+              ? { message: rec.errorMessage }
+              : undefined,
+      }
+
+      if (status === 'failed' || status === 'cancelled') {
+        return yield* Effect.fail(
+          new AiTaskFailed({
+            taskId,
+            status,
+            message: final.error?.message ?? `AI task ${status} (id=${taskId})`,
+            details: final,
+          }),
+        )
+      }
+      if (status === 'partial_failed') {
+        return yield* Effect.fail(
+          new AiTaskFailed({
+            taskId,
+            status,
+            message: final.error?.message ?? `AI task ${status} (id=${taskId})`,
+            details: final,
+          }),
+        )
+      }
+      return final
+    })
+
+  const list =
+    <Q extends AiListQuery>(
+      base: string,
+      flatPath: string | null,
+      groupedPath: string,
+    ) =>
+    (q: Q): Effect.Effect<unknown, ApiError> =>
+      api.request(
+        q.grouped || flatPath === null
+          ? `${base}${groupedPath}`
+          : `${base}${flatPath}`,
+        {
+          query: {
+            page: q.page,
+            size: q.size,
+          },
+        },
+      )
+
+  const groupedItems = (
+    group: unknown,
+    itemKeys: ReadonlyArray<string>,
+  ): ReadonlyArray<unknown> => {
+    const record = asRecord(group)
+    for (const key of itemKeys) {
+      const value = record[key]
+      if (Array.isArray(value)) return value
+    }
+    return []
+  }
+
+  const matchById = (
+    base: string,
+    id: string,
+    itemKeys: ReadonlyArray<string>,
+  ): Effect.Effect<unknown, AiRecordNotFound | ApiError> =>
+    Effect.gen(function* () {
+      // Try grouped pagination; flatten and match by id. Capped scan to avoid
+      // unbounded pagination on enormous datasets.
+      const MAX_PAGES = 50
+      const SIZE = 50
+      for (let page = 1; page <= MAX_PAGES; page++) {
+        const raw = yield* api.request(`${base}/grouped`, {
+          query: { page, size: SIZE },
+        })
+        const data = unwrapData(raw)
+        const groups = Array.isArray(data) ? data : []
+        for (const group of groups) {
+          for (const item of groupedItems(group, itemKeys)) {
+            const r = asRecord(item)
+            if (typeof r.id === 'string' && r.id === id) return item
+          }
+        }
+        const pagination = asRecord(asRecord(asRecord(raw).meta).pagination)
+        const totalPages =
+          typeof pagination.totalPages === 'number'
+            ? pagination.totalPages
+            : groups.length < SIZE
+              ? page
+              : page + 1
+        if (page >= totalPages) break
+      }
+      return yield* Effect.fail(
+        new AiRecordNotFound({
+          message: `AI record not found: ${id}`,
+          ref: id,
+        }),
+      )
+    })
+
+  const summaryByArticle = (
+    refId: string,
+    opts?: AiByArticleOptions,
+  ): Effect.Effect<unknown, ApiError> =>
+    api.request(`/ai/summaries/article/${refId}`, {
+      query: {
+        lang: opts?.lang,
+        onlyDb: opts?.onlyDb,
+      },
+    })
+
+  const insightsByArticle = (
+    refId: string,
+    opts?: AiByArticleOptions,
+  ): Effect.Effect<unknown, ApiError> =>
+    api.request(`/ai/insights/article/${refId}`, {
+      query: {
+        lang: opts?.lang,
+        onlyDb: opts?.onlyDb,
+      },
+    })
+
+  const translationsByArticle = (
+    refId: string,
+    opts?: AiByArticleOptions,
+  ): Effect.Effect<unknown, ApiError> =>
+    opts?.lang
+      ? api.request(`/ai/translations/article/${refId}`, {
+          query: { lang: opts.lang },
+        })
+      : api.request(`/ai/translations/ref/${refId}`)
+
+  return {
+    // -- generate
+    regenSummary: (input) =>
+      createTask('summary', '/ai/summaries/task', {
+        refId: input.refId,
+        ...(input.targetLanguages?.length
+          ? { targetLanguages: [...input.targetLanguages] }
+          : {}),
+      }),
+
+    translate: (input) =>
+      createTask('translation', '/ai/translations/task', {
+        refId: input.refId,
+        targetLanguages: [...input.targetLanguages],
+      }),
+
+    refreshInsights: (input) =>
+      createTask('insights', '/ai/insights/task', {
+        refId: input.refId,
+      }),
+
+    waitForTask,
+
+    // -- summary
+    listSummaries: list('/ai/summaries', '/', '/grouped'),
+    getSummary: (id) => matchById('/ai/summaries', id, ['summaries']),
+    getSummariesByArticle: summaryByArticle,
+    updateSummary: (id, patch) =>
+      api.request(`/ai/summaries/${id}`, { method: 'PATCH', body: patch }),
+    deleteSummary: (id) =>
+      api
+        .request(`/ai/summaries/${id}`, { method: 'DELETE' })
+        .pipe(Effect.asVoid),
+
+    // -- translation
+    listTranslations: list('/ai/translations', null, '/grouped'),
+    getTranslation: (id) => matchById('/ai/translations', id, ['translations']),
+    getTranslationsByArticle: translationsByArticle,
+    getTranslationLanguages: (refId) =>
+      api.request(`/ai/translations/article/${refId}/languages`),
+    updateTranslation: (id, patch) =>
+      api.request(`/ai/translations/${id}`, { method: 'PATCH', body: patch }),
+    deleteTranslation: (id) =>
+      api
+        .request(`/ai/translations/${id}`, { method: 'DELETE' })
+        .pipe(Effect.asVoid),
+
+    // -- insights
+    listInsights: list('/ai/insights', '/', '/grouped'),
+    getInsights: (id) => matchById('/ai/insights', id, ['insights']),
+    getInsightsByArticle: insightsByArticle,
+    updateInsights: (id, patch) =>
+      api.request(`/ai/insights/${id}`, { method: 'PATCH', body: patch }),
+    deleteInsights: (id) =>
+      api
+        .request(`/ai/insights/${id}`, { method: 'DELETE' })
+        .pipe(Effect.asVoid),
+
+    // -- entries
+    listEntries: (q) =>
+      api.request('/ai/translations/entries', {
+        query: {
+          page: q.page,
+          size: q.size,
+          keyPath: q.keyPath,
+          lang: q.lang,
+        },
+      }),
+    generateEntries: (input) =>
+      api.request('/ai/translations/entries/generate', {
+        method: 'POST',
+        body: {
+          ...(input.keyPaths?.length ? { keyPaths: [...input.keyPaths] } : {}),
+          ...(input.targetLangs?.length
+            ? { targetLangs: [...input.targetLangs] }
+            : {}),
+        },
+      }),
+    updateEntry: (id, patch) =>
+      api.request(`/ai/translations/entries/${id}`, {
+        method: 'PATCH',
+        body: patch,
+      }),
+    deleteEntry: (id) =>
+      api
+        .request(`/ai/translations/entries/${id}`, { method: 'DELETE' })
+        .pipe(Effect.asVoid),
+  }
+}
+
+// Silence unused-import warning for the ambient `Generic` re-export (kept so
+// callers can narrow `AiServiceError` without re-importing `errors.ts`).
+export type _Generic = Generic
+
+// ---------------------------------------------------------------------------
+// Tag + Layer
+// ---------------------------------------------------------------------------
 
 export class Ai extends Context.Tag('Ai')<Ai, AiService>() {
-  static Default: Layer.Layer<Ai> = Layer.effect(
+  static Default: Layer.Layer<Ai, never, Api> = Layer.effect(
     Ai,
-    Effect.die('Ai service is a v2 placeholder'),
+    Effect.gen(function* () {
+      const api = yield* Api
+      return make(api)
+    }),
   )
 }
+
+/** Build an Ai layer from an explicit ApiService (tests). */
+export const layer = (api: ApiService): Layer.Layer<Ai> =>
+  Layer.succeed(Ai, make(api))

--- a/packages/cli/test/cli/ai/ai.test.ts
+++ b/packages/cli/test/cli/ai/ai.test.ts
@@ -1,0 +1,358 @@
+import { describe, expect, it } from '@effect/vitest'
+import { Effect, Layer } from 'effect'
+
+import {
+  AiRecordNotFound,
+  AiTaskCreateFailed,
+  AiTaskFailed,
+} from '../../../src/domain/errors'
+import { Ai } from '../../../src/services/Ai'
+import { Api } from '../../../src/services/Api'
+import { Auth, type AuthService } from '../../../src/services/Auth'
+import {
+  Config,
+  type ConfigService,
+  type ResolvedConfig,
+} from '../../../src/services/Config'
+import { testHttpLayer } from '../../helper/test-http'
+
+const resolved: ResolvedConfig = {
+  apiUrl: 'https://blog.example.com',
+  apiBase: 'https://blog.example.com/api/v2',
+  authBase: 'https://blog.example.com/api/v2/auth',
+  apiVersion: 2,
+  clientId: 'mxs-cli',
+  configPath: '/tmp/config.json',
+  credentialsPath: '/tmp/credentials.json',
+  profileName: 'dev',
+  isProduction: false,
+  profileExplicit: false,
+  urlOverridden: false,
+}
+
+const noopConfig: ConfigService = {
+  getConfigDir: Effect.succeed('/tmp'),
+  getProfilesDir: Effect.succeed('/tmp/profiles'),
+  getProfileDir: (n) => Effect.succeed(`/tmp/profiles/${n}`),
+  getProfileConfigPath: (n) => Effect.succeed(`/tmp/${n}/config.json`),
+  getProfileCredentialsPath: (n) => Effect.succeed(`/tmp/${n}/cred.json`),
+  getCurrentPath: Effect.succeed('/tmp/current'),
+  getLegacyConfigPath: Effect.succeed('/tmp/config.json'),
+  getLegacyCredentialsPath: Effect.succeed('/tmp/credentials.json'),
+  readProfileConfig: () => Effect.succeed({}),
+  writeProfileConfig: () => Effect.void,
+  updateProfileConfig: () => Effect.succeed({}),
+  readProfileCredentials: () => Effect.succeed(null),
+  writeProfileCredentials: () => Effect.void,
+  deleteProfileCredentials: () => Effect.void,
+  readLegacyConfig: Effect.succeed({}),
+  readLegacyConfigRaw: Effect.succeed(null),
+  readLegacyCredentialsRaw: Effect.succeed(null),
+  deleteLegacyConfig: Effect.void,
+  deleteLegacyCredentials: Effect.void,
+  readCurrent: Effect.succeed(resolved.profileName),
+  writeCurrent: () => Effect.void,
+  listProfileDirs: Effect.succeed([]),
+  profileExists: () => Effect.succeed(true),
+  removeProfileDir: () => Effect.void,
+  resolve: () => Effect.succeed(resolved),
+}
+
+const noopAuth: AuthService = {
+  probe: () => Effect.die('probe not used'),
+  requestDeviceCode: () => Effect.die('requestDeviceCode not used'),
+  pollDeviceToken: () => Effect.die('pollDeviceToken not used'),
+  refresh: () => Effect.succeed(null),
+  login: () => Effect.die('login not used'),
+  logout: () => Effect.void,
+  whoami: Effect.die('whoami not used'),
+  status: Effect.die('status not used'),
+  ensureFresh: (r) =>
+    Effect.succeed({
+      access_token: r.token ?? '',
+      expires_at: Date.now() + 3600_000,
+    }),
+  enrichUser: (_profile, _authBase, cred) => Effect.succeed(cred),
+}
+
+const buildLayer = (httpLayer: Layer.Layer<any>) => {
+  const apiLayer = Api.Default.pipe(
+    Layer.provide(Layer.succeed(Config, noopConfig)),
+    Layer.provide(Layer.succeed(Auth, noopAuth)),
+    Layer.provide(httpLayer),
+  )
+  return Ai.Default.pipe(Layer.provide(apiLayer))
+}
+
+const URL_TASK_POST = 'https://blog.example.com/api/v2/ai/summaries/task'
+const URL_TRANSLATE_POST = 'https://blog.example.com/api/v2/ai/translations/task'
+const URL_INSIGHTS_POST = 'https://blog.example.com/api/v2/ai/insights/task'
+const URL_SUMMARIES_GROUPED =
+  'https://blog.example.com/api/v2/ai/summaries/grouped?page=1&size=50'
+const URL_TRANSLATIONS_GROUPED =
+  'https://blog.example.com/api/v2/ai/translations/grouped?page=1&size=50'
+const URL_INSIGHTS_GROUPED =
+  'https://blog.example.com/api/v2/ai/insights/grouped?page=1&size=50'
+const taskUrl = (id: string) =>
+  `https://blog.example.com/api/v2/tasks/${id}`
+
+describe('Ai.regenSummary + waitForTask', () => {
+  it('polls until completed and returns a final view', async () => {
+    const TASK_ID = '01HXXX'
+    const REF_ID = '012345678901234567'
+    const { layer: http, recorder } = testHttpLayer({
+      [`POST ${URL_TASK_POST}`]: {
+        status: 200,
+        body: { data: { taskId: TASK_ID, created: true } },
+      },
+      [`GET ${taskUrl(TASK_ID)}`]: ({ call }) =>
+        call === 1
+          ? { status: 200, body: { data: { status: 'running' } } }
+          : {
+              status: 200,
+              body: {
+                data: {
+                  status: 'completed',
+                  totalCost: 4.2,
+                  totalTokens: 1234,
+                  resultIds: ['r1'],
+                  payload: { refId: REF_ID, targetLanguages: ['en'] },
+                },
+              },
+            },
+    })
+    process.env.MXS_AI_POLL_MS = '1'
+    const program = Effect.gen(function* () {
+      const ai = yield* Ai
+      const created = yield* ai.regenSummary({
+        refId: REF_ID,
+        targetLanguages: ['en'],
+      })
+      return yield* ai.waitForTask(created.taskId, { type: created.type })
+    })
+    const result = await Effect.runPromise(
+      program.pipe(Effect.provide(buildLayer(http))),
+    )
+    delete process.env.MXS_AI_POLL_MS
+    expect(result.status).toBe('completed')
+    expect(result.totalTokens).toBe(1234)
+    expect(result.totalCost).toBeCloseTo(4.2)
+    expect(result.resultIds).toEqual(['r1'])
+    const post = recorder.calls.find((c) => c.method === 'POST')
+    expect(post?.body).toEqual({ refId: REF_ID, targetLanguages: ['en'] })
+    const polls = recorder.calls.filter(
+      (c) => c.method === 'GET' && c.url === taskUrl(TASK_ID),
+    )
+    expect(polls.length).toBeGreaterThanOrEqual(2)
+  })
+
+  it('throws AiTaskFailed on terminal failure', async () => {
+    const TASK_ID = '01HFAIL'
+    const { layer: http } = testHttpLayer({
+      [`POST ${URL_TASK_POST}`]: {
+        status: 200,
+        body: { data: { taskId: TASK_ID, created: true } },
+      },
+      [`GET ${taskUrl(TASK_ID)}`]: {
+        status: 200,
+        body: {
+          data: { status: 'failed', error: { message: 'provider down' } },
+        },
+      },
+    })
+    process.env.MXS_AI_POLL_MS = '1'
+    const program = Effect.gen(function* () {
+      const ai = yield* Ai
+      const created = yield* ai.regenSummary({ refId: 'a' })
+      return yield* ai.waitForTask(created.taskId, { type: created.type })
+    })
+    const err = await Effect.runPromise(
+      program.pipe(
+        Effect.provide(buildLayer(http)),
+        Effect.flip,
+      ) as Effect.Effect<unknown, never, never>,
+    )
+    delete process.env.MXS_AI_POLL_MS
+    expect(err).toBeInstanceOf(AiTaskFailed)
+  })
+
+  it('throws AiTaskFailed on partial_failed', async () => {
+    const TASK_ID = '01HPARTIAL'
+    const { layer: http } = testHttpLayer({
+      [`POST ${URL_TASK_POST}`]: {
+        status: 200,
+        body: { data: { taskId: TASK_ID, created: true } },
+      },
+      [`GET ${taskUrl(TASK_ID)}`]: {
+        status: 200,
+        body: {
+          data: {
+            status: 'partial_failed',
+            error: { message: 'ja failed' },
+          },
+        },
+      },
+    })
+    process.env.MXS_AI_POLL_MS = '1'
+    const program = Effect.gen(function* () {
+      const ai = yield* Ai
+      const created = yield* ai.regenSummary({ refId: 'a' })
+      return yield* ai.waitForTask(created.taskId, { type: created.type })
+    })
+    const err = await Effect.runPromise(
+      program.pipe(
+        Effect.provide(buildLayer(http)),
+        Effect.flip,
+      ) as Effect.Effect<unknown, never, never>,
+    )
+    delete process.env.MXS_AI_POLL_MS
+    expect(err).toBeInstanceOf(AiTaskFailed)
+  })
+
+  it('flags missing taskId as AiTaskCreateFailed', async () => {
+    const { layer: http } = testHttpLayer({
+      [`POST ${URL_TASK_POST}`]: {
+        status: 200,
+        body: { data: { created: false } },
+      },
+    })
+    const program = Effect.gen(function* () {
+      const ai = yield* Ai
+      return yield* ai.regenSummary({ refId: 'a' })
+    })
+    const err = await Effect.runPromise(
+      program.pipe(
+        Effect.provide(buildLayer(http)),
+        Effect.flip,
+      ) as Effect.Effect<unknown, never, never>,
+    )
+    expect(err).toBeInstanceOf(AiTaskCreateFailed)
+  })
+})
+
+describe('Ai.translate', () => {
+  it('forwards targetLanguages verbatim', async () => {
+    const { layer: http, recorder } = testHttpLayer({
+      [`POST ${URL_TRANSLATE_POST}`]: {
+        status: 200,
+        body: { data: { taskId: '01HT', created: true } },
+      },
+    })
+    const program = Effect.gen(function* () {
+      const ai = yield* Ai
+      return yield* ai.translate({
+        refId: 'abc',
+        targetLanguages: ['en', 'ja'],
+      })
+    })
+    const r = await Effect.runPromise(
+      program.pipe(Effect.provide(buildLayer(http))),
+    )
+    expect(r.taskId).toBe('01HT')
+    expect(recorder.calls.at(-1)?.body).toEqual({
+      refId: 'abc',
+      targetLanguages: ['en', 'ja'],
+    })
+  })
+})
+
+describe('Ai.refreshInsights', () => {
+  it('sends only refId to the insights refresh endpoint', async () => {
+    const { layer: http, recorder } = testHttpLayer({
+      [`POST ${URL_INSIGHTS_POST}`]: {
+        status: 200,
+        body: { data: { taskId: '01HI', created: true } },
+      },
+    })
+    const program = Effect.gen(function* () {
+      const ai = yield* Ai
+      return yield* ai.refreshInsights({ refId: 'r' })
+    })
+    await Effect.runPromise(program.pipe(Effect.provide(buildLayer(http))))
+    expect(recorder.calls.at(-1)?.body).toEqual({ refId: 'r' })
+  })
+})
+
+describe('Ai grouped record lookup', () => {
+  it('finds records under family-specific grouped response keys', async () => {
+    const { layer: http } = testHttpLayer({
+      [`GET ${URL_SUMMARIES_GROUPED}`]: {
+        status: 200,
+        body: {
+          data: [
+            {
+              article: { id: 'post-1' },
+              summaries: [{ id: 'summary-1', summary: 'one' }],
+            },
+          ],
+          meta: { pagination: { totalPages: 1 } },
+        },
+      },
+      [`GET ${URL_TRANSLATIONS_GROUPED}`]: {
+        status: 200,
+        body: {
+          data: [
+            {
+              article: { id: 'post-1' },
+              translations: [{ id: 'translation-1', title: 'one' }],
+            },
+          ],
+          meta: { pagination: { totalPages: 1 } },
+        },
+      },
+      [`GET ${URL_INSIGHTS_GROUPED}`]: {
+        status: 200,
+        body: {
+          data: [
+            {
+              article: { id: 'post-1' },
+              insights: [{ id: 'insights-1', content: 'one' }],
+            },
+          ],
+          meta: { pagination: { totalPages: 1 } },
+        },
+      },
+    })
+    const program = Effect.gen(function* () {
+      const ai = yield* Ai
+      const summary = yield* ai.getSummary('summary-1')
+      const translation = yield* ai.getTranslation('translation-1')
+      const insights = yield* ai.getInsights('insights-1')
+      return { summary, translation, insights }
+    })
+    const result = await Effect.runPromise(
+      program.pipe(Effect.provide(buildLayer(http))),
+    )
+    expect(result.summary).toMatchObject({ id: 'summary-1' })
+    expect(result.translation).toMatchObject({ id: 'translation-1' })
+    expect(result.insights).toMatchObject({ id: 'insights-1' })
+  })
+
+  it('raises AiRecordNotFound after scanning grouped family keys', async () => {
+    const { layer: http } = testHttpLayer({
+      [`GET ${URL_SUMMARIES_GROUPED}`]: {
+        status: 200,
+        body: {
+          data: [
+            {
+              article: { id: 'post-1' },
+              summaries: [{ id: 'summary-1', summary: 'one' }],
+            },
+          ],
+          meta: { pagination: { totalPages: 1 } },
+        },
+      },
+    })
+    const program = Effect.gen(function* () {
+      const ai = yield* Ai
+      return yield* ai.getSummary('missing')
+    })
+    const err = await Effect.runPromise(
+      program.pipe(
+        Effect.provide(buildLayer(http)),
+        Effect.flip,
+      ) as Effect.Effect<unknown, never, never>,
+    )
+    expect(err).toBeInstanceOf(AiRecordNotFound)
+  })
+})


### PR DESCRIPTION
## Summary

- Adds the `mxs ai` command group: full management surface for AI artifacts (summary, translation, insights), plus the i18n translation-entries sub-tree.
- Generate verbs (`summary regen`, `translate run`, `insights refresh`) enqueue a task on the server, then poll `GET /tasks/:id` until terminal — with `--no-wait` for fire-and-forget, and `created: false` joining an in-flight deduplicated task.
- Read/manage verbs (`list`, `get`, `by-article`, `edit`, `delete`, plus `translate languages` and `translate entries {list,generate,edit,delete}`) cover every existing core endpoint. `edit` uses `$EDITOR` with a JSON envelope per resource. No core changes; no new server endpoints.

Spec: `docs/superpowers/specs/2026-06-17-mxs-ai-v2-design.md`.
Roadmap: replaces the v2 AI block with a shipped entry; only `mxs ai tokens` (usage aggregation) remains under v2.

## Test plan

- [x] `pnpm -C packages/cli typecheck` clean
- [x] `pnpm -C packages/cli exec eslint src/services/Ai.ts src/cli/ai src/domain/errors.ts src/cli/help/index.ts src/bin/mxs.ts` clean
- [x] `pnpm -C packages/cli exec vitest run test/cli/ai/ai.test.ts` (8 pass)
- [x] `mxs ai` group help renders correctly
- [x] `mxs ai summary regen --help` shows expected flags
- [ ] Smoke against a real dev instance: `mxs ai summary regen <slug> --to en` waits and prints a final task view
- [ ] `mxs ai translate run <slug> --to ja --no-wait` returns `pending` and exits 0
- [ ] `mxs ai summary edit <recordId>` round-trips through `$EDITOR`
