### PR TITLE
feat(admin): clarify article editor format switching

### DIFF
--- a/apps/admin/src/features/write/components/WriteRouteViewsContent.tsx
+++ b/apps/admin/src/features/write/components/WriteRouteViewsContent.tsx
@@ -11,6 +11,7 @@ import {
   Braces,
   Bug,
   Check,
+  CircleHelp,
   Clock,
   Copy,
   File as FileIcon,
@@ -367,7 +368,7 @@ function WritePage(props: { kind: WriteKind }) {
   const [preferredContentFormat, setPreferredContentFormat] =
     useLocalStorageState<ContentFormat>(
       PREFERRED_CONTENT_FORMAT_STORAGE_KEY,
-      'markdown',
+      'lexical',
     )
   const [state, setState] = useState<WriteFormState>(() => ({
     ...emptyState,
@@ -552,7 +553,10 @@ function WritePage(props: { kind: WriteKind }) {
     state.title.trim().length > 0 ||
     state.text.trim().length > 0 ||
     state.content.trim().length > 0
-  const canSwitchEditorType = !state.text.trim() && !state.content.trim()
+  const canSwitchEditorType =
+    state.contentFormat === 'lexical'
+      ? !hasLexicalContent(state.content)
+      : !state.text.trim()
 
   useEffect(() => {
     latestDraftFingerprintRef.current = draftFingerprint
@@ -1652,7 +1656,7 @@ function EditorMetaStrip(props: {
         : 'bg-neutral-300 dark:bg-neutral-600'
   const formatLabel =
     props.format === 'lexical'
-      ? t('write.format.toMarkdown')
+      ? t('write.format.toCodeMirror')
       : t('write.format.toLexical')
 
   return (
@@ -1671,14 +1675,34 @@ function EditorMetaStrip(props: {
         {props.canSwitchFormat ? (
           <button
             aria-label={formatLabel}
-            className="focus-visible:outline-hidden inline-flex size-7 items-center justify-center rounded-md text-neutral-400 transition-colors hover:bg-neutral-100 hover:text-neutral-700 focus-visible:ring-1 focus-visible:ring-neutral-400 dark:text-neutral-500 dark:hover:bg-neutral-900 dark:hover:text-neutral-200"
+            className="focus-visible:outline-hidden inline-flex h-7 items-center gap-1 rounded-md px-2 text-xs text-neutral-500 transition-colors hover:bg-neutral-100 hover:text-neutral-700 focus-visible:ring-1 focus-visible:ring-neutral-400 dark:text-neutral-400 dark:hover:bg-neutral-900 dark:hover:text-neutral-200"
             onClick={props.onToggleFormat}
             title={formatLabel}
             type="button"
           >
             <ArrowLeftRight aria-hidden="true" className="size-3.5" />
+            <span>{formatLabel}</span>
           </button>
-        ) : null}
+        ) : (
+          <Popover>
+            <Popover.Trigger
+              aria-label={t('write.format.switchUnavailable.title')}
+              className="focus-visible:outline-hidden inline-flex size-7 items-center justify-center rounded-md text-neutral-400 transition-colors hover:bg-neutral-100 hover:text-neutral-700 focus-visible:ring-1 focus-visible:ring-neutral-400 dark:text-neutral-500 dark:hover:bg-neutral-900 dark:hover:text-neutral-200"
+              title={t('write.format.switchUnavailable.title')}
+              type="button"
+            >
+              <CircleHelp aria-hidden="true" className="size-3.5" />
+            </Popover.Trigger>
+            <Popover.Content align="end" className="space-y-1.5 p-3" width="sm">
+              <div className="text-sm font-medium text-fg">
+                {t('write.format.switchUnavailable.title')}
+              </div>
+              <p className="text-xs leading-relaxed text-fg-muted">
+                {t('write.format.switchUnavailable.description')}
+              </p>
+            </Popover.Content>
+          </Popover>
+        )}
         {props.aiButtonVisible ? (
           <button
             aria-label={t('write.pill.aiGenerate')}
@@ -3185,7 +3209,9 @@ function fromDraft(
   const base = {
     ...previous,
     content: draft.content ?? '',
-    contentFormat: draft.contentFormat ?? 'markdown',
+    contentFormat:
+      draft.contentFormat ??
+      (draft.text || draft.content ? 'markdown' : previous.contentFormat),
     images: draft.images ?? previous.images,
     meta: isRecord(draft.meta) ? draft.meta : previous.meta,
     text: draft.text ?? '',
@@ -3676,6 +3702,26 @@ function parseSerializedEditorState(
   }
 
   return undefined
+}
+
+function hasLexicalContent(content: string) {
+  const state = parseSerializedEditorState(content)
+  if (!state) return false
+
+  return lexicalNodeHasContent(state.root)
+}
+
+function lexicalNodeHasContent(node: unknown): boolean {
+  if (!node || typeof node !== 'object') return false
+
+  const record = node as Record<string, unknown>
+  if (typeof record.text === 'string' && record.text.trim()) return true
+
+  if (Array.isArray(record.children)) {
+    return record.children.some(lexicalNodeHasContent)
+  }
+
+  return record.type !== 'root' && record.type !== 'paragraph'
 }
 
 async function saveExcalidrawSnapshot(snapshot: object, existingRef?: string) {

--- a/apps/admin/src/i18n/resources/en-US.ts
+++ b/apps/admin/src/i18n/resources/en-US.ts
@@ -2883,6 +2883,10 @@ export const enUS = {
   'write.field.publicAtPreset.week': 'In a week',
   'write.format.toLexical': 'Switch to Lexical',
   'write.format.toMarkdown': 'Switch to Markdown',
+  'write.format.toCodeMirror': 'Switch to CodeMirror',
+  'write.format.switchUnavailable.title': 'Editor switching is unavailable',
+  'write.format.switchUnavailable.description':
+    'CodeMirror edits Markdown source, while Lexical stores rich-text structure. Converting an article that already has content can lose formatting, special nodes, or source syntax, so switching is disabled. Choose the editor you need before writing in a new, empty article.',
   'write.header.backToList': 'Back to list',
   'write.header.editPage': 'Edit page',
   'write.header.newPage': 'New page',

--- a/apps/admin/src/i18n/resources/zh-CN.ts
+++ b/apps/admin/src/i18n/resources/zh-CN.ts
@@ -2752,6 +2752,10 @@ export const zhCN = {
   'write.field.publicAtPreset.week': '一周后',
   'write.format.toLexical': '切换到 Lexical',
   'write.format.toMarkdown': '切换到 Markdown',
+  'write.format.toCodeMirror': '切换到 CodeMirror',
+  'write.format.switchUnavailable.title': '暂时无法切换编辑器',
+  'write.format.switchUnavailable.description':
+    'CodeMirror 直接编辑 Markdown 源码，Lexical 则保存富文本结构。正文已有内容时，在两者之间转换可能丢失格式、特殊节点或原始写法，因此当前文章不支持切换。请在新建文章且正文为空时选择所需编辑器，再开始写作。',
   'write.header.backToList': '返回列表',
   'write.header.editPage': '修改页面',
   'write.header.newPage': '新建页面',


### PR DESCRIPTION
## Summary

- 将新建文章默认编辑器调整为 Lexical。
- 对真正为空的草稿保留用户上一次选择的编辑器格式。
- 仅当文章已包含语义化 Lexical 内容时，禁止在 Lexical 与 CodeMirror 间切换。
- 为切换按钮增加明确文案，并在格式锁定时提供详细说明，避免用户误以为功能失效。

## Why

当前编辑器格式之间不存在可靠的双向无损转换。若文章已有内容后继续切换，可能导致富文本节点、嵌套结构或格式信息丢失。

此 PR 保留现有保护策略，同时让默认行为和限制原因更明确。

Closes #2767

## Test plan

- [x] `pnpm -C apps/admin run typecheck`
- [x] `NODE_ENV=production pnpm exec vite build --mode production`