### PR TITLE
feat(content): add progressive Markdown to Lexical migration

### DIFF
--- a/apps/admin/src/api/content-migrations.ts
+++ b/apps/admin/src/api/content-migrations.ts
@@ -1,0 +1,103 @@
+import { postJson } from './http'
+
+export type MigrationMemberKind = 'draft' | 'source' | 'translation'
+
+export interface MigrationMemberPrecondition {
+  hash: string
+  id: string
+  kind: MigrationMemberKind
+  version?: number
+}
+
+export interface MarkdownMigrationIssue {
+  code: string
+  details?: Record<string, unknown>
+  feature: string
+  lang?: string
+  member: MigrationMemberKind
+  memberId: string
+  message: string
+  range: {
+    end: { column: number; line: number; offset: number }
+    start: { column: number; line: number; offset: number }
+  }
+  severity: 'blocking'
+}
+
+export interface SerializedMigrationEditorState {
+  root: {
+    children: unknown[]
+    [key: string]: unknown
+  }
+}
+
+type MigrationConversionResult =
+  | {
+      content: SerializedMigrationEditorState
+      converterVersion: string
+      profile: 'yohaku-v1'
+      sourceHash: string
+      status: 'convertible'
+      text: string
+    }
+  | {
+      converterVersion: string
+      issues: Omit<MarkdownMigrationIssue, 'lang' | 'member' | 'memberId'>[]
+      profile: 'yohaku-v1'
+      sourceHash: string
+      status: 'blocked'
+    }
+
+export interface MarkdownMigrationDryRunResponse {
+  converterVersion: string
+  issues: MarkdownMigrationIssue[]
+  preconditions: MigrationMemberPrecondition[]
+  profile: 'yohaku-v1'
+  source: MigrationConversionResult
+  sourceHash: string
+  status: 'blocked' | 'convertible'
+  translations: Array<{
+    alignment: {
+      alignedBlockCount: number
+      sourceBlockCount: number
+      translationBlockCount: number
+    }
+    id: string
+    lang: string
+    result: MigrationConversionResult | Record<string, unknown>
+  }>
+}
+
+export interface MarkdownToLexicalMigrationDescriptor {
+  converterVersion: string
+  preconditions: MigrationMemberPrecondition[]
+  profile: 'yohaku-v1'
+  sourceHash: string
+  sourceMarkdown: string
+}
+
+export function dryRunMarkdownToLexical(data: {
+  draftId?: string
+  profile: 'yohaku-v1'
+  refId: string
+  refType: 'note' | 'page' | 'post'
+  sourceText: string
+}) {
+  return postJson<MarkdownMigrationDryRunResponse, typeof data>(
+    '/content-migrations/markdown-to-lexical/dry-run',
+    data,
+  )
+}
+
+export function migrationDescriptorFromDryRun(
+  sourceMarkdown: string,
+  result: MarkdownMigrationDryRunResponse,
+): MarkdownToLexicalMigrationDescriptor {
+  return {
+    converterVersion: result.converterVersion,
+    preconditions: result.preconditions,
+    profile: result.profile,
+    sourceHash: result.sourceHash,
+    sourceMarkdown,
+  }
+}

--- a/apps/admin/src/api/notes.ts
+++ b/apps/admin/src/api/notes.ts
@@ -1,14 +1,11 @@
 import type { Image, PaginateResult } from '~/models/base'
 import type { NoteModel } from '~/models/note'
 
+import type { MarkdownToLexicalMigrationDescriptor } from './content-migrations'
 import { deleteJson, getJson, patchJson, postJson, putJson } from './http'
 
 export type NoteSortKey =
-  | 'createdAt'
-  | 'modifiedAt'
-  | 'mood'
-  | 'title'
-  | 'weather'
+  'createdAt' | 'modifiedAt' | 'mood' | 'title' | 'weather'
 export type SortOrder = 'asc' | 'desc'
 
 export interface GetNotesParams {
@@ -37,6 +34,7 @@ export interface CreateNoteData {
   images?: Image[]
   isPublished?: boolean
   location?: null | string
+  migration?: MarkdownToLexicalMigrationDescriptor
   meta?: Record<string, unknown>
   mood?: string
   password?: null | string

--- a/apps/admin/src/api/pages.ts
+++ b/apps/admin/src/api/pages.ts
@@ -1,6 +1,7 @@
 import type { Image, PaginateResult } from '~/models/base'
 import type { PageModel } from '~/models/page'
 
+import type { MarkdownToLexicalMigrationDescriptor } from './content-migrations'
 import { deleteJson, getJson, patchJson, postJson, putJson } from './http'
 
 export interface GetPagesParams {
@@ -14,6 +15,7 @@ export interface CreatePageData {
   draftId?: string
   images?: Image[]
   meta?: Record<string, unknown>
+  migration?: MarkdownToLexicalMigrationDescriptor
   order?: number
   slug: string
   subtitle?: string

--- a/apps/admin/src/api/posts.ts
+++ b/apps/admin/src/api/posts.ts
@@ -1,6 +1,7 @@
 import type { Image, PaginateResult } from '~/models/base'
 import type { PostModel } from '~/models/post'
 
+import type { MarkdownToLexicalMigrationDescriptor } from './content-migrations'
 import { deleteJson, getJson, patchJson, postJson, putJson } from './http'
 
 export type PostSortKey = 'createdAt' | 'modifiedAt' | 'pinAt'
@@ -29,6 +30,7 @@ export interface CreatePostData {
   images?: Image[]
   isPremium?: boolean
   isPublished?: boolean
+  migration?: MarkdownToLexicalMigrationDescriptor
   meta?: Record<string, unknown>
   pin?: null | string
   pinOrder?: null | number

--- a/apps/admin/src/features/write/components/WriteRouteViewsContent.tsx
+++ b/apps/admin/src/features/write/components/WriteRouteViewsContent.tsx
@@ -1,17 +1,21 @@
 import { projectAgentDiffNodesToFactualState } from '@haklex/rich-ext-ai-agent/static'
-import { createMxLitexmlRegistry, mxLexicalToMarkdown } from '@mx-space/editor'
+import {
+  analyzeMxMarkdown,
+  createMxLitexmlRegistry,
+  mxLexicalToMarkdown,
+} from '@mx-space/editor'
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
 import { load } from 'js-yaml'
 import type { SerializedEditorState } from 'lexical'
 import type { LucideIcon } from 'lucide-react'
 import {
   ArrowLeftRight,
+  BadgeAlert,
   BookOpen,
   Bot,
   Braces,
   Bug,
   Check,
-  CircleHelp,
   Clock,
   Copy,
   File as FileIcon,
@@ -22,6 +26,7 @@ import {
   Loader2,
   MapPin,
   Pencil,
+  RefreshCw,
   Search,
   Send,
   SlidersHorizontal,
@@ -41,6 +46,13 @@ import { toast } from 'sonner'
 
 import { AiQueryType, writerGenerate } from '~/api/ai'
 import { getCategories, getTags } from '~/api/categories'
+import {
+  dryRunMarkdownToLexical,
+  type MarkdownMigrationDryRunResponse,
+  type MarkdownMigrationIssue,
+  type MarkdownToLexicalMigrationDescriptor,
+  migrationDescriptorFromDryRun,
+} from '~/api/content-migrations'
 import type { CreateDraftData } from '~/api/drafts'
 import {
   createDraft,
@@ -125,6 +137,7 @@ import { TextArea, TextInput } from '~/ui/primitives/text-field'
 import { cn } from '~/utils/cn'
 import { getDayOfYear } from '~/utils/time'
 import { CodeMirrorEditor, ImageDropZone } from '~/vendor/codemirror'
+import { getEditorView } from '~/vendor/codemirror/editor-store'
 import type {
   RichEditorWithAgentProps,
   RichEditorWithAgentRef,
@@ -184,6 +197,22 @@ interface DraftSaveVariables {
 interface ActiveDraftConflict {
   conflicts: DraftMergeConflict[]
   remote: DraftModel
+}
+
+type FormatActionState =
+  | { type: 'empty-switch' }
+  | { type: 'migration-available' }
+  | { type: 'migration-checking' }
+  | { type: 'migration-blocked'; issueCount: number }
+  | { type: 'migration-staged' }
+  | { type: 'migration-committing' }
+  | { type: 'lexical' }
+
+interface MarkdownMigrationSession {
+  dryRun?: MarkdownMigrationDryRunResponse
+  issues: MarkdownMigrationIssue[]
+  sourceMarkdown: string
+  staged: boolean
 }
 
 const emptyState: WriteFormState = {
@@ -413,6 +442,7 @@ function WritePage(props: { kind: WriteKind }) {
   const previewSnapshotRef = useRef<{
     state: WriteFormState
     draftId: string
+    markdownMigration: MarkdownMigrationSession | null
   } | null>(null)
   const appliedRouteDraftIdRef = useRef<string | null>(null)
   const formSeededKeyRef = useRef<string | null>(null)
@@ -425,6 +455,11 @@ function WritePage(props: { kind: WriteKind }) {
   const [draftConflict, setDraftConflict] =
     useState<ActiveDraftConflict | null>(null)
   const [draftConflictResolving, setDraftConflictResolving] = useState(false)
+  const [markdownMigration, setMarkdownMigration] =
+    useState<MarkdownMigrationSession | null>(null)
+  const [migrationDiagnosticsOpen, setMigrationDiagnosticsOpen] =
+    useState(false)
+  const reconstructedMigrationKeyRef = useRef<string | null>(null)
   const draftRefType = draftRefTypeByKind[props.kind]
 
   useCollectionListQuery(categoriesCollection, {
@@ -577,11 +612,6 @@ function WritePage(props: { kind: WriteKind }) {
     state.title.trim().length > 0 ||
     state.text.trim().length > 0 ||
     state.content.trim().length > 0
-  const canSwitchEditorType =
-    state.contentFormat === 'lexical'
-      ? !hasLexicalContent(state.content)
-      : !state.text.trim()
-
   useEffect(() => {
     latestDraftDataRef.current = currentDraftData
     latestDraftFingerprintRef.current = draftFingerprint
@@ -638,6 +668,9 @@ function WritePage(props: { kind: WriteKind }) {
     if (formSeededKeyRef.current === seedKey) return
     formSeededKeyRef.current = seedKey
 
+    setMarkdownMigration(null)
+    setMigrationDiagnosticsOpen(false)
+    reconstructedMigrationKeyRef.current = null
     setState(fromModel(props.kind, detailModel))
   }, [
     detailModel,
@@ -679,6 +712,8 @@ function WritePage(props: { kind: WriteKind }) {
     draftDirtyRef.current = false
     setLastSavedFingerprint(fingerprint)
     setDraftId(draft.id)
+    setMarkdownMigration(null)
+    reconstructedMigrationKeyRef.current = null
     setState(nextState)
 
     if (draft.refId && !id) {
@@ -698,11 +733,125 @@ function WritePage(props: { kind: WriteKind }) {
     state,
   ])
 
+  const migrationCheckMutation = useMutation<
+    MarkdownMigrationDryRunResponse,
+    unknown,
+    { preserveLexical?: boolean; sourceMarkdown: string }
+  >({
+    mutationFn: ({ sourceMarkdown }) =>
+      dryRunMarkdownToLexical({
+        draftId: draftId || undefined,
+        profile: 'yohaku-v1',
+        refId: id,
+        refType: draftRefType,
+        sourceText: sourceMarkdown,
+      }),
+    onError: (error: unknown) =>
+      toast.error(
+        getErrorMessage(error, t('write.migration.toast.checkFailed')),
+      ),
+    onSuccess: (result, variables) => {
+      const convertible = result.status === 'convertible'
+      setMarkdownMigration({
+        dryRun: result,
+        issues: result.issues,
+        sourceMarkdown: variables.sourceMarkdown,
+        staged: convertible || Boolean(variables.preserveLexical),
+      })
+
+      if (
+        result.status !== 'convertible' ||
+        result.source.status !== 'convertible'
+      ) {
+        setMigrationDiagnosticsOpen(true)
+        return
+      }
+      if (variables.preserveLexical) return
+
+      const source = result.source
+      draftDirtyRef.current = true
+      setPreferredContentFormat('lexical')
+      setState((previous) => ({
+        ...previous,
+        content: JSON.stringify(source.content),
+        contentFormat: 'lexical',
+        text: source.text,
+      }))
+      toast.success(t('write.migration.toast.staged'))
+    },
+  })
+
+  useEffect(() => {
+    if (
+      !isEditing ||
+      publishedContent?.contentFormat !== 'markdown' ||
+      state.contentFormat !== 'lexical' ||
+      markdownMigration ||
+      migrationCheckMutation.isPending
+    ) {
+      return
+    }
+
+    const reconstructionKey = `${props.kind}:${id}:${draftId || routeDraftId}`
+    if (reconstructedMigrationKeyRef.current === reconstructionKey) return
+    reconstructedMigrationKeyRef.current = reconstructionKey
+    migrationCheckMutation.mutate({
+      preserveLexical: true,
+      sourceMarkdown: publishedContent.text,
+    })
+  }, [
+    draftId,
+    id,
+    isEditing,
+    markdownMigration,
+    migrationCheckMutation,
+    props.kind,
+    publishedContent,
+    routeDraftId,
+    state.contentFormat,
+  ])
+
   const saveMutation = useMutation<WriteModel>({
-    mutationFn: () => saveWrite(props.kind, id, state, draftId || undefined),
+    mutationFn: async () => {
+      let migration: MarkdownToLexicalMigrationDescriptor | undefined
+      const requiresMigration =
+        isEditing &&
+        publishedContent?.contentFormat === 'markdown' &&
+        state.contentFormat === 'lexical'
+
+      if (requiresMigration) {
+        const sourceMarkdown =
+          markdownMigration?.sourceMarkdown ?? publishedContent.text
+        const dryRun = await dryRunMarkdownToLexical({
+          draftId: draftId || undefined,
+          profile: 'yohaku-v1',
+          refId: id,
+          refType: draftRefType,
+          sourceText: sourceMarkdown,
+        })
+        setMarkdownMigration({
+          dryRun,
+          issues: dryRun.issues,
+          sourceMarkdown,
+          staged: true,
+        })
+        if (
+          dryRun.status !== 'convertible' ||
+          dryRun.source.status !== 'convertible'
+        ) {
+          setMigrationDiagnosticsOpen(true)
+          throw new Error(t('write.migration.toast.blocked'))
+        }
+        migration = migrationDescriptorFromDryRun(sourceMarkdown, dryRun)
+      }
+
+      return saveWrite(props.kind, id, state, draftId || undefined, migration)
+    },
     onError: (error: unknown) =>
       toast.error(getErrorMessage(error, t('write.toast.saveFailed'))),
     onSuccess: async (result) => {
+      setMarkdownMigration(null)
+      setMigrationDiagnosticsOpen(false)
       draftDirtyRef.current = false
       lastSavedDraftFingerprintRef.current = latestDraftFingerprintRef.current
       setLastSavedFingerprint(latestDraftFingerprintRef.current)
@@ -938,6 +1087,165 @@ function WritePage(props: { kind: WriteKind }) {
     }
   }
 
+  useEffect(() => {
+    if (
+      state.contentFormat === 'markdown' &&
+      markdownMigration &&
+      !markdownMigration.staged &&
+      markdownMigration.sourceMarkdown !== state.text
+    ) {
+      setMarkdownMigration(null)
+    }
+  }, [markdownMigration, state.contentFormat, state.text])
+
+  const stageLocalMarkdownMigration = (sourceMarkdown: string) => {
+    const result = analyzeMxMarkdown(sourceMarkdown, {
+      profile: 'yohaku-v1',
+    })
+    if (result.status === 'blocked') {
+      const issues: MarkdownMigrationIssue[] = result.issues.map((issue) => ({
+        ...issue,
+        member: 'source',
+        memberId: 'new',
+      }))
+      setMarkdownMigration({
+        issues,
+        sourceMarkdown,
+        staged: false,
+      })
+      setMigrationDiagnosticsOpen(true)
+      return
+    }
+
+    draftDirtyRef.current = true
+    setPreferredContentFormat('lexical')
+    setMarkdownMigration({
+      issues: [],
+      sourceMarkdown,
+      staged: true,
+    })
+    setState((previous) => ({
+      ...previous,
+      content: JSON.stringify(result.content),
+      contentFormat: 'lexical',
+      text: result.text,
+    }))
+    toast.success(t('write.migration.toast.staged'))
+  }
+
+  const formatActionState: FormatActionState = (() => {
+    if (migrationCheckMutation.isPending) {
+      return { type: 'migration-checking' }
+    }
+    if (
+      saveMutation.isPending &&
+      state.contentFormat === 'lexical' &&
+      publishedContent?.contentFormat === 'markdown'
+    ) {
+      return { type: 'migration-committing' }
+    }
+    if (state.contentFormat === 'markdown') {
+      if (!state.text.trim()) return { type: 'empty-switch' }
+      if (
+        markdownMigration &&
+        !markdownMigration.staged &&
+        markdownMigration.issues.length > 0
+      ) {
+        return {
+          type: 'migration-blocked',
+          issueCount: markdownMigration.issues.length,
+        }
+      }
+      return { type: 'migration-available' }
+    }
+    if (isEditing && publishedContent?.contentFormat === 'markdown') {
+      if (markdownMigration?.issues.length) {
+        return {
+          type: 'migration-blocked',
+          issueCount: markdownMigration.issues.length,
+        }
+      }
+      return { type: 'migration-staged' }
+    }
+    if (!isEditing && !hasLexicalContent(state.content)) {
+      return { type: 'empty-switch' }
+    }
+    return { type: 'lexical' }
+  })()
+
+  const runMigrationCheck = (preserveLexical = false) => {
+    const sourceMarkdown =
+      preserveLexical && markdownMigration
+        ? markdownMigration.sourceMarkdown
+        : state.text
+    if (!isEditing) {
+      stageLocalMarkdownMigration(sourceMarkdown)
+      return
+    }
+    migrationCheckMutation.mutate({ preserveLexical, sourceMarkdown })
+  }
+
+  const handleFormatAction = () => {
+    switch (formatActionState.type) {
+      case 'empty-switch': {
+        if (
+          isEditing &&
+          publishedContent?.contentFormat === 'markdown' &&
+          state.contentFormat === 'markdown'
+        ) {
+          runMigrationCheck()
+          return
+        }
+        setMarkdownMigration(null)
+        updateContentFormat(
+          state.contentFormat === 'lexical' ? 'markdown' : 'lexical',
+        )
+        return
+      }
+      case 'migration-available': {
+        runMigrationCheck()
+        return
+      }
+      case 'migration-blocked':
+      case 'migration-staged': {
+        setMigrationDiagnosticsOpen(true)
+        return
+      }
+      case 'lexical':
+      case 'migration-checking':
+      case 'migration-committing': {
+        return
+      }
+    }
+  }
+
+  const restoreOriginalMarkdown = () => {
+    if (!markdownMigration?.staged) return
+    draftDirtyRef.current = true
+    setPreferredContentFormat('markdown')
+    setState((previous) => ({
+      ...previous,
+      content: '',
+      contentFormat: 'markdown',
+      isPremium: false,
+      text: markdownMigration.sourceMarkdown,
+    }))
+    setMarkdownMigration(null)
+    setMigrationDiagnosticsOpen(false)
+  }
+
+  const locateMigrationIssue = (issue: MarkdownMigrationIssue) => {
+    if (issue.member !== 'source' || state.contentFormat !== 'markdown') return
+    setMigrationDiagnosticsOpen(false)
+    window.requestAnimationFrame(() => {
+      const view = getEditorView()
+      if (!view) return
+      const anchor = Math.min(issue.range.start.offset, view.state.doc.length)
+      view.dispatch({ selection: { anchor } })
+      view.focus()
+    })
+  }
+
   const getAgentMetaFields = () => getWriteAgentMetaFields(props.kind, state)
 
   const applyAgentMetaUpdates = (updates: Record<string, unknown>) => {
@@ -961,6 +1269,8 @@ function WritePage(props: { kind: WriteKind }) {
     setLastSavedFingerprint(fingerprint)
     setDraftConflict(null)
     setDraftId(draft.id)
+    setMarkdownMigration(null)
+    reconstructedMigrationKeyRef.current = null
     setState(nextState)
     const nextParams = new URLSearchParams(searchParams)
     nextParams.set('draftId', draft.id)
@@ -971,9 +1281,11 @@ function WritePage(props: { kind: WriteKind }) {
 
   const enterDraftPreview = (draft: DraftModel) => {
     if (!previewingDraft) {
-      previewSnapshotRef.current = { state, draftId }
+      previewSnapshotRef.current = { state, draftId, markdownMigration }
     }
     setPreviewingDraft(draft)
+    setMarkdownMigration(null)
+    reconstructedMigrationKeyRef.current = null
     setState((previous) => fromDraft(props.kind, draft, previous))
     setDraftId(draft.id)
     const nextParams = new URLSearchParams(searchParams)
@@ -1006,6 +1318,7 @@ function WritePage(props: { kind: WriteKind }) {
     if (snap) {
       setState(snap.state)
       setDraftId(snap.draftId)
+      setMarkdownMigration(snap.markdownMigration)
       const nextParams = new URLSearchParams(searchParams)
       if (snap.draftId) nextParams.set('draftId', snap.draftId)
       else nextParams.delete('draftId')
@@ -1045,6 +1358,8 @@ function WritePage(props: { kind: WriteKind }) {
     draftDirtyRef.current = false
     setLastSavedFingerprint(fingerprint)
     setDraftId(remote.id)
+    setMarkdownMigration(null)
+    reconstructedMigrationKeyRef.current = null
     setState(nextState)
     setDraftConflict(null)
     toast.success(t('write.toast.draftRemoteApplied'))
@@ -1359,16 +1674,10 @@ function WritePage(props: { kind: WriteKind }) {
                   <EditorMetaStrip
                     aiButtonPending={writerGenerateMutation.isPending}
                     aiButtonVisible={aiButtonVisible}
-                    canSwitchFormat={canSwitchEditorType}
+                    formatAction={formatActionState}
                     format={state.contentFormat}
                     onAiGenerate={generateTitleOrSlug}
-                    onToggleFormat={() =>
-                      updateContentFormat(
-                        state.contentFormat === 'lexical'
-                          ? 'markdown'
-                          : 'lexical',
-                      )
-                    }
+                    onFormatAction={handleFormatAction}
                     status={metaStatus.status}
                     statusText={metaStatus.text}
                   />
@@ -1529,7 +1838,151 @@ function WritePage(props: { kind: WriteKind }) {
           open={pageLexicalDebugOpen}
         />
       ) : null}
+      <MarkdownMigrationDialog
+        checking={migrationCheckMutation.isPending}
+        issues={markdownMigration?.issues ?? []}
+        onClose={() => setMigrationDiagnosticsOpen(false)}
+        onIssueClick={locateMigrationIssue}
+        onRecheck={() => {
+          if (state.contentFormat === 'lexical' && markdownMigration) {
+            migrationCheckMutation.mutate({
+              preserveLexical: true,
+              sourceMarkdown: markdownMigration.sourceMarkdown,
+            })
+            return
+          }
+          setMarkdownMigration(null)
+          runMigrationCheck()
+        }}
+        onRestore={
+          markdownMigration?.staged ? restoreOriginalMarkdown : undefined
+        }
+        open={migrationDiagnosticsOpen}
+        staged={Boolean(markdownMigration?.staged)}
+      />
     </form>
+  )
+}
+
+function MarkdownMigrationDialog(props: {
+  checking: boolean
+  issues: MarkdownMigrationIssue[]
+  onClose: () => void
+  onIssueClick: (issue: MarkdownMigrationIssue) => void
+  onRecheck: () => void
+  onRestore?: () => void
+  open: boolean
+  staged: boolean
+}) {
+  const { t } = useI18n()
+  const groups = useMemo(() => {
+    const grouped = new Map<string, MarkdownMigrationIssue[]>()
+    for (const issue of props.issues) {
+      const key =
+        issue.member === 'translation'
+          ? `translation:${issue.lang ?? issue.memberId}`
+          : issue.member
+      grouped.set(key, [...(grouped.get(key) ?? []), issue])
+    }
+    return [...grouped.entries()]
+  }, [props.issues])
+
+  return (
+    <Modal
+      className="max-h-[min(80vh,44rem)] w-[min(92vw,42rem)]"
+      onClose={props.onClose}
+      open={props.open}
+    >
+      <ModalHeader
+        icon={props.issues.length > 0 ? BadgeAlert : ArrowLeftRight}
+        subtitle={
+          props.staged ? t('write.migration.dialog.stagedSubtitle') : undefined
+        }
+        title={t('write.migration.dialog.title')}
+      />
+      <Scroll className="min-h-0 flex-1">
+        <div className="space-y-4 p-4">
+          {props.issues.length === 0 ? (
+            <div className="rounded-md border border-emerald-200 bg-emerald-50 p-3 text-sm text-emerald-800 dark:border-emerald-900 dark:bg-emerald-950/30 dark:text-emerald-300">
+              {t('write.migration.dialog.ready')}
+            </div>
+          ) : (
+            groups.map(([group, issues]) => (
+              <section className="space-y-2" key={group}>
+                <h3 className="text-xs font-semibold uppercase tracking-wide text-fg-muted">
+                  {group.startsWith('translation:')
+                    ? t('write.migration.dialog.translationGroup', {
+                        lang: group.slice('translation:'.length),
+                      })
+                    : group === 'draft'
+                      ? t('write.migration.dialog.draftGroup')
+                      : t('write.migration.dialog.sourceGroup')}
+                </h3>
+                <div className="divide-y divide-border overflow-hidden rounded-md border border-border">
+                  {issues.map((issue, index) => {
+                    const canLocate = issue.member === 'source' && !props.staged
+                    return (
+                      <button
+                        className={cn(
+                          'block w-full bg-surface-card p-3 text-left',
+                          canLocate &&
+                            'transition-colors hover:bg-surface-inset',
+                        )}
+                        disabled={!canLocate}
+                        key={`${issue.code}:${issue.range.start.offset}:${index}`}
+                        onClick={() => props.onIssueClick(issue)}
+                        type="button"
+                      >
+                        <div className="flex items-start justify-between gap-3">
+                          <div className="min-w-0">
+                            <div className="text-sm font-medium text-fg">
+                              {issue.feature}
+                            </div>
+                            <p className="mt-1 text-xs leading-relaxed text-fg-muted">
+                              {issue.message}
+                            </p>
+                          </div>
+                          <code className="shrink-0 text-[11px] text-fg-subtle">
+                            {t('write.migration.dialog.line', {
+                              line: issue.range.start.line,
+                            })}
+                          </code>
+                        </div>
+                        <div className="mt-2 text-[11px] text-fg-subtle">
+                          {issue.code}
+                        </div>
+                      </button>
+                    )
+                  })}
+                </div>
+              </section>
+            ))
+          )}
+        </div>
+      </Scroll>
+      <ModalFooter className="justify-between">
+        <div>
+          {props.onRestore ? (
+            <Button onClick={props.onRestore} type="button" variant="ghost">
+              {t('write.migration.action.restore')}
+            </Button>
+          ) : null}
+        </div>
+        <Button
+          disabled={props.checking}
+          onClick={props.onRecheck}
+          type="button"
+          variant="secondary"
+        >
+          {props.checking ? (
+            <Loader2 aria-hidden="true" className="size-4 animate-spin" />
+          ) : (
+            <RefreshCw aria-hidden="true" className="size-4" />
+          )}
+          {t('write.migration.action.recheck')}
+        </Button>
+      </ModalFooter>
+    </Modal>
   )
 }
 
@@ -1881,10 +2334,10 @@ function formatRelativeTime(value: string | null | undefined) {
 function EditorMetaStrip(props: {
   aiButtonPending: boolean
   aiButtonVisible: boolean
-  canSwitchFormat: boolean
   format: ContentFormat
+  formatAction: FormatActionState
   onAiGenerate: () => void
-  onToggleFormat: () => void
+  onFormatAction: () => void
   status: MetaStatus
   statusText: string
 }) {
@@ -1897,10 +2350,47 @@ function EditorMetaStrip(props: {
         : props.status === 'saved' || props.status === 'published'
           ? 'bg-emerald-500'
           : 'bg-neutral-300 dark:bg-neutral-600'
-  const formatLabel =
-    props.format === 'lexical'
-      ? t('write.format.toCodeMirror')
-      : t('write.format.toLexical')
+  const formatLabel = (() => {
+    switch (props.formatAction.type) {
+      case 'empty-switch': {
+        return props.format === 'lexical'
+          ? t('write.format.toCodeMirror')
+          : t('write.format.toLexical')
+      }
+      case 'migration-available': {
+        return t('write.migration.action.convert')
+      }
+      case 'migration-checking': {
+        return t('write.migration.action.checking')
+      }
+      case 'migration-blocked': {
+        return t('write.migration.action.blocked', {
+          count: props.formatAction.issueCount,
+        })
+      }
+      case 'migration-staged': {
+        return t('write.migration.action.staged')
+      }
+      case 'migration-committing': {
+        return t('write.migration.action.committing')
+      }
+      case 'lexical': {
+        return t('write.migration.action.lexical')
+      }
+    }
+  })()
+  const migrationHighlighted = [
+    'migration-available',
+    'migration-blocked',
+    'migration-checking',
+    'migration-committing',
+    'migration-staged',
+  ].includes(props.formatAction.type)
+  const formatActionDisabled = [
+    'lexical',
+    'migration-checking',
+    'migration-committing',
+  ].includes(props.formatAction.type)
 
   return (
     <div className="group mb-3 flex min-h-7 items-center justify-between opacity-60 transition-opacity duration-200 hover:opacity-100">
@@ -1915,37 +2405,31 @@ function EditorMetaStrip(props: {
         <span className="truncate">{props.statusText}</span>
       </div>
       <div className="flex shrink-0 items-center gap-0.5">
-        {props.canSwitchFormat ? (
-          <button
-            aria-label={formatLabel}
-            className="focus-visible:outline-hidden inline-flex h-7 items-center gap-1 rounded-md px-2 text-xs text-neutral-500 transition-colors hover:bg-neutral-100 hover:text-neutral-700 focus-visible:ring-1 focus-visible:ring-neutral-400 dark:text-neutral-400 dark:hover:bg-neutral-900 dark:hover:text-neutral-200"
-            onClick={props.onToggleFormat}
-            title={formatLabel}
-            type="button"
-          >
+        <button
+          aria-label={formatLabel}
+          className={cn(
+            'focus-visible:outline-hidden inline-flex h-7 items-center gap-1 rounded-md border px-2 text-xs transition-colors focus-visible:ring-1 disabled:opacity-70',
+            migrationHighlighted
+              ? 'border-amber-300 bg-amber-50 text-amber-800 hover:bg-amber-100 focus-visible:ring-amber-400 dark:border-amber-800 dark:bg-amber-950/40 dark:text-amber-300 dark:hover:bg-amber-950/70'
+              : 'border-transparent text-neutral-500 hover:bg-neutral-100 hover:text-neutral-700 focus-visible:ring-neutral-400 dark:text-neutral-400 dark:hover:bg-neutral-900 dark:hover:text-neutral-200',
+            props.formatAction.type === 'migration-blocked' &&
+              'border-red-300 bg-red-50 text-red-700 hover:bg-red-100 dark:border-red-900 dark:bg-red-950/40 dark:text-red-300 dark:hover:bg-red-950/70',
+          )}
+          disabled={formatActionDisabled}
+          onClick={props.onFormatAction}
+          title={formatLabel}
+          type="button"
+        >
+          {props.formatAction.type === 'migration-checking' ||
+          props.formatAction.type === 'migration-committing' ? (
+            <Loader2 aria-hidden="true" className="size-3.5 animate-spin" />
+          ) : props.formatAction.type === 'migration-blocked' ? (
+            <BadgeAlert aria-hidden="true" className="size-3.5" />
+          ) : (
             <ArrowLeftRight aria-hidden="true" className="size-3.5" />
-            <span>{formatLabel}</span>
-          </button>
-        ) : (
-          <Popover>
-            <Popover.Trigger
-              aria-label={t('write.format.switchUnavailable.title')}
-              className="focus-visible:outline-hidden inline-flex size-7 items-center justify-center rounded-md text-neutral-400 transition-colors hover:bg-neutral-100 hover:text-neutral-700 focus-visible:ring-1 focus-visible:ring-neutral-400 dark:text-neutral-500 dark:hover:bg-neutral-900 dark:hover:text-neutral-200"
-              title={t('write.format.switchUnavailable.title')}
-              type="button"
-            >
-              <CircleHelp aria-hidden="true" className="size-3.5" />
-            </Popover.Trigger>
-            <Popover.Content align="end" className="space-y-1.5 p-3" width="sm">
-              <div className="text-sm font-medium text-fg">
-                {t('write.format.switchUnavailable.title')}
-              </div>
-              <p className="text-xs leading-relaxed text-fg-muted">
-                {t('write.format.switchUnavailable.description')}
-              </p>
-            </Popover.Content>
-          </Popover>
-        )}
+          )}
+          <span>{formatLabel}</span>
+        </button>
         {props.aiButtonVisible ? (
           <button
             aria-label={t('write.pill.aiGenerate')}
@@ -3614,6 +4098,7 @@ function resolveDraftPasswordProtected(
 function buildPostWriteData(
   state: WriteFormState,
   draftId?: string,
+  migration?: MarkdownToLexicalMigrationDescriptor,
 ): CreatePostData {
   const projected = projectWriteState(state)
   return {
@@ -3629,6 +4114,7 @@ function buildPostWriteData(
         : buildWriteImages(projected),
     isPremium: projected.isPremium,
     isPublished: projected.isPublished,
+    migration,
     meta: resolvePaywallMeta(
       projected.meta,
       projected.isPremium,
@@ -3651,6 +4137,7 @@ function buildPostWriteData(
 function buildNoteWriteData(
   state: WriteFormState,
   draftId?: string,
+  migration?: MarkdownToLexicalMigrationDescriptor,
 ): CreateNoteData {
   const projected = projectWriteState(state)
   return {
@@ -3666,6 +4153,7 @@ function buildNoteWriteData(
         : buildWriteImages(projected),
     isPublished: projected.isPublished,
     location: projected.location || null,
+    migration,
     meta: projected.meta,
     mood: projected.mood || undefined,
     password: projected.passwordProtected
@@ -3683,6 +4171,7 @@ function buildNoteWriteData(
 function buildPageWriteData(
   state: WriteFormState,
   draftId?: string,
+  migration?: MarkdownToLexicalMigrationDescriptor,
 ): CreatePageData {
   const projected = projectWriteState(state)
   return {
@@ -3695,6 +4184,7 @@ function buildPageWriteData(
         ? undefined
         : buildWriteImages(projected),
     meta: projected.meta,
+    migration,
     order: projected.order ? Number(projected.order) : undefined,
     slug: projected.slug,
     subtitle: projected.subtitle,
@@ -3708,16 +4198,17 @@ function saveWrite(
   id: string,
   state: WriteFormState,
   draftId?: string,
+  migration?: MarkdownToLexicalMigrationDescriptor,
 ): Promise<WriteModel> {
   if (kind === 'post') {
-    return savePost(id, buildPostWriteData(state, draftId))
+    return savePost(id, buildPostWriteData(state, draftId, migration))
   }
 
   if (kind === 'note') {
-    return saveNote(id, buildNoteWriteData(state, draftId))
+    return saveNote(id, buildNoteWriteData(state, draftId, migration))
   }
 
-  return savePage(id, buildPageWriteData(state, draftId))
+  return savePage(id, buildPageWriteData(state, draftId, migration))
 }
 
 function getDraftFingerprint(

--- a/apps/admin/src/i18n/resources/en-US.ts
+++ b/apps/admin/src/i18n/resources/en-US.ts
@@ -3211,6 +3211,29 @@ export const enUS = {
   'write.format.switchUnavailable.title': 'Editor switching is unavailable',
   'write.format.switchUnavailable.description':
     'CodeMirror edits Markdown source, while Lexical stores rich-text structure. Converting an article that already has content can lose formatting, special nodes, or source syntax, so switching is disabled. Choose the editor you need before writing in a new, empty article.',
+  'write.migration.action.blocked': 'Conversion blocked ({{count}})',
+  'write.migration.action.checking': 'Checking conversion',
+  'write.migration.action.committing': 'Committing conversion',
+  'write.migration.action.convert': 'Convert to Lexical',
+  'write.migration.action.lexical': 'Lexical',
+  'write.migration.action.recheck': 'Recheck',
+  'write.migration.action.restore': 'Restore original Markdown',
+  'write.migration.action.staged': 'Lexical · Not yet published',
+  'write.migration.dialog.draftGroup': 'Current draft',
+  'write.migration.dialog.line': 'Line {{line}}',
+  'write.migration.dialog.ready':
+    'The source and all AI translations are convertible. A normal publish will transition them to Lexical in one transaction.',
+  'write.migration.dialog.sourceGroup': 'Source',
+  'write.migration.dialog.stagedSubtitle':
+    'The Lexical content exists only in the editor or draft; the published document is unchanged.',
+  'write.migration.dialog.title': 'Markdown conversion check',
+  'write.migration.dialog.translationGroup': 'AI translation: {{lang}}',
+  'write.migration.toast.blocked':
+    'Migration conditions changed. Resolve the diagnostics and run the check again.',
+  'write.migration.toast.checkFailed':
+    'The Markdown conversion check could not be completed',
+  'write.migration.toast.staged':
+    'Converted to a Lexical draft. The published document and AI translations remain unchanged until publish.',
   'write.header.backToList': 'Back to list',
   'write.header.editPage': 'Edit page',
   'write.header.newPage': 'New page',

--- a/apps/admin/src/i18n/resources/zh-CN.ts
+++ b/apps/admin/src/i18n/resources/zh-CN.ts
@@ -3054,6 +3054,28 @@ export const zhCN = {
   'write.format.switchUnavailable.title': '暂时无法切换编辑器',
   'write.format.switchUnavailable.description':
     'CodeMirror 直接编辑 Markdown 源码，Lexical 则保存富文本结构。正文已有内容时，在两者之间转换可能丢失格式、特殊节点或原始写法，因此当前文章不支持切换。请在新建文章且正文为空时选择所需编辑器，再开始写作。',
+  'write.migration.action.blocked': '转换受阻（{{count}}）',
+  'write.migration.action.checking': '正在检查转换',
+  'write.migration.action.committing': '正在提交转换',
+  'write.migration.action.convert': '转换为 Lexical',
+  'write.migration.action.lexical': 'Lexical',
+  'write.migration.action.recheck': '重新检查',
+  'write.migration.action.restore': '恢复原始 Markdown',
+  'write.migration.action.staged': 'Lexical · 尚未发布',
+  'write.migration.dialog.draftGroup': '当前草稿',
+  'write.migration.dialog.line': '第 {{line}} 行',
+  'write.migration.dialog.ready':
+    '源文档及全部 AI 翻译均可转换。正常发布时，它们将以同一事务切换为 Lexical。',
+  'write.migration.dialog.sourceGroup': '源文档',
+  'write.migration.dialog.stagedSubtitle':
+    '当前 Lexical 内容仅存在于编辑器或草稿中，尚未改变已发布文档。',
+  'write.migration.dialog.title': 'Markdown 转换检查',
+  'write.migration.dialog.translationGroup': 'AI 翻译：{{lang}}',
+  'write.migration.toast.blocked':
+    '转换条件已发生变化，请处理诊断项后重新检查。',
+  'write.migration.toast.checkFailed': '无法完成 Markdown 转换检查',
+  'write.migration.toast.staged':
+    '已转换为 Lexical 草稿；发布前不会修改线上文档或 AI 翻译。',
   'write.header.backToList': '返回列表',
   'write.header.editPage': '修改页面',
   'write.header.newPage': '新建页面',

--- a/apps/admin/src/ui/feedback/modal.tsx
+++ b/apps/admin/src/ui/feedback/modal.tsx
@@ -112,24 +112,16 @@ export function ModalHeader(props: {
   return (
     <div
       className={cn(
-        'flex h-12 shrink-0 items-center justify-between gap-3 border-b border-border px-4',
+        'grid shrink-0 grid-cols-[minmax(0,1fr)_auto] gap-x-3 border-b border-border px-4',
+        props.subtitle ? 'min-h-16 content-center py-2.5' : 'h-12 items-center',
         props.className,
       )}
     >
-      <div className="min-w-0">
-        <ModalTitle className="inline-flex min-w-0 items-center gap-2 text-base font-semibold text-fg">
-          {Icon ? (
-            <Icon aria-hidden="true" className="size-4 shrink-0" />
-          ) : null}
-          <span className="truncate">{props.title}</span>
-        </ModalTitle>
-        {props.subtitle ? (
-          <p className="mt-0.5 truncate text-xs text-fg-muted">
-            {props.subtitle}
-          </p>
-        ) : null}
-      </div>
-      <div className="flex shrink-0 items-center gap-1">
+      <ModalTitle className="inline-flex min-w-0 self-center items-center gap-2 text-base font-semibold text-fg">
+        {Icon ? <Icon aria-hidden="true" className="size-4 shrink-0" /> : null}
+        <span className="truncate">{props.title}</span>
+      </ModalTitle>
+      <div className="col-start-2 row-start-1 flex shrink-0 self-center items-center gap-1">
         {props.actions}
         {showClose ? (
           <ModalClose
@@ -140,6 +132,11 @@ export function ModalHeader(props: {
           </ModalClose>
         ) : null}
       </div>
+      {props.subtitle ? (
+        <p className="col-start-1 row-start-2 mt-0.5 min-w-0 truncate text-xs text-fg-muted">
+          {props.subtitle}
+        </p>
+      ) : null}
     </div>
   )
 }

--- a/apps/core/src/app.module.ts
+++ b/apps/core/src/app.module.ts
@@ -31,6 +31,7 @@ import { CategoryModule } from './modules/category/category.module'
 import { CommentModule } from './modules/comment/comment.module'
 import { CompanionModule } from './modules/companion/companion.module'
 import { ConfigsModule } from './modules/configs/configs.module'
+import { ContentMigrationModule } from './modules/content-migration/content-migration.module'
 import { CronTaskModule } from './modules/cron-task/cron-task.module'
 import { DebugModule } from './modules/debug/debug.module'
 import { DependencyModule } from './modules/dependency/dependency.module'
@@ -98,6 +99,7 @@ import { SampleResponseInterceptor } from './shared/sample/sample-response.inter
     CommentModule,
     CompanionModule,
     ConfigsModule,
+    ContentMigrationModule,
     CronTaskModule,
 
     DependencyModule,

--- a/apps/core/src/modules/ai/ai-translation/ai-translation.repository.ts
+++ b/apps/core/src/modules/ai/ai-translation/ai-translation.repository.ts
@@ -1,16 +1,25 @@
-import { Inject, Injectable } from '@nestjs/common'
+import { ConflictException, Inject, Injectable } from '@nestjs/common'
 import { and, desc, eq, inArray, or, type SQL, sql } from 'drizzle-orm'
 
 import { PG_DB_TOKEN } from '~/constants/system.constant'
-import { aiTranslations, translationEntries } from '~/database/schema'
+import {
+  aiTranslations,
+  notes,
+  pages,
+  posts,
+  translationEntries,
+} from '~/database/schema'
+import { DraftRefType } from '~/modules/draft/draft.enum'
 import {
   BaseRepository,
   type PaginationResult,
   toEntityId,
 } from '~/processors/database/base.repository'
 import type { AppDatabase } from '~/processors/database/postgres.provider'
+import { acquireContentFormatTransitionLock } from '~/shared/content-format-transition-lock'
 import { type EntityId, parseEntityId } from '~/shared/id/entity-id'
 import { SnowflakeService } from '~/shared/id/snowflake.service'
+import { ContentFormat } from '~/shared/types/content-format.type'
 
 import type {
   AiTranslationRow,
@@ -268,25 +277,65 @@ export class AiTranslationRepository extends BaseRepository {
       sourceBlockSnapshots: input.sourceBlockSnapshots,
       sourceMetaHashes: input.sourceMetaHashes,
     }
-    const [row] = await this.db
-      .insert(aiTranslations)
-      .values({
-        id: this.snowflake.nextId(),
-        refId: refBig,
+    return this.db.transaction(async (tx) => {
+      await acquireContentFormatTransitionLock(tx, {
+        refId: String(input.refId),
         refType: input.refType,
-        lang: input.lang,
-        ...updatableColumns,
       })
-      .onConflictDoUpdate({
-        target: [
-          aiTranslations.refId,
-          aiTranslations.refType,
-          aiTranslations.lang,
-        ],
-        set: updatableColumns,
-      })
-      .returning()
-    return mapTranslation(row)
+
+      let sourceFormat: string | undefined
+      if (input.refType === DraftRefType.Post) {
+        const [source] = await tx
+          .select({ contentFormat: posts.contentFormat })
+          .from(posts)
+          .where(eq(posts.id, refBig))
+          .limit(1)
+        sourceFormat = source?.contentFormat
+      } else if (input.refType === DraftRefType.Note) {
+        const [source] = await tx
+          .select({ contentFormat: notes.contentFormat })
+          .from(notes)
+          .where(eq(notes.id, refBig))
+          .limit(1)
+        sourceFormat = source?.contentFormat
+      } else if (input.refType === DraftRefType.Page) {
+        const [source] = await tx
+          .select({ contentFormat: pages.contentFormat })
+          .from(pages)
+          .where(eq(pages.id, refBig))
+          .limit(1)
+        sourceFormat = source?.contentFormat
+      }
+
+      if (
+        sourceFormat === ContentFormat.Lexical &&
+        input.contentFormat !== ContentFormat.Lexical
+      ) {
+        throw new ConflictException(
+          'A Markdown translation cannot be persisted for a Lexical source',
+        )
+      }
+
+      const [row] = await tx
+        .insert(aiTranslations)
+        .values({
+          id: this.snowflake.nextId(),
+          refId: refBig,
+          refType: input.refType,
+          lang: input.lang,
+          ...updatableColumns,
+        })
+        .onConflictDoUpdate({
+          target: [
+            aiTranslations.refId,
+            aiTranslations.refType,
+            aiTranslations.lang,
+          ],
+          set: updatableColumns,
+        })
+        .returning()
+      return mapTranslation(row)
+    })
   }
 
   async updateById(
@@ -508,12 +557,11 @@ export class TranslationEntryRepository extends BaseRepository {
       .from(translationEntries)
       .where(
         or(
-          ...keyPathLookupKeys.map(
-            ({ keyPath, lookupKey }) =>
-              and(
-                eq(translationEntries.keyPath, keyPath),
-                eq(translationEntries.lookupKey, lookupKey),
-              )!,
+          ...keyPathLookupKeys.map(({ keyPath, lookupKey }) =>
+            and(
+              eq(translationEntries.keyPath, keyPath),
+              eq(translationEntries.lookupKey, lookupKey),
+            )!,
           ),
         )!,
       )

--- a/apps/core/src/modules/content-migration/content-migration-commit.service.ts
+++ b/apps/core/src/modules/content-migration/content-migration-commit.service.ts
@@ -1,0 +1,466 @@
+import {
+  MX_MARKDOWN_CONVERTER_VERSION,
+  type SerializedMxEditorState,
+} from '@mx-space/editor'
+import {
+  BadRequestException,
+  ConflictException,
+  Inject,
+  Injectable,
+} from '@nestjs/common'
+import { and, eq } from 'drizzle-orm'
+
+import { PG_DB_TOKEN } from '~/constants/system.constant'
+import { aiTranslations, drafts, notes, pages, posts } from '~/database/schema'
+import type { ArticleContent } from '~/modules/ai/ai-translation/ai-translation.types'
+import { buildSourceMetaHashes } from '~/modules/ai/ai-translation/translation-meta'
+import { DraftRefType } from '~/modules/draft/draft.enum'
+import type { AppDatabase } from '~/processors/database/postgres.provider'
+import { LexicalService } from '~/processors/helper/helper.lexical.service'
+import { acquireContentFormatTransitionLock } from '~/shared/content-format-transition-lock'
+import { parseEntityId } from '~/shared/id/entity-id'
+import { ContentFormat } from '~/shared/types/content-format.type'
+import { computeContentHash } from '~/utils/content.util'
+
+import type { MarkdownToLexicalMigrationDescriptor } from './content-migration.schema'
+import type { MigrationMemberConversionResult } from './content-migration.types'
+import {
+  alignmentFor,
+  alignRootBlockIds,
+  analyzeMigrationMarkdown,
+  existingLexicalResult,
+  isFullyAligned,
+  sha256,
+} from './content-migration.utils'
+
+type PostPatch = Partial<typeof posts.$inferInsert>
+type NotePatch = Partial<typeof notes.$inferInsert>
+type PagePatch = Partial<typeof pages.$inferInsert>
+
+interface CommitCommon {
+  refId: string
+  descriptor: MarkdownToLexicalMigrationDescriptor
+  draftId?: string
+  source: Omit<ArticleContent, 'meta'> & {
+    content: string
+    contentFormat: ContentFormat.Lexical
+    meta?: Record<string, unknown> | null
+  }
+}
+
+export type MarkdownMigrationCommitInput = CommitCommon &
+  (
+    | { refType: DraftRefType.Post; patch: PostPatch }
+    | { refType: DraftRefType.Note; patch: NotePatch }
+    | { refType: DraftRefType.Page; patch: PagePatch }
+  )
+
+type PersistedSource = {
+  id: string
+  title: string | null
+  text: string | null
+  content: string | null
+  contentFormat: string
+  subtitle?: string | null
+  summary?: string | null
+  tags?: string[]
+  meta: Record<string, unknown> | null
+  modifiedAt: Date | null
+  createdAt: Date
+}
+
+function sourceLanguage(
+  source: { meta?: Record<string, unknown> | null },
+  fallback = 'unknown',
+): string {
+  const lang = source.meta?.lang
+  return typeof lang === 'string' && lang ? lang : fallback
+}
+
+function asArticleContent(
+  source: PersistedSource,
+  converted: {
+    content: SerializedMxEditorState
+    text: string
+  },
+): ArticleContent {
+  return {
+    title: source.title ?? '',
+    text: converted.text,
+    subtitle: source.subtitle,
+    summary: source.summary,
+    tags: source.tags,
+    contentFormat: ContentFormat.Lexical,
+    content: JSON.stringify(converted.content),
+  }
+}
+
+@Injectable()
+export class ContentMigrationCommitService {
+  constructor(
+    @Inject(PG_DB_TOKEN) private readonly db: AppDatabase,
+    private readonly lexicalService: LexicalService,
+  ) {}
+
+  private validateDescriptor(
+    input: MarkdownMigrationCommitInput,
+  ): MigrationMemberConversionResult {
+    const { descriptor } = input
+    if (descriptor.converterVersion !== MX_MARKDOWN_CONVERTER_VERSION) {
+      throw new ConflictException(
+        'Markdown converter version changed; run the migration check again',
+      )
+    }
+
+    const source = analyzeMigrationMarkdown(descriptor.sourceMarkdown, input)
+    if (source.sourceHash !== descriptor.sourceHash) {
+      throw new BadRequestException('Migration source hash does not match')
+    }
+    if (source.status === 'blocked') {
+      throw new BadRequestException(
+        'Migration source is no longer convertible with this profile',
+      )
+    }
+    return source
+  }
+
+  private assertPreconditionShape(input: MarkdownMigrationCommitInput) {
+    const counts = new Map<string, number>()
+    for (const precondition of input.descriptor.preconditions) {
+      const key = `${precondition.kind}:${precondition.id}`
+      counts.set(key, (counts.get(key) ?? 0) + 1)
+    }
+    if ([...counts.values()].some((count) => count !== 1)) {
+      throw new BadRequestException(
+        'Migration preconditions contain duplicate members',
+      )
+    }
+
+    const sourcePreconditions = input.descriptor.preconditions.filter(
+      (item) => item.kind === 'source',
+    )
+    if (
+      sourcePreconditions.length !== 1 ||
+      sourcePreconditions[0].id !== input.refId
+    ) {
+      throw new BadRequestException(
+        'Migration must contain exactly one source precondition',
+      )
+    }
+
+    const draftPreconditions = input.descriptor.preconditions.filter(
+      (item) => item.kind === 'draft',
+    )
+    if (
+      (input.draftId &&
+        (draftPreconditions.length !== 1 ||
+          draftPreconditions[0].id !== input.draftId)) ||
+      (!input.draftId && draftPreconditions.length > 0)
+    ) {
+      throw new BadRequestException(
+        'Migration draft precondition does not match the submitted draft',
+      )
+    }
+  }
+
+  private assertSubmittedLexicalPair(input: MarkdownMigrationCommitInput) {
+    let parsed: SerializedMxEditorState
+    try {
+      parsed = JSON.parse(input.source.content) as SerializedMxEditorState
+    } catch {
+      throw new BadRequestException('Submitted Lexical content is invalid JSON')
+    }
+    if (!parsed?.root || !Array.isArray(parsed.root.children)) {
+      throw new BadRequestException('Submitted Lexical content has no root')
+    }
+    if (
+      this.lexicalService.lexicalToMarkdown(input.source.content) !==
+      input.source.text
+    ) {
+      throw new BadRequestException(
+        'Submitted Lexical content and Markdown projection do not match',
+      )
+    }
+  }
+
+  private async lockSource(
+    tx: Parameters<Parameters<AppDatabase['transaction']>[0]>[0],
+    input: MarkdownMigrationCommitInput,
+  ): Promise<PersistedSource> {
+    const id = parseEntityId(input.refId)
+    switch (input.refType) {
+      case DraftRefType.Post: {
+        const [row] = await tx
+          .select()
+          .from(posts)
+          .where(eq(posts.id, id))
+          .limit(1)
+          .for('update')
+        if (!row)
+          throw new ConflictException('Source document no longer exists')
+        return row
+      }
+      case DraftRefType.Note: {
+        const [row] = await tx
+          .select()
+          .from(notes)
+          .where(eq(notes.id, id))
+          .limit(1)
+          .for('update')
+        if (!row)
+          throw new ConflictException('Source document no longer exists')
+        return row as PersistedSource
+      }
+      case DraftRefType.Page: {
+        const [row] = await tx
+          .select()
+          .from(pages)
+          .where(eq(pages.id, id))
+          .limit(1)
+          .for('update')
+        if (!row)
+          throw new ConflictException('Source document no longer exists')
+        return row
+      }
+    }
+  }
+
+  private async updateSource(
+    tx: Parameters<Parameters<AppDatabase['transaction']>[0]>[0],
+    input: MarkdownMigrationCommitInput,
+    preserveModifiedAt: Date | null,
+  ) {
+    const id = parseEntityId(input.refId)
+    switch (input.refType) {
+      case DraftRefType.Post: {
+        await tx
+          .update(posts)
+          .set({ ...input.patch, modifiedAt: preserveModifiedAt })
+          .where(eq(posts.id, id))
+        return
+      }
+      case DraftRefType.Note: {
+        await tx
+          .update(notes)
+          .set({ ...input.patch, modifiedAt: preserveModifiedAt })
+          .where(eq(notes.id, id))
+        return
+      }
+      case DraftRefType.Page: {
+        await tx
+          .update(pages)
+          .set({ ...input.patch, modifiedAt: preserveModifiedAt })
+          .where(eq(pages.id, id))
+      }
+    }
+  }
+
+  async commitMarkdownToLexical(
+    input: MarkdownMigrationCommitInput,
+  ): Promise<void> {
+    const baseline = this.validateDescriptor(input)
+    this.assertPreconditionShape(input)
+    this.assertSubmittedLexicalPair(input)
+    if (baseline.status !== 'convertible') {
+      throw new BadRequestException('Migration source is not convertible')
+    }
+
+    await this.db.transaction(async (tx) => {
+      await acquireContentFormatTransitionLock(tx, input)
+      const persisted = await this.lockSource(tx, input)
+      if (persisted.contentFormat !== ContentFormat.Markdown) {
+        throw new ConflictException('Source document is no longer Markdown')
+      }
+
+      const sourcePrecondition = input.descriptor.preconditions.find(
+        (item) => item.kind === 'source',
+      )!
+      const persistedSource = analyzeMigrationMarkdown(
+        persisted.text ?? '',
+        input,
+      )
+      if (persistedSource.sourceHash !== sourcePrecondition.hash) {
+        throw new ConflictException(
+          'Published source changed after the migration check',
+        )
+      }
+
+      const draftPrecondition = input.descriptor.preconditions.find(
+        (item) => item.kind === 'draft',
+      )
+      let lockedDraft: typeof drafts.$inferSelect | undefined
+      if (input.draftId && draftPrecondition) {
+        const [draft] = await tx
+          .select()
+          .from(drafts)
+          .where(eq(drafts.id, parseEntityId(input.draftId)))
+          .limit(1)
+          .for('update')
+        if (
+          !draft ||
+          draft.refType !== input.refType ||
+          String(draft.refId) !== input.refId
+        ) {
+          throw new ConflictException(
+            'Draft no longer belongs to the source document',
+          )
+        }
+        const draftHash =
+          draft.contentFormat === ContentFormat.Lexical && draft.content
+            ? sha256(draft.content)
+            : analyzeMigrationMarkdown(draft.text, input).sourceHash
+        if (
+          draft.version !== draftPrecondition.version ||
+          draftHash !== draftPrecondition.hash
+        ) {
+          throw new ConflictException('Draft changed after the migration check')
+        }
+        lockedDraft = draft
+      }
+
+      const translationRows = await tx
+        .select()
+        .from(aiTranslations)
+        .where(
+          and(
+            eq(aiTranslations.refId, parseEntityId(input.refId)),
+            eq(aiTranslations.refType, input.refType),
+          ),
+        )
+        .for('update')
+      const translationPreconditions = input.descriptor.preconditions.filter(
+        (item) => item.kind === 'translation',
+      )
+      const expectedTranslationIds = new Set<string>(
+        translationPreconditions.map((item) => String(item.id)),
+      )
+      if (
+        translationRows.length !== expectedTranslationIds.size ||
+        translationRows.some(
+          (row) => !expectedTranslationIds.has(String(row.id)),
+        )
+      ) {
+        throw new ConflictException(
+          'Translation set changed after the migration check',
+        )
+      }
+
+      const baselineArticle = asArticleContent(persisted, baseline)
+      const baselineContent = baselineArticle.content!
+      const sourceBlockSnapshots = this.lexicalService
+        .extractRootBlocks(baselineContent)
+        .map((block) => ({
+          id: block.id ?? '',
+          fingerprint: block.fingerprint,
+          type: block.type,
+          index: block.index,
+        }))
+      const sourceMetaHashes = buildSourceMetaHashes(baselineArticle)
+
+      for (const translation of translationRows) {
+        const precondition = translationPreconditions.find(
+          (item) => item.id === String(translation.id),
+        )!
+        const result =
+          translation.contentFormat === ContentFormat.Lexical
+            ? existingLexicalResult(translation)
+            : analyzeMigrationMarkdown(
+                translation.text,
+                input,
+                baseline.sourceHash,
+              )
+        if (!result || result.sourceHash !== precondition.hash) {
+          throw new ConflictException(
+            `Translation ${translation.lang} changed after the migration check`,
+          )
+        }
+        if (result.status === 'blocked') {
+          throw new ConflictException(
+            `Translation ${translation.lang} is no longer convertible`,
+          )
+        }
+        const alignment = alignmentFor(baseline, result)
+        if (!isFullyAligned(alignment)) {
+          throw new ConflictException(
+            `Translation ${translation.lang} no longer aligns with the source`,
+          )
+        }
+
+        const content = alignRootBlockIds(baseline.content, result.content)
+        const serializedContent = JSON.stringify(content)
+        const sourceLang = sourceLanguage(persisted, translation.sourceLang)
+        await tx
+          .update(aiTranslations)
+          .set({
+            contentFormat: ContentFormat.Lexical,
+            content: serializedContent,
+            text: this.lexicalService.lexicalToMarkdown(serializedContent),
+            hash: computeContentHash(baselineArticle, sourceLang),
+            sourceModifiedAt: persisted.modifiedAt,
+            sourceBlockSnapshots,
+            sourceMetaHashes,
+          })
+          .where(eq(aiTranslations.id, translation.id))
+      }
+
+      const finalLang = sourceLanguage(input.source, sourceLanguage(persisted))
+      const pureRepresentationMigration =
+        baseline.sourceHash === persistedSource.sourceHash &&
+        computeContentHash(baselineArticle, finalLang) ===
+          computeContentHash(input.source, finalLang)
+      const modifiedAt = pureRepresentationMigration
+        ? persisted.modifiedAt
+        : ((input.patch as { modifiedAt?: Date | null }).modifiedAt ??
+          new Date())
+
+      await this.updateSource(tx, input, modifiedAt)
+      if (lockedDraft) {
+        const draftChanged =
+          lockedDraft.title !== input.source.title ||
+          lockedDraft.text !== input.source.text ||
+          lockedDraft.content !== input.source.content ||
+          lockedDraft.contentFormat !== ContentFormat.Lexical
+        const nextVersion = draftChanged
+          ? lockedDraft.version + 1
+          : lockedDraft.version
+        const history = draftChanged
+          ? [
+              {
+                version: lockedDraft.version,
+                title: lockedDraft.title,
+                text:
+                  lockedDraft.contentFormat === ContentFormat.Markdown
+                    ? lockedDraft.text
+                    : undefined,
+                contentFormat: lockedDraft.contentFormat,
+                content: lockedDraft.content ?? undefined,
+                typeSpecificData: lockedDraft.typeSpecificData
+                  ? JSON.stringify(lockedDraft.typeSpecificData)
+                  : undefined,
+                savedAt: lockedDraft.updatedAt ?? lockedDraft.createdAt,
+                isFullSnapshot: true,
+              },
+              ...((lockedDraft.history ?? []) as unknown[]),
+            ].slice(0, 100)
+          : lockedDraft.history
+        await tx
+          .update(drafts)
+          .set({
+            ...(draftChanged
+              ? {
+                  title: input.source.title,
+                  text: input.source.text,
+                  content: input.source.content,
+                  contentFormat: ContentFormat.Lexical,
+                  history,
+                  version: nextVersion,
+                }
+              : {}),
+            publishedVersion: nextVersion,
+            updatedAt: new Date(),
+          })
+          .where(eq(drafts.id, lockedDraft.id))
+      }
+    })
+  }
+}

--- a/apps/core/src/modules/content-migration/content-migration.controller.ts
+++ b/apps/core/src/modules/content-migration/content-migration.controller.ts
@@ -1,0 +1,21 @@
+import { Body, HttpCode, Post } from '@nestjs/common'
+
+import { ApiController } from '~/common/decorators/api-controller.decorator'
+import { Auth } from '~/common/decorators/auth.decorator'
+
+import { MarkdownToLexicalDryRunDto } from './content-migration.schema'
+import { ContentMigrationService } from './content-migration.service'
+
+@ApiController('content-migrations')
+export class ContentMigrationController {
+  constructor(
+    private readonly contentMigrationService: ContentMigrationService,
+  ) {}
+
+  @Post('/markdown-to-lexical/dry-run')
+  @HttpCode(200)
+  @Auth()
+  dryRunMarkdownToLexical(@Body() body: MarkdownToLexicalDryRunDto) {
+    return this.contentMigrationService.dryRunMarkdownToLexical(body)
+  }
+}

--- a/apps/core/src/modules/content-migration/content-migration.module.ts
+++ b/apps/core/src/modules/content-migration/content-migration.module.ts
@@ -1,0 +1,16 @@
+import { Module } from '@nestjs/common'
+
+import { AiModule } from '../ai/ai.module'
+import { DraftModule } from '../draft/draft.module'
+import { NoteModule } from '../note/note.module'
+import { PageModule } from '../page/page.module'
+import { PostModule } from '../post/post.module'
+import { ContentMigrationController } from './content-migration.controller'
+import { ContentMigrationService } from './content-migration.service'
+
+@Module({
+  imports: [AiModule, DraftModule, NoteModule, PageModule, PostModule],
+  controllers: [ContentMigrationController],
+  providers: [ContentMigrationService],
+})
+export class ContentMigrationModule {}

--- a/apps/core/src/modules/content-migration/content-migration.schema.ts
+++ b/apps/core/src/modules/content-migration/content-migration.schema.ts
@@ -1,0 +1,36 @@
+import { createZodDto } from 'nestjs-zod'
+import { z } from 'zod'
+
+import { zEntityId } from '~/common/zod'
+import { DraftRefType } from '~/modules/draft/draft.enum'
+
+export const MigrationMemberPreconditionSchema = z.object({
+  kind: z.enum(['source', 'draft', 'translation']),
+  id: zEntityId,
+  hash: z.string().min(1).max(128),
+  version: z.number().int().positive().optional(),
+})
+
+export const MarkdownToLexicalMigrationDescriptorSchema = z.object({
+  profile: z.literal('yohaku-v1'),
+  converterVersion: z.string().min(1).max(64),
+  sourceMarkdown: z.string().max(2_000_000),
+  sourceHash: z.string().min(1).max(128),
+  preconditions: z.array(MigrationMemberPreconditionSchema).max(500),
+})
+
+export type MarkdownToLexicalMigrationDescriptor = z.infer<
+  typeof MarkdownToLexicalMigrationDescriptorSchema
+>
+
+export const MarkdownToLexicalDryRunSchema = z.object({
+  refType: z.enum(DraftRefType),
+  refId: zEntityId,
+  draftId: zEntityId.optional(),
+  sourceText: z.string().max(2_000_000),
+  profile: z.literal('yohaku-v1'),
+})
+
+export class MarkdownToLexicalDryRunDto extends createZodDto(
+  MarkdownToLexicalDryRunSchema,
+) {}

--- a/apps/core/src/modules/content-migration/content-migration.service.ts
+++ b/apps/core/src/modules/content-migration/content-migration.service.ts
@@ -1,0 +1,232 @@
+import {
+  analyzeMxMarkdown,
+  type MarkdownConversionResult,
+  MX_MARKDOWN_CONVERTER_VERSION,
+} from '@mx-space/editor'
+import {
+  BadRequestException,
+  Injectable,
+  NotFoundException,
+} from '@nestjs/common'
+
+import { AiTranslationRepository } from '~/modules/ai/ai-translation/ai-translation.repository'
+import type { AiTranslationRow } from '~/modules/ai/ai-translation/ai-translation.types'
+import { DraftRefType } from '~/modules/draft/draft.enum'
+import { DraftService } from '~/modules/draft/draft.service'
+import { NoteService } from '~/modules/note/note.service'
+import { PageService } from '~/modules/page/page.service'
+import { PostService } from '~/modules/post/post.service'
+import { ContentFormat } from '~/shared/types/content-format.type'
+
+import type { MarkdownToLexicalDryRunDto } from './content-migration.schema'
+import type {
+  MarkdownMigrationDryRunResponse,
+  MigrationIssue,
+  MigrationMemberConversionResult,
+  MigrationMemberPrecondition,
+} from './content-migration.types'
+import {
+  alignmentFor,
+  analyzeMigrationMarkdown,
+  existingLexicalResult,
+  invalidExistingLexicalResult,
+  isFullyAligned,
+  memberIssues,
+  sha256,
+  wholeSourceRange,
+} from './content-migration.utils'
+
+type ContentDocument = {
+  id: string
+  text: string
+  content?: string | null
+  contentFormat?: string | null
+  modifiedAt?: Date | null
+  createdAt?: Date | null
+}
+
+@Injectable()
+export class ContentMigrationService {
+  constructor(
+    private readonly postService: PostService,
+    private readonly noteService: NoteService,
+    private readonly pageService: PageService,
+    private readonly draftService: DraftService,
+    private readonly aiTranslationRepository: AiTranslationRepository,
+  ) {}
+
+  private async findDocument(
+    refType: DraftRefType,
+    refId: string,
+  ): Promise<ContentDocument | null> {
+    switch (refType) {
+      case DraftRefType.Post: {
+        return this.postService.findById(
+          refId,
+        ) as Promise<ContentDocument | null>
+      }
+      case DraftRefType.Note: {
+        return this.noteService.findById(
+          refId,
+        ) as Promise<ContentDocument | null>
+      }
+      case DraftRefType.Page: {
+        return this.pageService.findById(
+          refId,
+        ) as Promise<ContentDocument | null>
+      }
+    }
+  }
+
+  private analyzeSource(
+    sourceText: string,
+    input: { refType: DraftRefType; refId: string },
+    baselineSourceHash?: string,
+  ): MarkdownConversionResult {
+    return analyzeMigrationMarkdown(sourceText, input, baselineSourceHash)
+  }
+
+  private alignmentIssue(input: {
+    translation: AiTranslationRow
+    sourceBlockCount: number
+    translationBlockCount: number
+    alignedBlockCount: number
+  }): MigrationIssue {
+    return {
+      code: 'translation-structure-mismatch',
+      feature: 'translation-alignment',
+      message:
+        'The translation root block structure does not align with the source document.',
+      range: wholeSourceRange(input.translation.text),
+      severity: 'blocking',
+      member: 'translation',
+      memberId: String(input.translation.id),
+      lang: input.translation.lang,
+      details: {
+        sourceBlockCount: input.sourceBlockCount,
+        translationBlockCount: input.translationBlockCount,
+        alignedBlockCount: input.alignedBlockCount,
+      },
+    }
+  }
+
+  async dryRunMarkdownToLexical(
+    dto: MarkdownToLexicalDryRunDto,
+  ): Promise<MarkdownMigrationDryRunResponse> {
+    const document = await this.findDocument(dto.refType, dto.refId)
+    if (!document) throw new NotFoundException('Content document not found')
+    if (
+      (document.contentFormat ?? ContentFormat.Markdown) !==
+      ContentFormat.Markdown
+    ) {
+      throw new BadRequestException('Source document is not Markdown')
+    }
+
+    const [draft, translationRows] = await Promise.all([
+      dto.draftId ? this.draftService.findById(dto.draftId) : null,
+      this.aiTranslationRepository.listByRefId(dto.refId),
+    ])
+    if (dto.draftId && !draft) {
+      throw new NotFoundException('Draft not found')
+    }
+    if (
+      draft &&
+      (draft.refType !== dto.refType || String(draft.refId) !== dto.refId)
+    ) {
+      throw new BadRequestException('Draft does not belong to this document')
+    }
+
+    const translations = translationRows.filter(
+      (translation) => translation.refType === dto.refType,
+    )
+    const source = this.analyzeSource(dto.sourceText, dto)
+    const issues: MigrationIssue[] = memberIssues(source, 'source', dto.refId)
+    const preconditions: MigrationMemberPrecondition[] = []
+
+    const persistedSource = analyzeMxMarkdown(document.text ?? '', {
+      profile: 'yohaku-v1',
+    })
+    preconditions.push({
+      kind: 'source',
+      id: dto.refId,
+      hash: persistedSource.sourceHash,
+    })
+
+    if (draft) {
+      const draftResult = analyzeMxMarkdown(draft.text ?? '', {
+        profile: 'yohaku-v1',
+      })
+      preconditions.push({
+        kind: 'draft',
+        id: String(draft.id),
+        hash:
+          draft.contentFormat === ContentFormat.Lexical && draft.content
+            ? sha256(draft.content)
+            : draftResult.sourceHash,
+        version: draft.version,
+      })
+    }
+
+    const convertedTranslations: MarkdownMigrationDryRunResponse['translations'] =
+      []
+
+    for (const translation of translations) {
+      let result: MigrationMemberConversionResult
+      if (translation.contentFormat === ContentFormat.Lexical) {
+        result =
+          existingLexicalResult(translation) ??
+          invalidExistingLexicalResult(translation)
+      } else {
+        result = this.analyzeSource(translation.text, dto, source.sourceHash)
+      }
+
+      if (result.status === 'blocked') {
+        issues.push(
+          ...memberIssues(
+            result,
+            'translation',
+            String(translation.id),
+            translation.lang,
+          ),
+        )
+      }
+
+      const alignment = alignmentFor(source, result)
+      if (
+        source.status === 'convertible' &&
+        result.status !== 'blocked' &&
+        !isFullyAligned(alignment)
+      ) {
+        issues.push(
+          this.alignmentIssue({
+            translation,
+            ...alignment,
+          }),
+        )
+      }
+
+      preconditions.push({
+        kind: 'translation',
+        id: String(translation.id),
+        hash: result.sourceHash,
+      })
+      convertedTranslations.push({
+        id: String(translation.id),
+        lang: translation.lang,
+        result,
+        alignment,
+      })
+    }
+
+    return {
+      status: issues.length > 0 ? 'blocked' : 'convertible',
+      profile: 'yohaku-v1',
+      converterVersion: MX_MARKDOWN_CONVERTER_VERSION,
+      sourceHash: source.sourceHash,
+      preconditions,
+      source,
+      translations: convertedTranslations,
+      issues,
+    }
+  }
+}

--- a/apps/core/src/modules/content-migration/content-migration.types.ts
+++ b/apps/core/src/modules/content-migration/content-migration.types.ts
@@ -1,0 +1,49 @@
+import type {
+  MarkdownConversionIssue,
+  MarkdownConversionProfile,
+  MarkdownConversionResult,
+  SerializedMxEditorState,
+} from '@mx-space/editor'
+
+export interface MigrationMemberPrecondition {
+  kind: 'source' | 'draft' | 'translation'
+  id: string
+  hash: string
+  version?: number
+}
+
+export interface ExistingLexicalConversionResult {
+  status: 'already-lexical'
+  profile: MarkdownConversionProfile
+  sourceHash: string
+  content: SerializedMxEditorState
+}
+
+export type MigrationMemberConversionResult =
+  MarkdownConversionResult | ExistingLexicalConversionResult
+
+export interface MigrationIssue extends MarkdownConversionIssue {
+  member: 'source' | 'draft' | 'translation'
+  memberId: string
+  lang?: string
+}
+
+export interface MarkdownMigrationDryRunResponse {
+  status: 'convertible' | 'blocked'
+  profile: MarkdownConversionProfile
+  converterVersion: string
+  sourceHash: string
+  preconditions: MigrationMemberPrecondition[]
+  source: MarkdownConversionResult
+  translations: Array<{
+    id: string
+    lang: string
+    result: MigrationMemberConversionResult
+    alignment: {
+      sourceBlockCount: number
+      translationBlockCount: number
+      alignedBlockCount: number
+    }
+  }>
+  issues: MigrationIssue[]
+}

--- a/apps/core/src/modules/content-migration/content-migration.utils.ts
+++ b/apps/core/src/modules/content-migration/content-migration.utils.ts
@@ -1,0 +1,215 @@
+import { createHash } from 'node:crypto'
+
+import {
+  analyzeMxMarkdown,
+  type MarkdownConversionIssue,
+  type MarkdownConversionResult,
+  type MarkdownSourceRange,
+  MX_MARKDOWN_CONVERTER_VERSION,
+  type SerializedMxEditorState,
+} from '@mx-space/editor'
+
+import type { AiTranslationRow } from '~/modules/ai/ai-translation/ai-translation.types'
+import type { DraftRefType } from '~/modules/draft/draft.enum'
+
+import type {
+  ExistingLexicalConversionResult,
+  MigrationIssue,
+  MigrationMemberConversionResult,
+} from './content-migration.types'
+
+export function wholeSourceRange(source: string): MarkdownSourceRange {
+  const lines = source.split('\n')
+  return {
+    start: { line: 1, column: 1, offset: 0 },
+    end: {
+      line: lines.length,
+      column: lines.at(-1)!.length + 1,
+      offset: source.length,
+    },
+  }
+}
+
+export function sha256(value: string): string {
+  return `sha256:${createHash('sha256').update(value).digest('hex')}`
+}
+
+export function stableBlockIdFactory(input: {
+  refType: DraftRefType
+  refId: string
+  sourceHash: string
+}): (path: string) => string {
+  return (path) =>
+    createHash('sha256')
+      .update(`${input.refType}:${input.refId}:${input.sourceHash}:${path}`)
+      .digest('hex')
+      .slice(0, 20)
+}
+
+export function analyzeMigrationMarkdown(
+  sourceText: string,
+  input: { refType: DraftRefType; refId: string },
+  baselineSourceHash?: string,
+): MarkdownConversionResult {
+  const initial = analyzeMxMarkdown(sourceText, { profile: 'yohaku-v1' })
+  if (initial.status === 'blocked') return initial
+  return analyzeMxMarkdown(sourceText, {
+    profile: 'yohaku-v1',
+    blockIdFactory: stableBlockIdFactory({
+      ...input,
+      sourceHash: baselineSourceHash ?? initial.sourceHash,
+    }),
+  })
+}
+
+export function existingLexicalResult(
+  translation: Pick<AiTranslationRow, 'content' | 'text'>,
+): ExistingLexicalConversionResult | null {
+  if (!translation.content) return null
+  try {
+    const content = JSON.parse(translation.content) as SerializedMxEditorState
+    if (!content?.root || !Array.isArray(content.root.children)) return null
+    return {
+      status: 'already-lexical',
+      profile: 'yohaku-v1',
+      sourceHash: sha256(translation.content),
+      content,
+    }
+  } catch {
+    return null
+  }
+}
+
+export function invalidExistingLexicalResult(
+  translation: Pick<AiTranslationRow, 'content' | 'text'>,
+): MarkdownConversionResult {
+  const issue: MarkdownConversionIssue = {
+    code: 'invalid-existing-lexical',
+    feature: 'lexical-content',
+    message: 'The existing Lexical translation content is invalid.',
+    range: wholeSourceRange(translation.text),
+    severity: 'blocking',
+  }
+  return {
+    status: 'blocked',
+    converterVersion: MX_MARKDOWN_CONVERTER_VERSION,
+    profile: 'yohaku-v1',
+    sourceHash: sha256(translation.content ?? ''),
+    features: [],
+    issues: [issue],
+  }
+}
+
+export function memberIssues(
+  result: MarkdownConversionResult,
+  member: MigrationIssue['member'],
+  memberId: string,
+  lang?: string,
+): MigrationIssue[] {
+  if (result.status !== 'blocked') return []
+  return result.issues.map((issue) => ({
+    ...issue,
+    member,
+    memberId,
+    ...(lang ? { lang } : {}),
+  }))
+}
+
+function rootChildrenOf(result: MigrationMemberConversionResult): unknown[] {
+  if (result.status === 'blocked') return []
+  return result.content.root.children as unknown[]
+}
+
+const TRANSLATABLE_STRUCTURE_KEYS = new Set([
+  '$',
+  'altText',
+  'caption',
+  'detail',
+  'direction',
+  'displayName',
+  'format',
+  'indent',
+  'mode',
+  'style',
+  'summary',
+  'text',
+  'textFormat',
+  'textStyle',
+  'title',
+  'value',
+  'version',
+])
+
+function structuralValue(value: unknown): unknown {
+  if (Array.isArray(value)) return value.map(structuralValue)
+  if (!value || typeof value !== 'object') return value
+
+  return Object.fromEntries(
+    Object.entries(value as Record<string, unknown>)
+      .filter(([key]) => !TRANSLATABLE_STRUCTURE_KEYS.has(key))
+      .sort(([a], [b]) => a.localeCompare(b))
+      .map(([key, child]) => [key, structuralValue(child)]),
+  )
+}
+
+export function rootBlockSignatures(
+  result: MigrationMemberConversionResult,
+): string[] {
+  return rootChildrenOf(result).map((node) =>
+    JSON.stringify(structuralValue(node)),
+  )
+}
+
+export function alignmentFor(
+  source: MigrationMemberConversionResult,
+  translation: MigrationMemberConversionResult,
+): {
+  sourceBlockCount: number
+  translationBlockCount: number
+  alignedBlockCount: number
+} {
+  const sourceSignatures = rootBlockSignatures(source)
+  const translationSignatures = rootBlockSignatures(translation)
+  const alignedBlockCount = sourceSignatures.reduce(
+    (count, signature, index) =>
+      signature === translationSignatures[index] ? count + 1 : count,
+    0,
+  )
+  return {
+    sourceBlockCount: sourceSignatures.length,
+    translationBlockCount: translationSignatures.length,
+    alignedBlockCount,
+  }
+}
+
+export function isFullyAligned(alignment: ReturnType<typeof alignmentFor>) {
+  return (
+    alignment.sourceBlockCount === alignment.translationBlockCount &&
+    alignment.alignedBlockCount === alignment.sourceBlockCount
+  )
+}
+
+export function alignRootBlockIds(
+  source: SerializedMxEditorState,
+  translation: SerializedMxEditorState,
+): SerializedMxEditorState {
+  const aligned = structuredClone(translation)
+  const sourceChildren = source.root.children as Array<Record<string, unknown>>
+  const translationChildren = aligned.root.children as Array<
+    Record<string, unknown>
+  >
+
+  translationChildren.forEach((block, index) => {
+    const sourceState = sourceChildren[index]?.$ as
+      Record<string, unknown> | undefined
+    const blockId = sourceState?.blockId
+    if (typeof blockId !== 'string' || !blockId) return
+    const state =
+      block.$ && typeof block.$ === 'object' && !Array.isArray(block.$)
+        ? (block.$ as Record<string, unknown>)
+        : {}
+    block.$ = { ...state, blockId }
+  })
+
+  return aligned
+}

--- a/apps/core/src/modules/note/note.module.ts
+++ b/apps/core/src/modules/note/note.module.ts
@@ -5,6 +5,7 @@ import { GatewayModule } from '~/processors/gateway/gateway.module'
 
 import { AiModule } from '../ai/ai.module'
 import { CommentModule } from '../comment/comment.module'
+import { ContentMigrationCommitService } from '../content-migration/content-migration-commit.service'
 import { DraftModule } from '../draft/draft.module'
 import { EnrichmentModule } from '../enrichment/enrichment.module'
 import { SlugTrackerModule } from '../slug-tracker/slug-tracker.module'
@@ -18,6 +19,7 @@ import { NoteService } from './note.service'
   providers: [
     NoteService,
     NoteRepository,
+    ContentMigrationCommitService,
     { provide: NOTE_SERVICE_TOKEN, useExisting: NoteService },
   ],
   exports: [NoteService, NoteRepository, NOTE_SERVICE_TOKEN],

--- a/apps/core/src/modules/note/note.schema.ts
+++ b/apps/core/src/modules/note/note.schema.ts
@@ -10,6 +10,7 @@ import {
   zNonEmptyString,
   zPrefer,
 } from '~/common/zod'
+import { MarkdownToLexicalMigrationDescriptorSchema } from '~/modules/content-migration/content-migration.schema'
 import { createPagerSchema } from '~/shared/dto/pager.dto'
 import {
   validateLexicalCreateContentPair,
@@ -59,6 +60,7 @@ const NoteBaseSchema = WriteBaseSchema.extend({
   images: ImageArraySchema.optional().default([]),
   /** ID of the associated draft; marked as published when this note is published */
   draftId: zEntityId.optional(),
+  migration: MarkdownToLexicalMigrationDescriptorSchema.optional(),
 })
 
 export const NoteSchema = NoteBaseSchema.superRefine(

--- a/apps/core/src/modules/note/note.service.ts
+++ b/apps/core/src/modules/note/note.service.ts
@@ -1,4 +1,9 @@
-import { forwardRef, Inject, Injectable } from '@nestjs/common'
+import {
+  BadRequestException,
+  forwardRef,
+  Inject,
+  Injectable,
+} from '@nestjs/common'
 import { debounce, omit } from 'es-toolkit/compat'
 
 import { AppErrorCode, createAppException } from '~/common/errors'
@@ -6,6 +11,8 @@ import { ArticleTypeEnum } from '~/constants/article.constant'
 import { BusinessEvents, EventScope } from '~/constants/business-event.constant'
 import { CollectionRefTypes } from '~/constants/db.constant'
 import { EventBusEvents } from '~/constants/event-bus.constant'
+import type { MarkdownToLexicalMigrationDescriptor } from '~/modules/content-migration/content-migration.schema'
+import { ContentMigrationCommitService } from '~/modules/content-migration/content-migration-commit.service'
 import { FileReferenceType } from '~/modules/file/file-reference.enum'
 import { FileReferenceService } from '~/modules/file/file-reference.service'
 import { EventManagerService } from '~/processors/helper/helper.event.service'
@@ -45,6 +52,7 @@ export class NoteService {
     private readonly fileReferenceService: FileReferenceService,
     private readonly eventManager: EventManagerService,
     private readonly lexicalService: LexicalService,
+    private readonly contentMigrationCommitService: ContentMigrationCommitService,
     private readonly slugTrackerService: SlugTrackerService,
     private readonly aiSlugBackfillService: AiSlugBackfillService,
     private readonly enrichmentService: EnrichmentService,
@@ -359,13 +367,37 @@ export class NoteService {
 
   public async updateById(
     id: string,
-    data: Partial<NoteModel> & { draftId?: string },
+    data: Partial<NoteModel> & {
+      draftId?: string
+      migration?: MarkdownToLexicalMigrationDescriptor
+    },
   ) {
     this.lexicalService.normalizeContentForStorage(data)
     const oldDoc = await this.findById(id)
     if (!oldDoc) throw createAppException(AppErrorCode.NO_CONTENT_MODIFIABLE)
 
-    const { draftId } = data
+    const { draftId, migration } = data
+    const isMarkdownToLexical =
+      oldDoc.contentFormat === ContentFormat.Markdown &&
+      data.contentFormat === ContentFormat.Lexical
+    if (
+      oldDoc.contentFormat === ContentFormat.Lexical &&
+      data.contentFormat === ContentFormat.Markdown
+    ) {
+      throw new BadRequestException(
+        'Published Lexical content cannot be downgraded to Markdown',
+      )
+    }
+    if (isMarkdownToLexical && !migration) {
+      throw new BadRequestException(
+        'Markdown-to-Lexical writes require a migration descriptor',
+      )
+    }
+    if (migration && !isMarkdownToLexical) {
+      throw new BadRequestException(
+        'Migration descriptor is only valid for Markdown-to-Lexical writes',
+      )
+    }
     const hasSlugInput = Object.prototype.hasOwnProperty.call(data, 'slug')
     const normalizedSlug = hasSlugInput
       ? this.normalizeSlug(data.slug ?? undefined)
@@ -386,7 +418,7 @@ export class NoteService {
 
     const patch = omit(data, [...NOTE_PROTECTED_KEYS, 'slug'] as const)
     const userSuppliedCreatedAt = data.createdAt ?? (data as any).created
-    const updated = await this.noteRepository.update(id, {
+    const repositoryPatch = {
       title: patch.title,
       slug: hasSlugInput ? normalizedSlug : undefined,
       text: patch.text,
@@ -410,7 +442,35 @@ export class NoteService {
         ? getLessThanNow(userSuppliedCreatedAt)
         : undefined,
       modifiedAt: hasContentChanged || hasFieldChanged ? new Date() : undefined,
-    })
+    }
+    let updated
+    if (migration) {
+      if (!data.content || data.text === undefined) {
+        throw new BadRequestException(
+          'Lexical migration requires content and text',
+        )
+      }
+      await this.contentMigrationCommitService.commitMarkdownToLexical({
+        refType: DraftRefType.Note,
+        refId: id,
+        descriptor: migration,
+        draftId,
+        patch: repositoryPatch,
+        source: {
+          title: repositoryPatch.title ?? oldDoc.title,
+          text: data.text,
+          content: data.content,
+          contentFormat: ContentFormat.Lexical,
+          meta:
+            repositoryPatch.meta === undefined
+              ? oldDoc.meta
+              : repositoryPatch.meta,
+        },
+      })
+      updated = await this.noteRepository.findById(id)
+    } else {
+      updated = await this.noteRepository.update(id, repositoryPatch)
+    }
     if (!updated) throw createAppException(AppErrorCode.NO_CONTENT_MODIFIABLE)
 
     await this.trackSeoPathChanges(
@@ -422,7 +482,7 @@ export class NoteService {
       id,
     )
 
-    if (draftId) await this.draftService.markAsPublished(draftId)
+    if (draftId && !migration) await this.draftService.markAsPublished(draftId)
 
     scheduleManager.schedule(async () => {
       await this.fileReferenceService.updateReferencesForDocument(

--- a/apps/core/src/modules/page/page.module.ts
+++ b/apps/core/src/modules/page/page.module.ts
@@ -2,6 +2,7 @@ import { Module } from '@nestjs/common'
 
 import { GatewayModule } from '~/processors/gateway/gateway.module'
 
+import { ContentMigrationCommitService } from '../content-migration/content-migration-commit.service'
 import { DraftModule } from '../draft/draft.module'
 import { EnrichmentModule } from '../enrichment/enrichment.module'
 import { PageController } from './page.controller'
@@ -11,7 +12,7 @@ import { PageService } from './page.service'
 @Module({
   imports: [GatewayModule, DraftModule, EnrichmentModule],
   controllers: [PageController],
-  providers: [PageService, PageRepository],
+  providers: [PageService, PageRepository, ContentMigrationCommitService],
   exports: [PageService, PageRepository],
 })
 export class PageModule {}

--- a/apps/core/src/modules/page/page.schema.ts
+++ b/apps/core/src/modules/page/page.schema.ts
@@ -2,6 +2,7 @@ import { createZodDto } from 'nestjs-zod'
 import { z } from 'zod'
 
 import { zCoerceInt, zEntityId, zNonEmptyString, zPrefer } from '~/common/zod'
+import { MarkdownToLexicalMigrationDescriptorSchema } from '~/modules/content-migration/content-migration.schema'
 import {
   validateLexicalCreateContentPair,
   validateLexicalPartialContentPair,
@@ -24,6 +25,7 @@ const PageBaseSchema = WriteBaseSchema.extend({
   images: ImageArraySchema.optional(),
   /** ID of the associated draft; marked as published when this page is published */
   draftId: zEntityId.optional(),
+  migration: MarkdownToLexicalMigrationDescriptorSchema.optional(),
 })
 
 export const PageSchema = PageBaseSchema.superRefine(

--- a/apps/core/src/modules/page/page.service.ts
+++ b/apps/core/src/modules/page/page.service.ts
@@ -1,9 +1,16 @@
-import { forwardRef, Inject, Injectable } from '@nestjs/common'
+import {
+  BadRequestException,
+  forwardRef,
+  Inject,
+  Injectable,
+} from '@nestjs/common'
 import { omit } from 'es-toolkit/compat'
 import slugify from 'slugify'
 
 import { AppErrorCode, createAppException } from '~/common/errors'
 import { BusinessEvents, EventScope } from '~/constants/business-event.constant'
+import type { MarkdownToLexicalMigrationDescriptor } from '~/modules/content-migration/content-migration.schema'
+import { ContentMigrationCommitService } from '~/modules/content-migration/content-migration-commit.service'
 import { FileReferenceType } from '~/modules/file/file-reference.enum'
 import { FileReferenceService } from '~/modules/file/file-reference.service'
 import { EventManagerService } from '~/processors/helper/helper.event.service'
@@ -28,6 +35,7 @@ export class PageService {
     private readonly fileReferenceService: FileReferenceService,
     private readonly eventManager: EventManagerService,
     private readonly lexicalService: LexicalService,
+    private readonly contentMigrationCommitService: ContentMigrationCommitService,
     private readonly enrichmentService: EnrichmentService,
     @Inject(forwardRef(() => DraftService))
     private readonly draftService: DraftService,
@@ -137,11 +145,41 @@ export class PageService {
 
   public async updateById(
     id: string,
-    doc: Partial<PageModel> & { draftId?: string },
+    doc: Partial<PageModel> & {
+      draftId?: string
+      migration?: MarkdownToLexicalMigrationDescriptor
+    },
   ) {
     this.lexicalService.normalizeContentForStorage(doc)
 
-    const { draftId } = doc
+    const { draftId, migration } = doc
+
+    const oldDoc = await this.findById(id)
+    if (!oldDoc) {
+      throw createAppException(AppErrorCode.NO_CONTENT_MODIFIABLE)
+    }
+
+    const isMarkdownToLexical =
+      oldDoc.contentFormat === ContentFormat.Markdown &&
+      doc.contentFormat === ContentFormat.Lexical
+    if (
+      oldDoc.contentFormat === ContentFormat.Lexical &&
+      doc.contentFormat === ContentFormat.Markdown
+    ) {
+      throw new BadRequestException(
+        'Published Lexical content cannot be downgraded to Markdown',
+      )
+    }
+    if (isMarkdownToLexical && !migration) {
+      throw new BadRequestException(
+        'Markdown-to-Lexical writes require a migration descriptor',
+      )
+    }
+    if (migration && !isMarkdownToLexical) {
+      throw new BadRequestException(
+        'Migration descriptor is only valid for Markdown-to-Lexical writes',
+      )
+    }
 
     if (['text', 'title', 'subtitle'].some((key) => isDefined(doc[key]))) {
       doc.modifiedAt = new Date()
@@ -151,7 +189,7 @@ export class PageService {
     }
 
     const patch = omit(doc, PAGE_PROTECTED_KEYS as any) as Partial<PageModel>
-    const newDoc = await this.pageRepository.update(id, {
+    const repositoryPatch = {
       title: patch.title,
       slug: patch.slug,
       subtitle: patch.subtitle,
@@ -164,13 +202,45 @@ export class PageService {
           ? (this.normalizeMeta(patch.meta) as Record<string, unknown> | null)
           : undefined,
       order: patch.order,
-    })
+    }
+    let newDoc
+    if (migration) {
+      if (!doc.content || doc.text === undefined) {
+        throw new BadRequestException(
+          'Lexical migration requires content and text',
+        )
+      }
+      await this.contentMigrationCommitService.commitMarkdownToLexical({
+        refType: DraftRefType.Page,
+        refId: id,
+        descriptor: migration,
+        draftId,
+        patch: repositoryPatch,
+        source: {
+          title: repositoryPatch.title ?? oldDoc.title,
+          subtitle:
+            repositoryPatch.subtitle === undefined
+              ? oldDoc.subtitle
+              : repositoryPatch.subtitle,
+          text: doc.text,
+          content: doc.content,
+          contentFormat: ContentFormat.Lexical,
+          meta:
+            repositoryPatch.meta === undefined
+              ? oldDoc.meta
+              : repositoryPatch.meta,
+        },
+      })
+      newDoc = await this.pageRepository.findById(id)
+    } else {
+      newDoc = await this.pageRepository.update(id, repositoryPatch)
+    }
 
     if (!newDoc) {
       throw createAppException(AppErrorCode.NO_CONTENT_MODIFIABLE)
     }
 
-    if (draftId) {
+    if (draftId && !migration) {
       await this.draftService.markAsPublished(draftId)
     }
 

--- a/apps/core/src/modules/post/post.module.ts
+++ b/apps/core/src/modules/post/post.module.ts
@@ -4,6 +4,7 @@ import { POST_SERVICE_TOKEN } from '~/constants/injection.constant'
 
 import { AiModule } from '../ai/ai.module'
 import { CommentModule } from '../comment/comment.module'
+import { ContentMigrationCommitService } from '../content-migration/content-migration-commit.service'
 import { DraftModule } from '../draft/draft.module'
 import { EnrichmentModule } from '../enrichment/enrichment.module'
 import { MembershipModule } from '../membership/membership.module'
@@ -28,6 +29,7 @@ import { PostService } from './post.service'
   providers: [
     PostRepository,
     PostService,
+    ContentMigrationCommitService,
     { provide: POST_SERVICE_TOKEN, useExisting: PostService },
   ],
   exports: [PostService, PostRepository, POST_SERVICE_TOKEN],

--- a/apps/core/src/modules/post/post.schema.ts
+++ b/apps/core/src/modules/post/post.schema.ts
@@ -10,6 +10,7 @@ import {
   zPinDate,
   zPrefer,
 } from '~/common/zod'
+import { MarkdownToLexicalMigrationDescriptorSchema } from '~/modules/content-migration/content-migration.schema'
 import { createPagerSchema } from '~/shared/dto/pager.dto'
 import {
   validateLexicalCreateContentPair,
@@ -41,6 +42,7 @@ const PostBaseSchema = WriteBaseSchema.extend({
   isPremium: z.boolean().optional(),
   /** ID of the associated draft; marked as published when this post is published */
   draftId: zEntityId.optional(),
+  migration: MarkdownToLexicalMigrationDescriptorSchema.optional(),
 })
 
 export const PostSchema = PostBaseSchema.superRefine(

--- a/apps/core/src/modules/post/post.service.ts
+++ b/apps/core/src/modules/post/post.service.ts
@@ -1,4 +1,8 @@
-import { Injectable, OnApplicationBootstrap } from '@nestjs/common'
+import {
+  BadRequestException,
+  Injectable,
+  OnApplicationBootstrap,
+} from '@nestjs/common'
 import { ModuleRef } from '@nestjs/core'
 import { debounce, omit } from 'es-toolkit/compat'
 import slugify from 'slugify'
@@ -12,6 +16,8 @@ import {
   CATEGORY_SERVICE_TOKEN,
   DRAFT_SERVICE_TOKEN,
 } from '~/constants/injection.constant'
+import type { MarkdownToLexicalMigrationDescriptor } from '~/modules/content-migration/content-migration.schema'
+import { ContentMigrationCommitService } from '~/modules/content-migration/content-migration-commit.service'
 import { FileReferenceType } from '~/modules/file/file-reference.enum'
 import { FileReferenceService } from '~/modules/file/file-reference.service'
 import { EventManagerService } from '~/processors/helper/helper.event.service'
@@ -49,6 +55,7 @@ export class PostService implements OnApplicationBootstrap {
     private readonly eventManager: EventManagerService,
     private readonly slugTrackerService: SlugTrackerService,
     private readonly lexicalService: LexicalService,
+    private readonly contentMigrationCommitService: ContentMigrationCommitService,
     private readonly enrichmentService: EnrichmentService,
     private readonly moduleRef: ModuleRef,
   ) {}
@@ -335,7 +342,10 @@ export class PostService implements OnApplicationBootstrap {
 
   async updateById(
     id: string,
-    data: Partial<PostModel> & { draftId?: string },
+    data: Partial<PostModel> & {
+      draftId?: string
+      migration?: MarkdownToLexicalMigrationDescriptor
+    },
   ) {
     this.lexicalService.normalizeContentForStorage(data)
 
@@ -344,6 +354,10 @@ export class PostService implements OnApplicationBootstrap {
       throw createAppException(AppErrorCode.POST_NOT_FOUND, { id })
     }
 
+    const { draftId, migration } = data
+    const isMarkdownToLexical =
+      oldDocument.contentFormat === ContentFormat.Markdown &&
+      data.contentFormat === ContentFormat.Lexical
     const effectiveIsPremium =
       data.isPremium !== undefined ? data.isPremium : oldDocument.isPremium
     const effectiveContentFormat =
@@ -356,8 +370,25 @@ export class PostService implements OnApplicationBootstrap {
     ) {
       throw createAppException(AppErrorCode.PREMIUM_REQUIRES_LEXICAL)
     }
+    if (
+      oldDocument.contentFormat === ContentFormat.Lexical &&
+      data.contentFormat === ContentFormat.Markdown
+    ) {
+      throw new BadRequestException(
+        'Published Lexical content cannot be downgraded to Markdown',
+      )
+    }
+    if (isMarkdownToLexical && !migration) {
+      throw new BadRequestException(
+        'Markdown-to-Lexical writes require a migration descriptor',
+      )
+    }
+    if (migration && !isMarkdownToLexical) {
+      throw new BadRequestException(
+        'Migration descriptor is only valid for Markdown-to-Lexical writes',
+      )
+    }
 
-    const { draftId } = data
     const { categoryId } = data
     if (categoryId && String(categoryId) !== String(oldDocument.categoryId)) {
       const category = await this.categoryService.findCategoryById(
@@ -395,7 +426,7 @@ export class PostService implements OnApplicationBootstrap {
       : patch.createdAt
     const pinAt =
       (data as any).pin !== undefined ? (data as any).pin : patch.pinAt
-    const updated = await this.postRepository.update(id, {
+    const repositoryPatch = {
       title: patch.title,
       slug: patch.slug,
       createdAt,
@@ -416,9 +447,46 @@ export class PostService implements OnApplicationBootstrap {
       pinAt,
       pinOrder: patch.pinOrder,
       modifiedAt: data.modifiedAt,
-    })
+    }
 
-    if (draftId) {
+    let updated
+    if (migration) {
+      if (!data.content || data.text === undefined) {
+        throw new BadRequestException(
+          'Lexical migration requires content and text',
+        )
+      }
+      await this.contentMigrationCommitService.commitMarkdownToLexical({
+        refType: DraftRefType.Post,
+        refId: id,
+        descriptor: migration,
+        draftId,
+        patch: repositoryPatch,
+        source: {
+          title: repositoryPatch.title ?? oldDocument.title,
+          text: data.text,
+          content: data.content,
+          contentFormat: ContentFormat.Lexical,
+          summary:
+            repositoryPatch.summary === undefined
+              ? oldDocument.summary
+              : repositoryPatch.summary,
+          tags:
+            repositoryPatch.tags === undefined
+              ? oldDocument.tags
+              : repositoryPatch.tags,
+          meta:
+            repositoryPatch.meta === undefined
+              ? oldDocument.meta
+              : repositoryPatch.meta,
+        },
+      })
+      updated = await this.postRepository.findById(id)
+    } else {
+      updated = await this.postRepository.update(id, repositoryPatch)
+    }
+
+    if (draftId && !migration) {
       await this.draftService.markAsPublished(draftId)
     }
 

--- a/apps/core/src/shared/content-format-transition-lock.ts
+++ b/apps/core/src/shared/content-format-transition-lock.ts
@@ -1,0 +1,15 @@
+import { sql } from 'drizzle-orm'
+
+import type { AppDatabase } from '~/processors/database/postgres.provider'
+
+type AppTransaction = Parameters<Parameters<AppDatabase['transaction']>[0]>[0]
+
+export async function acquireContentFormatTransitionLock(
+  tx: AppTransaction,
+  input: { refId: string; refType: string },
+): Promise<void> {
+  const key = `content-format:${input.refType}:${input.refId}`
+  await tx.execute(
+    sql`select pg_advisory_xact_lock(hashtextextended(${key}, 0))`,
+  )
+}

--- a/apps/core/test/src/modules/ai/ai-translation.repository.pg.e2e.spec.ts
+++ b/apps/core/test/src/modules/ai/ai-translation.repository.pg.e2e.spec.ts
@@ -1,25 +1,29 @@
+import { ConflictException } from '@nestjs/common'
 import { drizzle } from 'drizzle-orm/node-postgres'
 import { Pool } from 'pg'
 import { createIsolatedPgDatabase } from 'test/helper/pg-testcontainer'
 import { afterAll, beforeAll, describe, expect, it } from 'vitest'
 
+import { pages } from '~/database/schema'
 import {
   AiTranslationRepository,
   TranslationEntryRepository,
 } from '~/modules/ai/ai-translation/ai-translation.repository'
 import type { AppDatabase } from '~/processors/database/postgres.provider'
 import { SnowflakeService } from '~/shared/id/snowflake.service'
+import { ContentFormat } from '~/shared/types/content-format.type'
 
 describe('ai-translation repositories upsert (real PG, ON CONFLICT)', () => {
   let pool: Pool
   let database: Awaited<ReturnType<typeof createIsolatedPgDatabase>>
+  let db: AppDatabase
   let translationRepo: AiTranslationRepository
   let entryRepo: TranslationEntryRepository
 
   beforeAll(async () => {
     database = await createIsolatedPgDatabase()
     pool = new Pool({ connectionString: database.getConnectionUri() })
-    const db = drizzle(pool) as unknown as AppDatabase
+    db = drizzle(pool) as unknown as AppDatabase
     const snowflake = new SnowflakeService()
     translationRepo = new AiTranslationRepository(db, snowflake)
     entryRepo = new TranslationEntryRepository(db, snowflake)
@@ -68,6 +72,41 @@ describe('ai-translation repositories upsert (real PG, ON CONFLICT)', () => {
 
     const all = await translationRepo.listByRefId(refId)
     expect(all).toHaveLength(1)
+  })
+
+  it('rejects a stale Markdown translation after its source becomes Lexical', async () => {
+    const refId = '424242424242424243'
+    await db.insert(pages).values({
+      id: refId as any,
+      title: 'Lexical page',
+      slug: 'lexical-page',
+      text: 'body',
+      content: '{"root":{"children":[]}}',
+      contentFormat: ContentFormat.Lexical,
+      order: 1,
+    })
+
+    await expect(
+      translationRepo.upsert({
+        hash: 'stale-hash',
+        refId,
+        refType: 'page',
+        lang: 'ja',
+        sourceLang: 'zh',
+        title: 'stale',
+        text: 'stale Markdown',
+        subtitle: null,
+        summary: null,
+        tags: [],
+        sourceModifiedAt: null,
+        aiModel: 'm',
+        aiProvider: 'p',
+        contentFormat: ContentFormat.Markdown,
+        content: null,
+        sourceBlockSnapshots: undefined,
+        sourceMetaHashes: undefined,
+      } as any),
+    ).rejects.toBeInstanceOf(ConflictException)
   })
 
   it('inserts then updates a translation_entries row, preserving sourceUpdatedAt when omitted', async () => {

--- a/apps/core/test/src/modules/content-migration/content-migration-commit.service.spec.ts
+++ b/apps/core/test/src/modules/content-migration/content-migration-commit.service.spec.ts
@@ -1,0 +1,265 @@
+import { mxLexicalToMarkdown } from '@mx-space/editor'
+import { ConflictException } from '@nestjs/common'
+import { describe, expect, it } from 'vitest'
+
+import { aiTranslations, drafts, posts } from '~/database/schema'
+import type { MarkdownToLexicalMigrationDescriptor } from '~/modules/content-migration/content-migration.schema'
+import { analyzeMigrationMarkdown } from '~/modules/content-migration/content-migration.utils'
+import { ContentMigrationCommitService } from '~/modules/content-migration/content-migration-commit.service'
+import { DraftRefType } from '~/modules/draft/draft.enum'
+import { LexicalService } from '~/processors/helper/helper.lexical.service'
+import { ContentFormat } from '~/shared/types/content-format.type'
+
+interface FakeState {
+  draft: Record<string, any> | null
+  source: Record<string, any>
+  translations: Array<Record<string, any>>
+}
+
+function createTransactionalDatabase(initial: FakeState) {
+  let committed = structuredClone(initial)
+  let lockCalls = 0
+
+  return {
+    get lockCalls() {
+      return lockCalls
+    },
+    get state() {
+      return committed
+    },
+    transaction: async (callback: (tx: any) => Promise<void>) => {
+      const working = structuredClone(committed)
+      let translationUpdateIndex = 0
+      const tx = {
+        execute: async () => {
+          lockCalls += 1
+        },
+        select: () => ({
+          from: (table: unknown) => {
+            const rows =
+              table === posts
+                ? [working.source]
+                : table === drafts
+                  ? working.draft
+                    ? [working.draft]
+                    : []
+                  : table === aiTranslations
+                    ? working.translations
+                    : []
+            const builder = {
+              for: async () => structuredClone(rows),
+              limit: () => builder,
+              where: () => builder,
+            }
+            return builder
+          },
+        }),
+        update: (table: unknown) => ({
+          set: (patch: Record<string, unknown>) => ({
+            where: async () => {
+              if (table === posts) {
+                Object.assign(working.source, patch)
+              } else if (table === drafts && working.draft) {
+                Object.assign(working.draft, patch)
+              } else if (table === aiTranslations) {
+                Object.assign(
+                  working.translations[translationUpdateIndex++],
+                  patch,
+                )
+              }
+            },
+          }),
+        }),
+      }
+
+      await callback(tx)
+      committed = working
+    },
+  }
+}
+
+const ref = { refId: '100', refType: DraftRefType.Post }
+const sourceMarkdown = 'Hello\n\nWorld'
+
+function sourceRow() {
+  return {
+    id: '100',
+    title: 'Post',
+    slug: 'post',
+    text: sourceMarkdown,
+    content: null,
+    contentFormat: ContentFormat.Markdown,
+    summary: null,
+    tags: [],
+    meta: { lang: 'en' },
+    modifiedAt: new Date('2026-01-01T00:00:00Z'),
+    createdAt: new Date('2025-01-01T00:00:00Z'),
+  }
+}
+
+function translation(id: string, lang: string, text: string) {
+  return {
+    id,
+    refId: '100',
+    refType: DraftRefType.Post,
+    lang,
+    sourceLang: 'en',
+    title: `Post ${lang}`,
+    text,
+    subtitle: null,
+    summary: null,
+    tags: [],
+    hash: 'legacy-hash',
+    sourceModifiedAt: null,
+    aiModel: null,
+    aiProvider: null,
+    contentFormat: ContentFormat.Markdown,
+    content: null,
+    sourceBlockSnapshots: null,
+    sourceMetaHashes: null,
+    createdAt: new Date('2026-01-02T00:00:00Z'),
+  }
+}
+
+function draftRow() {
+  return {
+    id: '300',
+    refId: '100',
+    refType: DraftRefType.Post,
+    title: 'Post',
+    text: sourceMarkdown,
+    content: null,
+    contentFormat: ContentFormat.Markdown,
+    images: null,
+    meta: null,
+    typeSpecificData: null,
+    history: [],
+    version: 4,
+    publishedVersion: 3,
+    createdAt: new Date('2026-01-01T00:00:00Z'),
+    updatedAt: new Date('2026-01-03T00:00:00Z'),
+  }
+}
+
+function buildCommitInput(
+  translations: Array<Record<string, any>>,
+  includeDraft = true,
+) {
+  const baseline = analyzeMigrationMarkdown(sourceMarkdown, ref)
+  if (baseline.status !== 'convertible') throw new Error('invalid fixture')
+
+  const preconditions: MarkdownToLexicalMigrationDescriptor['preconditions'] = [
+    {
+      kind: 'source',
+      id: '100' as any,
+      hash: analyzeMigrationMarkdown(sourceMarkdown, ref).sourceHash,
+    },
+    ...translations.map((row) => ({
+      kind: 'translation' as const,
+      id: row.id as any,
+      hash: analyzeMigrationMarkdown(row.text, ref, baseline.sourceHash)
+        .sourceHash,
+    })),
+  ]
+  if (includeDraft) {
+    preconditions.push({
+      kind: 'draft',
+      id: '300' as any,
+      hash: analyzeMigrationMarkdown(sourceMarkdown, ref).sourceHash,
+      version: 4,
+    })
+  }
+
+  const content = JSON.stringify(baseline.content)
+  const descriptor: MarkdownToLexicalMigrationDescriptor = {
+    profile: 'yohaku-v1',
+    converterVersion: baseline.converterVersion,
+    sourceMarkdown,
+    sourceHash: baseline.sourceHash,
+    preconditions,
+  }
+
+  return {
+    ...ref,
+    descriptor,
+    draftId: includeDraft ? '300' : undefined,
+    patch: {
+      title: 'Post',
+      text: mxLexicalToMarkdown(content),
+      content,
+      contentFormat: ContentFormat.Lexical,
+      modifiedAt: new Date('2026-07-28T00:00:00Z'),
+    },
+    source: {
+      title: 'Post',
+      text: mxLexicalToMarkdown(content),
+      content,
+      contentFormat: ContentFormat.Lexical as const,
+      summary: null,
+      tags: [],
+      meta: { lang: 'en' },
+    },
+  }
+}
+
+describe('ContentMigrationCommitService', () => {
+  it('atomically migrates source, draft, and translations with aligned block IDs', async () => {
+    const translations = [translation('200', 'zh', '你好\n\n世界')]
+    const database = createTransactionalDatabase({
+      source: sourceRow(),
+      draft: draftRow(),
+      translations,
+    })
+    const service = new ContentMigrationCommitService(
+      database as never,
+      new LexicalService(),
+    )
+
+    await service.commitMarkdownToLexical(buildCommitInput(translations))
+
+    expect(database.state.source.contentFormat).toBe(ContentFormat.Lexical)
+    expect(database.lockCalls).toBe(1)
+    expect(database.state.translations[0].contentFormat).toBe(
+      ContentFormat.Lexical,
+    )
+    expect(database.state.translations[0].sourceBlockSnapshots).toHaveLength(2)
+    expect(database.state.draft).toMatchObject({
+      contentFormat: ContentFormat.Lexical,
+      publishedVersion: 5,
+      version: 5,
+    })
+
+    const sourceBlocks = JSON.parse(database.state.source.content).root.children
+    const translationBlocks = JSON.parse(database.state.translations[0].content)
+      .root.children
+    expect(sourceBlocks.map((block: any) => block.$.blockId)).toEqual(
+      translationBlocks.map((block: any) => block.$.blockId),
+    )
+  })
+
+  it('rolls back earlier translation writes when a later precondition is stale', async () => {
+    const originalTranslations = [
+      translation('200', 'zh', '你好\n\n世界'),
+      translation('201', 'ja', 'こんにちは\n\n世界'),
+    ]
+    const input = buildCommitInput(originalTranslations, false)
+    const database = createTransactionalDatabase({
+      source: sourceRow(),
+      draft: null,
+      translations: [
+        originalTranslations[0],
+        { ...originalTranslations[1], text: 'changed after dry-run' },
+      ],
+    })
+    const before = structuredClone(database.state)
+    const service = new ContentMigrationCommitService(
+      database as never,
+      new LexicalService(),
+    )
+
+    await expect(service.commitMarkdownToLexical(input)).rejects.toBeInstanceOf(
+      ConflictException,
+    )
+    expect(database.state).toEqual(before)
+  })
+})

--- a/apps/core/test/src/modules/content-migration/content-migration.service.spec.ts
+++ b/apps/core/test/src/modules/content-migration/content-migration.service.spec.ts
@@ -1,0 +1,207 @@
+import { BadRequestException } from '@nestjs/common'
+import { describe, expect, it, vi } from 'vitest'
+
+import { ContentMigrationService } from '~/modules/content-migration/content-migration.service'
+import { DraftRefType } from '~/modules/draft/draft.enum'
+
+function translation(overrides: Record<string, unknown> = {}) {
+  return {
+    id: '200',
+    refId: '100',
+    refType: DraftRefType.Post,
+    lang: 'en',
+    sourceLang: 'zh',
+    title: 'Title',
+    text: 'Hello\n\nWorld',
+    subtitle: null,
+    summary: null,
+    tags: [],
+    hash: 'source-hash',
+    sourceModifiedAt: null,
+    aiModel: null,
+    aiProvider: null,
+    contentFormat: 'markdown',
+    content: null,
+    sourceBlockSnapshots: null,
+    sourceMetaHashes: null,
+    createdAt: new Date('2026-01-01T00:00:00Z'),
+    ...overrides,
+  }
+}
+
+function createService(
+  options: {
+    source?: Record<string, unknown> | null
+    draft?: Record<string, unknown> | null
+    translations?: Record<string, unknown>[]
+  } = {},
+) {
+  const postService = {
+    findById: vi.fn().mockResolvedValue(
+      options.source === undefined
+        ? {
+            id: '100',
+            text: '你好\n\n世界',
+            content: null,
+            contentFormat: 'markdown',
+            modifiedAt: new Date('2026-01-01T00:00:00Z'),
+          }
+        : options.source,
+    ),
+  }
+  const noteService = { findById: vi.fn() }
+  const pageService = { findById: vi.fn() }
+  const draftService = {
+    findById: vi.fn().mockResolvedValue(options.draft ?? null),
+  }
+  const translationRepository = {
+    listByRefId: vi
+      .fn()
+      .mockResolvedValue(options.translations ?? [translation()]),
+  }
+
+  const service = new ContentMigrationService(
+    postService as never,
+    noteService as never,
+    pageService as never,
+    draftService as never,
+    translationRepository as never,
+  )
+
+  return {
+    service,
+    postService,
+    draftService,
+    translationRepository,
+  }
+}
+
+const request = {
+  refType: DraftRefType.Post,
+  refId: '100',
+  sourceText: '你好\n\n世界',
+  profile: 'yohaku-v1' as const,
+}
+
+describe('ContentMigrationService', () => {
+  it('dry-runs source and translations with aligned deterministic block IDs', async () => {
+    const { service, postService, translationRepository } = createService()
+
+    const result = await service.dryRunMarkdownToLexical(request)
+
+    expect(result.status).toBe('convertible')
+    expect(result.issues).toEqual([])
+    expect(result.translations).toHaveLength(1)
+    expect(result.translations[0].alignment).toEqual({
+      sourceBlockCount: 2,
+      translationBlockCount: 2,
+      alignedBlockCount: 2,
+    })
+
+    expect(result.source.status).toBe('convertible')
+    expect(result.translations[0].result.status).toBe('convertible')
+    if (
+      result.source.status === 'convertible' &&
+      result.translations[0].result.status === 'convertible'
+    ) {
+      const sourceBlocks = result.source.content.root.children as any[]
+      const translationBlocks = result.translations[0].result.content.root
+        .children as any[]
+      expect(sourceBlocks.map((block) => block.$.blockId)).toEqual(
+        translationBlocks.map((block) => block.$.blockId),
+      )
+    }
+
+    expect(result.preconditions.map((item) => item.kind)).toEqual([
+      'source',
+      'translation',
+    ])
+    expect(postService.findById).toHaveBeenCalledWith('100')
+    expect(translationRepository.listByRefId).toHaveBeenCalledWith('100')
+  })
+
+  it('attributes an unsupported translation blocker to its language and row', async () => {
+    const { service } = createService({
+      translations: [translation({ text: '<Tabs>legacy</Tabs>' })],
+    })
+
+    const result = await service.dryRunMarkdownToLexical(request)
+
+    expect(result.status).toBe('blocked')
+    expect(result.issues).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          code: 'unsupported-raw-html',
+          member: 'translation',
+          memberId: '200',
+          lang: 'en',
+        }),
+      ]),
+    )
+    expect(result.source.status).toBe('convertible')
+  })
+
+  it('blocks migration when translated root blocks cannot align to the source', async () => {
+    const { service } = createService({
+      translations: [translation({ text: 'Only one block' })],
+    })
+
+    const result = await service.dryRunMarkdownToLexical(request)
+
+    expect(result.status).toBe('blocked')
+    expect(result.issues).toContainEqual(
+      expect.objectContaining({
+        code: 'translation-structure-mismatch',
+        details: {
+          sourceBlockCount: 2,
+          translationBlockCount: 1,
+          alignedBlockCount: 1,
+        },
+        member: 'translation',
+      }),
+    )
+  })
+
+  it('checks stable non-translatable block properties, not only node type and index', async () => {
+    const { service } = createService({
+      source: {
+        id: '100',
+        text: '```ts\nconst answer = 42\n```',
+        content: null,
+        contentFormat: 'markdown',
+      },
+      translations: [translation({ text: '```ts\nconst answer = 7\n```' })],
+    })
+
+    const result = await service.dryRunMarkdownToLexical({
+      ...request,
+      sourceText: '```ts\nconst answer = 42\n```',
+    })
+
+    expect(result.status).toBe('blocked')
+    expect(result.issues).toContainEqual(
+      expect.objectContaining({
+        code: 'translation-structure-mismatch',
+        details: expect.objectContaining({ alignedBlockCount: 0 }),
+      }),
+    )
+  })
+
+  it('rejects a draft precondition that belongs to another document', async () => {
+    const { service } = createService({
+      draft: {
+        id: '300',
+        refId: '999',
+        refType: DraftRefType.Post,
+        text: 'Draft',
+        content: null,
+        contentFormat: 'markdown',
+        version: 4,
+      },
+    })
+
+    await expect(
+      service.dryRunMarkdownToLexical({ ...request, draftId: '300' }),
+    ).rejects.toBeInstanceOf(BadRequestException)
+  })
+})

--- a/apps/core/test/src/modules/note/note.service.spec.ts
+++ b/apps/core/test/src/modules/note/note.service.spec.ts
@@ -45,6 +45,9 @@ const createService = () => {
   }
   const eventManager = { emit: vi.fn() }
   const lexicalService = { normalizeContentForStorage: vi.fn() }
+  const contentMigrationCommitService = {
+    commitMarkdownToLexical: vi.fn(),
+  }
   const slugTrackerService = {
     createTracker: vi.fn(),
     findTrackerBySlug: vi.fn(),
@@ -66,6 +69,7 @@ const createService = () => {
     fileReferenceService as any,
     eventManager as any,
     lexicalService as any,
+    contentMigrationCommitService as any,
     slugTrackerService as any,
     aiSlugBackfillService as any,
     enrichmentService as any,

--- a/apps/core/test/src/modules/post/post.service.spec.ts
+++ b/apps/core/test/src/modules/post/post.service.spec.ts
@@ -1,3 +1,4 @@
+import { BadRequestException } from '@nestjs/common'
 import { describe, expect, it, vi } from 'vitest'
 
 import { createPgRepositoryMock, now } from '@/helper/pg-repository-mock'
@@ -7,6 +8,7 @@ import {
   CATEGORY_SERVICE_TOKEN,
   DRAFT_SERVICE_TOKEN,
 } from '~/constants/injection.constant'
+import { DraftRefType } from '~/modules/draft/draft.enum'
 import { FileReferenceType } from '~/modules/file/file-reference.enum'
 import type { PostRepository, PostRow } from '~/modules/post/post.repository'
 import { PostService } from '~/modules/post/post.service'
@@ -78,6 +80,9 @@ const createService = () => {
     deleteAllTracker: vi.fn(),
   }
   const lexicalService = { normalizeContentForStorage: vi.fn() }
+  const contentMigrationCommitService = {
+    commitMarkdownToLexical: vi.fn(),
+  }
   const enrichmentService = { scheduleDocPrefetch: vi.fn() }
   const service = new PostService(
     repository as any,
@@ -87,6 +92,7 @@ const createService = () => {
     eventManager as any,
     slugTrackerService as any,
     lexicalService as any,
+    contentMigrationCommitService as any,
     enrichmentService as any,
     moduleRef as any,
   )
@@ -95,6 +101,7 @@ const createService = () => {
   return {
     categoryService,
     commentService,
+    contentMigrationCommitService,
     draftService,
     fileReferenceService,
     repository,
@@ -104,6 +111,80 @@ const createService = () => {
 }
 
 describe('PostService', () => {
+  it('rejects a direct Markdown-to-Lexical update without a migration descriptor', async () => {
+    const { repository, service } = createService()
+    repository.findById.mockResolvedValue(createPost())
+    repository.findBySlug.mockResolvedValue(createPost())
+
+    await expect(
+      service.updateById('post-1', {
+        title: 'Post',
+        slug: 'post',
+        categoryId: 'cat-1' as any,
+        text: 'body',
+        content: '{"root":{"children":[]}}',
+        contentFormat: ContentFormat.Lexical,
+      }),
+    ).rejects.toBeInstanceOf(BadRequestException)
+    expect(repository.update).not.toHaveBeenCalled()
+  })
+
+  it('rejects downgrading a published Lexical document to Markdown', async () => {
+    const { repository, service } = createService()
+    repository.findById.mockResolvedValue(
+      createPost({
+        content: '{"root":{"children":[]}}',
+        contentFormat: ContentFormat.Lexical,
+      }),
+    )
+
+    await expect(
+      service.updateById('post-1', {
+        text: 'body',
+        contentFormat: ContentFormat.Markdown,
+      }),
+    ).rejects.toBeInstanceOf(BadRequestException)
+    expect(repository.update).not.toHaveBeenCalled()
+  })
+
+  it('delegates a staged migration to the atomic commit boundary', async () => {
+    const { contentMigrationCommitService, draftService, repository, service } =
+      createService()
+    repository.findById.mockResolvedValue(createPost())
+    repository.findBySlug.mockResolvedValue(createPost())
+
+    const descriptor = {
+      profile: 'yohaku-v1' as const,
+      converterVersion: '0.1.0',
+      sourceMarkdown: 'body',
+      sourceHash: 'sha256:source',
+      preconditions: [
+        { kind: 'source' as const, id: 'post-1' as any, hash: 'sha256:old' },
+      ],
+    }
+    await service.updateById('post-1', {
+      title: 'Post',
+      slug: 'post',
+      categoryId: 'cat-1' as any,
+      text: 'body',
+      content: '{"root":{"children":[]}}',
+      contentFormat: ContentFormat.Lexical,
+      migration: descriptor,
+    })
+
+    expect(
+      contentMigrationCommitService.commitMarkdownToLexical,
+    ).toHaveBeenCalledWith(
+      expect.objectContaining({
+        refType: DraftRefType.Post,
+        refId: 'post-1',
+        descriptor,
+      }),
+    )
+    expect(repository.update).not.toHaveBeenCalled()
+    expect(draftService.markAsPublished).not.toHaveBeenCalled()
+  })
+
   it('creates posts through the PG repository after category and slug validation', async () => {
     const { repository, service } = createService()
     repository.findBySlug.mockResolvedValue(null)

--- a/docs/superpowers/specs/2026-07-28-admin-markdown-to-lexical-progressive-migration-design.md
+++ b/docs/superpowers/specs/2026-07-28-admin-markdown-to-lexical-progressive-migration-design.md
@@ -1,0 +1,1167 @@
+# Admin Progressive Markdown-to-Lexical Migration — Design
+
+**Date:** 2026-07-28
+**Status:** Draft (awaiting review)
+**Scope:** `packages/editor`, `apps/admin`, `apps/core`, `packages/db-schema`, and Yohaku
+**Related:** `docs/superpowers/specs/2026-06-08-lexical-text-ownership-design.md`, `docs/superpowers/specs/2026-05-24-lexical-block-partial-translation-design.md`
+
+## 1. Summary
+
+Admin currently supports both Markdown and Lexical documents, but an existing
+non-empty Markdown document cannot switch to Lexical. The format control is
+replaced by an unavailable-state help affordance as soon as the editor contains
+content.
+
+This design replaces that global prohibition with progressive, document-level
+migration:
+
+- every non-empty Markdown document exposes a highlighted, interactive
+  **Convert to Lexical** action;
+- eligibility is computed from the syntax actually present in that document,
+  not from whether every historical Yohaku Markdown feature has a Lexical
+  equivalent;
+- a document is convertible only when every syntax region in its migration
+  unit has a behavior-preserving mapping;
+- unsupported documents remain Markdown and receive source-located
+  diagnostics; their conversion action remains interactive;
+- conversion in the editor changes the active editing buffer and draft, but
+  does not publish content by itself;
+- the published document and all existing AI translations transition to
+  Lexical atomically when the converted document is saved;
+- Markdown draft history remains an immutable audit record;
+- `text` remains the writer-owned Markdown projection of Lexical `content`.
+
+The initial release intentionally supports a useful subset of the current
+Markdown grammar. Unsupported features do not block the release and do not
+block documents that do not use them.
+
+## 2. Decision
+
+The migration gate is per migration unit, not global.
+
+> A Markdown document may migrate when every syntax region used by the active
+> source buffer and every coupled AI translation can be converted without
+> silent semantic or behavioral degradation.
+
+The following are explicit consequences:
+
+| Question                                                                     | Decision                  |
+| ---------------------------------------------------------------------------- | ------------------------- |
+| Must every Yohaku Markdown feature be supported before release?              | No.                       |
+| May a document containing only supported syntax migrate?                     | Yes.                      |
+| Is the conversion action disabled for an unsupported document?               | No; it opens diagnostics. |
+| May unsupported syntax be flattened to text?                                 | No.                       |
+| May the source become Lexical while a valid AI translation remains Markdown? | No.                       |
+| Does clicking the conversion action publish the document?                    | No.                       |
+| May the active draft become Lexical before the published source does?        | Yes.                      |
+| Are historical draft snapshots rewritten?                                    | No.                       |
+| Is general Lexical-to-Markdown format switching added?                       | No.                       |
+
+## 3. Current State
+
+### 3.1 Admin
+
+`WriteRouteViewsContent.tsx` owns a dual-format form state:
+
+- `contentFormat: 'markdown' | 'lexical'`;
+- `text` for Markdown content and the Lexical Markdown projection;
+- `content` for serialized Lexical JSON.
+
+The current switch rule is content-based:
+
+```ts
+const canSwitchEditorType =
+  state.contentFormat === 'lexical'
+    ? !hasLexicalContent(state.content)
+    : !state.text.trim()
+```
+
+When `canSwitchEditorType` is false, `EditorMetaStrip` removes the format action
+and renders a help popover explaining that switching is unavailable. Lexical
+writes are projected through `mxLexicalToMarkdown()` before save.
+
+Draft autosave runs independently from the published save path. A design that
+stages a Lexical editor state must therefore define how draft persistence and
+published migration interact.
+
+### 3.2 Core persistence
+
+Posts, notes, pages, drafts, and draft histories already persist:
+
+| Field            | Markdown meaning       | Lexical meaning                  |
+| ---------------- | ---------------------- | -------------------------------- |
+| `content_format` | `markdown`             | `lexical`                        |
+| `text`           | authoritative Markdown | writer-owned Markdown projection |
+| `content`        | absent                 | serialized Lexical state         |
+
+Lexical creates and updates require `content` and `text` to travel as an atomic
+pair. This design preserves that ownership rule.
+
+### 3.3 AI translations
+
+`ai_translations` already stores:
+
+- `content_format` and `content`;
+- the Markdown `text` projection;
+- `source_block_snapshots`;
+- `source_meta_hashes`;
+- the whole-source `hash` and `source_modified_at`.
+
+The translation service selects the Markdown or Lexical strategy from the
+source `contentFormat`. Fresh translations generated after a source is Lexical
+already produce Lexical content. Historical translation rows require explicit
+migration.
+
+### 3.4 Yohaku
+
+Yohaku selects Markdown or Lexical rendering independently for posts, notes,
+and pages. Its Markdown runtime is based on `markdown-to-jsx` plus custom rules,
+custom containers, raw component overrides, and special code-fence behavior.
+
+Yohaku's existing Lexical renderer covers much, but not all, of that behavior.
+Heading anchors, footnote interactions, table alignment, code-fence attributes,
+and several container/component forms require parity work before documents
+using those features become eligible.
+
+### 3.5 Existing Markdown conversion
+
+`@mx-space/editor` currently exposes `mxLexicalToMarkdown()`. Haklex also
+provides Markdown paste transformers, but those transformers are designed for
+editing convenience rather than lossless migration:
+
+- several rich block transformers are export-only;
+- tables lose alignment and inline cell structure;
+- unsupported containers may become literal paragraphs;
+- fenced-code attributes are not preserved;
+- arbitrary HTML and custom React-like elements are not modeled.
+
+The paste path is not a migration path.
+
+## 4. Goals
+
+- Allow supported Markdown documents to migrate before the entire grammar has
+  Lexical coverage.
+- Keep the conversion action visible, highlighted, and interactive for every
+  non-empty Markdown document.
+- Provide exact, source-located explanations for blocked documents.
+- Preserve Yohaku's externally observable rendering and interaction behavior.
+- Prevent silent fallback of unsupported syntax to plain text.
+- Convert the active editing buffer without implicitly publishing it.
+- Keep source, current draft, and AI translation format transitions
+  consistent.
+- Preserve stable root block identity across source and translations.
+- Preserve the `content + text` writer-owned pair.
+- Make dry-run and commit deterministic, versioned, and safe under concurrent
+  edits.
+- Reuse one conversion implementation for Admin preview, Core validation, and
+  later bulk migration.
+
+## 5. Non-goals
+
+- Waiting for every historical Markdown feature to be supported.
+- Byte-identical Markdown round trips.
+- Deleting the `text` column or changing its projection role.
+- Migrating comments, thinking entries, skills, project readmes, summaries, or
+  other Markdown-bearing fields outside the post/note/page write model.
+- Rewriting draft history.
+- Adding a general Lexical-to-Markdown editor switch.
+- Automatically executing arbitrary HTML, style, or script through a new
+  Lexical node.
+- Automatically spending AI quota to regenerate blocked translations in the
+  first release.
+- Removing Yohaku's Markdown renderer in the first release.
+- Shipping a bulk migration interface before per-document migration is stable.
+
+## 6. Terminology
+
+| Term                          | Meaning                                                                                                                           |
+| ----------------------------- | --------------------------------------------------------------------------------------------------------------------------------- |
+| Conversion profile            | A versioned description of source grammar and target-node behavior; initially `yohaku-v1`.                                        |
+| Syntax feature                | A recognized Markdown construct such as `inline.spoiler` or `container.gallery`.                                                  |
+| Supported feature             | A feature with a behavior-preserving parser, target node, projection, and Yohaku renderer.                                        |
+| Blocking issue                | A source range that cannot be converted without loss or unsafe fallback.                                                          |
+| Active source buffer          | The Markdown currently visible in Admin, including unsaved or draft-backed edits.                                                 |
+| Published source              | The persisted post, note, or page currently served publicly.                                                                      |
+| Migration unit                | The active source buffer, selected/current draft, published source transition, and all AI translations for one content reference. |
+| Staged conversion             | A successful conversion loaded into the Lexical editor before the published source has been saved as Lexical.                     |
+| Pure representation migration | A save whose Lexical content is semantically identical to the converted Markdown baseline.                                        |
+| Migration with edits          | A save where the user changed the staged Lexical document before publishing.                                                      |
+
+## 7. Invariants
+
+### 7.1 Document-level eligibility
+
+Global converter completeness is never a prerequisite. Eligibility is computed
+for one migration unit at a time.
+
+### 7.2 Complete source coverage
+
+Every source range must be classified as one of:
+
+- supported syntax;
+- plain text;
+- whitespace/trivia;
+- a blocking unsupported construct.
+
+An unknown container, HTML element, or fence attribute must not disappear into
+a generic paragraph and thereby produce a false `convertible` result.
+
+### 7.3 No silent degradation
+
+Unsupported syntax blocks conversion. It must not be:
+
+- dropped;
+- flattened to text;
+- converted into a visually similar but behaviorally different node;
+- stored in an untyped catch-all node without an explicit future product
+  decision.
+
+### 7.4 Atomic published transition
+
+When a published source transitions from Markdown to Lexical, every valid
+`ai_translations` row for that source must become Lexical in the same database
+transaction. A mixed published state is invalid.
+
+An active draft may be Lexical while the published source is still Markdown.
+Drafts are private editing artifacts and do not determine the public rendering
+or translation strategy.
+
+### 7.5 Writer-owned projection
+
+For every Lexical write:
+
+```text
+content = authoritative serialized Lexical state
+text    = writer-owned Markdown projection of that exact state
+```
+
+Core validates and stores the pair. The migration service is an explicitly
+named internal writer and may derive both fields during translation migration.
+
+### 7.6 Stable block identity
+
+Converted source root blocks receive stable IDs. Converted translation blocks
+copy the ID of the source block to which they are structurally aligned.
+Index-only alignment is insufficient once structures diverge.
+
+### 7.7 Idempotence and concurrency
+
+Re-running dry-run against unchanged inputs returns an equivalent result.
+Commit must fail safely when any source, draft, or translation precondition has
+changed since dry-run.
+
+### 7.8 Historical preservation
+
+Draft histories and migration audit records retain the pre-migration Markdown.
+No automatic rollback overwrites a user's current content.
+
+## 8. Scope and Migration Unit
+
+### 8.1 Eligible source types
+
+The first release supports persisted records whose `contentFormat` is
+`markdown`:
+
+- posts;
+- notes;
+- pages.
+
+Any page represented outside this content-format contract is out of scope.
+
+### 8.2 Coupled records
+
+For a content reference `(refType, refId)`, the migration unit contains:
+
+| Member                      | Eligibility role                                    | Commit behavior                             |
+| --------------------------- | --------------------------------------------------- | ------------------------------------------- |
+| Active Admin source buffer  | Must scan successfully                              | Becomes submitted Lexical source            |
+| Published source            | Must still match the expected persisted version     | Transitions to Lexical on save              |
+| Selected/current live draft | Must remain compatible with the active buffer       | May autosave as Lexical before publish      |
+| AI translation rows         | Every Markdown row must scan and structurally align | Transition atomically with published source |
+| Draft history               | None                                                | Remains unchanged                           |
+
+No translation rows is a valid migration unit.
+
+### 8.3 Translation strictness
+
+The first release does not automatically regenerate a translation to make the
+source eligible. If one translation cannot be converted or aligned, the unit
+is blocked and diagnostics identify the language and source range.
+
+A later release may add an explicit “discard and regenerate this translation”
+decision. That is not implicit behavior.
+
+## 9. Architecture
+
+```mermaid
+flowchart TD
+  Buffer[Admin Markdown Buffer] --> DryRun[Migration Dry-run API]
+  Stored[Published Source and Draft] --> DryRun
+  Translations[AI Translation Rows] --> DryRun
+
+  DryRun --> Converter[yohaku-v1 Converter]
+  Converter --> Eligibility{Entire Unit Eligible?}
+
+  Eligibility -->|No| Diagnostics[Source-located Diagnostics]
+  Diagnostics --> Action[Highlighted Conversion Action]
+
+  Eligibility -->|Yes| Preview[Serialized Lexical Preview]
+  Preview --> Editor[Lexical Editor and Draft Autosave]
+  Editor --> Save[Published Save with Migration Preconditions]
+
+  Save --> Commit[ContentMigrationService Transaction]
+  Commit --> SourceWrite[Source content plus text]
+  Commit --> TranslationWrite[Lexical Translations and Snapshots]
+  Commit --> Audit[Migration Audit Record]
+
+  SourceWrite --> PostCommit[Cache, Search, Enrichment, Events]
+  TranslationWrite --> PostCommit
+  PostCommit --> Yohaku[Yohaku Lexical Renderer]
+```
+
+### 9.1 Ownership
+
+| Component            | Responsibility                                                                                                                  |
+| -------------------- | ------------------------------------------------------------------------------------------------------------------------------- |
+| `packages/editor`    | Pure grammar scanning, conversion, diagnostics, projection, and structural alignment primitives                                 |
+| `apps/admin`         | Current buffer ownership, conversion affordance, diagnostics UI, staged editor state, and migration metadata on save            |
+| `apps/core`          | Authoritative dry-run, concurrency validation, transactional persistence, audit, translation migration, and post-commit effects |
+| `packages/db-schema` | Optional migration audit persistence                                                                                            |
+| Yohaku               | Runtime behavioral parity for converted nodes                                                                                   |
+
+React components do not own grammar rules or database migration logic.
+
+## 10. Conversion Profile
+
+### 10.1 Public API
+
+`@mx-space/editor` adds a DOM-free entrypoint:
+
+```ts
+export type MarkdownConversionProfile = 'yohaku-v1'
+
+export interface MarkdownSourceRange {
+  start: { line: number; column: number; offset: number }
+  end: { line: number; column: number; offset: number }
+}
+
+export interface MarkdownConversionIssue {
+  code: string
+  feature: string
+  message: string
+  range: MarkdownSourceRange
+  severity: 'blocking'
+  details?: Record<string, unknown>
+}
+
+export interface MarkdownFeatureOccurrence {
+  feature: string
+  range: MarkdownSourceRange
+  targetNode?: string
+}
+
+export type MarkdownConversionResult =
+  | {
+      status: 'convertible'
+      converterVersion: string
+      profile: MarkdownConversionProfile
+      sourceHash: string
+      features: MarkdownFeatureOccurrence[]
+      content: SerializedMxEditorState
+      text: string
+    }
+  | {
+      status: 'blocked'
+      converterVersion: string
+      profile: MarkdownConversionProfile
+      sourceHash: string
+      features: MarkdownFeatureOccurrence[]
+      issues: MarkdownConversionIssue[]
+    }
+
+export function analyzeMxMarkdown(
+  markdown: string,
+  options: {
+    profile: MarkdownConversionProfile
+    blockIdFactory?: (path: string) => string
+  },
+): MarkdownConversionResult
+```
+
+Conversion and analysis are one operation. A separate boolean
+`canConvertMarkdown()` API is prohibited because it would encourage eligibility
+logic to diverge from actual conversion.
+
+### 10.2 Runtime constraints
+
+The converter must be:
+
+- deterministic;
+- usable in browsers and Node.js;
+- independent of React and the DOM;
+- explicit about every unsupported construct;
+- able to report source ranges;
+- able to accept a stable root block ID factory;
+- versioned independently from the profile name.
+
+`profile` identifies source semantics. `converterVersion` identifies the exact
+implementation used for a dry-run result. Adding support for a previously
+blocked feature changes `converterVersion` but does not necessarily require a
+new source profile.
+
+### 10.3 Detection order
+
+The parser must recognize high-specificity constructs before generic Markdown:
+
+1. fenced blocks and their raw attributes;
+2. `:::` containers;
+3. raw HTML/component elements;
+4. block KaTeX and GFM alerts;
+5. tables, lists, quotes, headings, footnotes, and other standard blocks;
+6. custom inline tokens;
+7. standard inline Markdown;
+8. plain text and trivia.
+
+This order prevents custom source from being consumed as ordinary paragraphs.
+
+### 10.4 Coverage accounting
+
+The parser records source spans for recognized structural tokens and performs a
+second unsupported-construct scan for patterns that generic Markdown might
+otherwise accept as text:
+
+- unknown `::: name` containers;
+- unregistered HTML-like element names;
+- raw `script` and `style`;
+- custom code-fence attributes;
+- unclosed custom blocks;
+- malformed custom mentions and component tags that the current runtime would
+  partially interpret.
+
+The second scan is a safety layer, not an alternate parser. It may produce
+false-negative eligibility, but must not produce false-positive eligibility.
+
+## 11. Syntax and Behavior Matrix
+
+The matrix is based on Yohaku's runtime parser and renderer rather than
+documentation-only examples.
+
+### 11.1 Standard Markdown
+
+| Source feature                  | Target                                          | Initial status                                 | Required behavior                                      |
+| ------------------------------- | ----------------------------------------------- | ---------------------------------------------- | ------------------------------------------------------ |
+| Paragraph and line break        | Paragraph/Text nodes                            | Supported                                      | Preserve inline ordering and hard breaks               |
+| ATX and Setext heading          | HeadingNode                                     | Supported after anchor parity                  | Preserve heading level and historical anchor           |
+| Bold, italic, strikethrough     | Text formats                                    | Supported                                      | Preserve nested combinations                           |
+| Inline code                     | Code text format                                | Supported                                      | Preserve literal content                               |
+| Ordered/unordered list          | ListNode/ListItemNode                           | Supported                                      | Preserve start value and nesting                       |
+| Task list                       | Checklist state                                 | Supported                                      | Preserve checked state                                 |
+| Blockquote                      | QuoteNode                                       | Supported                                      | Preserve nested block structure                        |
+| Horizontal rule                 | HorizontalRuleNode                              | Supported                                      | Equivalent rendering                                   |
+| Inline link/autolink/mail link  | Link/AutoLink nodes                             | Supported                                      | Preserve target, title, and standalone-link enrichment |
+| Reference link/image            | Resolved target nodes                           | Supported                                      | Reference syntax may normalize in projection           |
+| Image                           | ImageNode or VideoNode by current runtime rules | Supported after fixture parity                 | Preserve URL, alt/caption, and media detection         |
+| Table without alignment markers | Table nodes                                     | Supported after rich-cell importer             | Preserve inline cell content                           |
+| Table with alignment markers    | Table nodes with alignment state                | Blocked until alignment support                | Preserve left/center/right behavior                    |
+| HTML comment                    | CommentNode                                     | Supported when round-trip behavior is verified | Preserve comment payload                               |
+| Arbitrary raw HTML              | None                                            | Blocked                                        | No silent execution or flattening                      |
+
+### 11.2 Custom inline syntax
+
+| Syntax                         | Current Yohaku behavior                        | Target                                           | Initial status                      |
+| ------------------------------ | ---------------------------------------------- | ------------------------------------------------ | ----------------------------------- |
+| `==text==`                     | Highlight/mark                                 | Highlight text format                            | Supported                           |
+| `++text++`                     | Inserted text                                  | Insert format/node                               | Supported                           |
+| `&#124;&#124;text&#124;&#124;` | Interactive spoiler                            | SpoilerNode                                      | Supported after interaction fixture |
+| `[Display]{GH@name}`           | GitHub social mention                          | MentionNode with platform, account, display name | Supported                           |
+| `{TW@name}`                    | Twitter/X social mention                       | MentionNode                                      | Supported                           |
+| `{TG@name}`                    | Telegram social mention                        | MentionNode                                      | Supported                           |
+| `$equation$`                   | Inline KaTeX                                   | KaTeXInlineNode                                  | Supported                           |
+| `[^id]`                        | Footnote reference with tooltip and navigation | FootnoteNode                                     | Blocked until Yohaku parity         |
+
+Malformed forms that Yohaku renders as literal text remain literal text. The
+converter must not reinterpret a form more aggressively than Yohaku.
+
+### 11.3 Custom block syntax
+
+| Syntax                                                | Current behavior         | Target                        | Initial status                           |
+| ----------------------------------------------------- | ------------------------ | ----------------------------- | ---------------------------------------- |
+| `$$ equation $$`                                      | Block KaTeX              | KaTeXBlockNode                | Supported                                |
+| `> [!NOTE]`, `TIP`, `IMPORTANT`, `WARNING`, `CAUTION` | GFM alert quote          | AlertQuoteNode                | Supported after nested-block parity      |
+| `::: gallery`                                         | Image gallery            | GalleryNode                   | Supported after source extraction parity |
+| `::: carousel`                                        | Carousel gallery         | GalleryNode with layout       | Supported after layout field             |
+| `::: banner {type}`                                   | Rich banner              | BannerNode                    | Supported                                |
+| `::: note/info/success/warn/warning/error/danger`     | Banner aliases           | Normalized BannerNode         | Supported                                |
+| `::: grid {cols,gap,rows,type}`                       | Content/image grid       | GridContainerNode             | Blocked until node and renderer exist    |
+| `::: masonry {gap}`                                   | Responsive image masonry | MasonryNode or Gallery layout | Blocked until node and renderer exist    |
+| Unknown `:::` container                               | Undefined/custom         | None                          | Blocked with source range                |
+
+Banner alias normalization must match Yohaku:
+
+| Source alias                 | Target type |
+| ---------------------------- | ----------- |
+| `note`, `info`               | `note`      |
+| `success`, `tip`             | `tip`       |
+| `important`                  | `important` |
+| `warn`, `warning`            | `warning`   |
+| `error`, `danger`, `caution` | `caution`   |
+
+### 11.4 Raw component syntax
+
+| Source                    | Target                             | Initial status                             | Required behavior                                      |
+| ------------------------- | ---------------------------------- | ------------------------------------------ | ------------------------------------------------------ |
+| `<details><summary>...`   | DetailsNode                        | Supported after nested Markdown parity     | Preserve summary, open/print behavior, and children    |
+| `<Tabs><tab label="...">` | TabsNode with nested editor states | Blocked                                    | Preserve ordered panels and labels                     |
+| `<video ...>`             | VideoNode                          | Supported after attribute parity           | Preserve src, poster, size, and controls behavior      |
+| `<LinkCard ...>`          | LinkCardNode                       | Supported only for recognized current form | Legacy or unknown props block                          |
+| `<Gallery ...>`           | GalleryNode                        | Supported only for a validated prop shape  | Unknown props block                                    |
+| `<tag>`                   | TagNode                            | Supported after projection fixture         | Preserve inline behavior                               |
+| `<style>`                 | None                               | Blocked                                    | Requires a separate security decision                  |
+| `<script>`                | None                               | Blocked                                    | Current execution behavior is not inherited implicitly |
+| Unknown element           | None                               | Blocked                                    | Report element name and range                          |
+
+### 11.5 Fenced code
+
+| Fence                                                               | Target                         | Initial status                  | Required behavior                               |
+| ------------------------------------------------------------------- | ------------------------------ | ------------------------------- | ----------------------------------------------- |
+| Ordinary language                                                   | CodeBlockNode                  | Supported                       | Preserve language and exact code                |
+| `mermaid`                                                           | MermaidNode                    | Supported after renderer parity | Preserve diagram source                         |
+| `excalidraw`                                                        | ExcalidrawNode                 | Supported after JSON validation | Preserve snapshot                               |
+| `component`                                                         | Dedicated component/DLS node   | Blocked                         | Preserve catalog policy, source, and attributes |
+| Fence with `shadow`, `with-styles`, collapse, or unknown attributes | CodeBlockNode with typed attrs | Blocked until schema exists     | Do not drop attributes                          |
+
+## 12. Behavioral Parity Requirements
+
+Node construction alone is insufficient. A feature is marked supported only
+when Yohaku's Lexical renderer satisfies its observable contract.
+
+### 12.1 Heading anchors
+
+Markdown currently generates heading IDs in the form `index__slug` while the
+Lexical renderer generates `slug`. Existing inbound links must remain valid.
+
+Migrated HeadingNodes therefore carry `legacyAnchorId`, or the renderer emits a
+legacy alias anchor. New Lexical-only documents may use the canonical slug
+strategy with duplicate disambiguation.
+
+### 12.2 Standalone links
+
+A paragraph containing only a bare URL currently receives enriched block-link
+rendering. Converted content must continue to enter that path.
+
+### 12.3 Footnotes
+
+Parity includes:
+
+- tooltip content;
+- click-to-scroll;
+- target highlight;
+- stable reference and definition IDs;
+- the existing self-link LinkCard behavior.
+
+Footnotes remain blocked until these behaviors are present in the Lexical path.
+
+### 12.4 Tables
+
+Parity includes:
+
+- header state;
+- column alignment;
+- inline formatting inside cells;
+- links and code inside cells;
+- row and cell ordering.
+
+### 12.5 Code blocks
+
+Parity includes:
+
+- language;
+- exact code;
+- raw attributes;
+- Mermaid and Excalidraw special rendering;
+- component/DLS security policy.
+
+### 12.6 Raw scripts
+
+The current Markdown article renderer may execute `script` when
+`allowsScript` is enabled. This is not automatically carried into Lexical.
+Documents containing script remain blocked until a separate security design
+chooses one of:
+
+- permanent rejection;
+- a narrowly allowlisted script node;
+- an isolated legacy rendering boundary.
+
+## 13. Dry-run Contract
+
+### 13.1 Endpoint
+
+Core adds an admin-only endpoint conceptually shaped as:
+
+```text
+POST /admin/content-migrations/markdown-to-lexical/dry-run
+```
+
+Request:
+
+```ts
+interface MarkdownMigrationDryRunRequest {
+  refType: 'post' | 'note' | 'page'
+  refId: string
+  draftId?: string
+  sourceText: string
+  profile: 'yohaku-v1'
+}
+```
+
+`sourceText` is required because the active Admin buffer may contain edits not
+yet present in the published row or autosaved draft.
+
+Core reads the published source, relevant draft metadata, and all translation
+rows. The client does not submit translation content.
+
+### 13.2 Response
+
+```ts
+interface MigrationMemberPrecondition {
+  kind: 'source' | 'draft' | 'translation'
+  id: string
+  hash: string
+  version?: number
+}
+
+interface MarkdownMigrationDryRunResponse {
+  status: 'convertible' | 'blocked'
+  profile: 'yohaku-v1'
+  converterVersion: string
+  sourceHash: string
+  preconditions: MigrationMemberPrecondition[]
+  source: MarkdownConversionResult
+  translations: Array<{
+    id: string
+    lang: string
+    result: MarkdownConversionResult
+    alignment?: {
+      sourceBlockCount: number
+      translationBlockCount: number
+      alignedBlockCount: number
+    }
+  }>
+  issues: Array<
+    MarkdownConversionIssue & {
+      member: 'source' | 'draft' | 'translation'
+      memberId: string
+      lang?: string
+    }
+  >
+}
+```
+
+A blocked dry-run returns HTTP 200. Unsupported content is an expected product
+state, not a transport error.
+
+### 13.3 Side-effect boundary
+
+Dry-run:
+
+- performs no database write;
+- creates no AI task;
+- changes no source or translation freshness state;
+- does not update `modifiedAt`;
+- does not emit content events;
+- does not log raw document text.
+
+## 14. Translation Alignment
+
+### 14.1 Baseline source
+
+The dry-run converts `sourceText` into baseline Lexical content and assigns
+stable root block IDs using a migration-specific ID factory keyed by:
+
+- ref type;
+- ref ID;
+- source hash;
+- root structural path.
+
+The exact ID representation may use UUIDv5 or another collision-resistant
+deterministic scheme. The externally important property is that Admin and Core
+produce the same IDs for the same dry-run inputs.
+
+### 14.2 Translation conversion
+
+Each Markdown translation is converted independently. Its root blocks are then
+aligned with baseline source blocks.
+
+Alignment may use:
+
+- structural node type;
+- root path/order as an initial candidate;
+- translatable segment/property shape;
+- stable non-translatable properties;
+- an LCS-style sequence match when insertions or deletions exist.
+
+Index equality alone is not sufficient.
+
+### 14.3 Alignment outcome
+
+| Outcome                                        | Eligibility                                                                           |
+| ---------------------------------------------- | ------------------------------------------------------------------------------------- |
+| Every translated root block maps unambiguously | Eligible                                                                              |
+| Source block has no translated counterpart     | Eligible only if existing partial-translation semantics can represent source fallback |
+| Translated block has no source counterpart     | Blocked in the first release                                                          |
+| Multiple source blocks are equally plausible   | Blocked                                                                               |
+| Segment/property shape is incompatible         | Blocked                                                                               |
+
+Aligned translated blocks copy the corresponding source `blockId`.
+
+### 14.4 Freshness after save
+
+If the submitted Lexical source is identical to the dry-run baseline:
+
+- migrated translations receive the current source hash;
+- source block snapshots are built from the migrated source;
+- source meta hashes are recomputed;
+- translations remain fresh.
+
+If the user edits the staged Lexical source before save:
+
+- translations are still persisted as Lexical;
+- their snapshots describe the dry-run baseline;
+- changed source blocks are treated as stale by the existing partial
+  translation path;
+- regeneration is scheduled through the existing stale-translation mechanism;
+- no migrated row reverts to Markdown.
+
+## 15. Admin Interaction Design
+
+### 15.1 Format action states
+
+`EditorMetaStrip` replaces `canSwitchFormat` with an explicit action model:
+
+```ts
+type FormatActionState =
+  | { type: 'empty-switch' }
+  | { type: 'migration-available' }
+  | { type: 'migration-checking' }
+  | { type: 'migration-blocked'; issueCount: number }
+  | { type: 'migration-staged' }
+  | { type: 'migration-committing' }
+  | { type: 'lexical' }
+```
+
+| State                         | Visual behavior                                | Interaction                                             |
+| ----------------------------- | ---------------------------------------------- | ------------------------------------------------------- |
+| Empty Markdown                | Neutral format switch                          | Switch immediately                                      |
+| Non-empty Markdown, unchecked | Highlighted “Convert to Lexical”               | Run dry-run                                             |
+| Checking                      | Highlighted loading state                      | Prevent duplicate requests only                         |
+| Convertible                   | Transition into Lexical editor                 | Preserve original Markdown migration metadata           |
+| Blocked                       | Warning highlight with issue count             | Open or reopen diagnostics                              |
+| Staged                        | Lexical active plus “Not yet published” status | Edit, autosave draft, or restore this staged conversion |
+| Committing                    | Progress state                                 | Prevent duplicate save                                  |
+| Published Lexical             | Normal Lexical format indicator                | No Markdown format switch                               |
+
+The highlighted migration affordance must not reuse the visual selected state
+of an already-Lexical document. It represents an action, not current format.
+
+### 15.2 Click behavior
+
+For non-empty Markdown:
+
+1. send the active `sourceText` to dry-run;
+2. if blocked, retain the Markdown editor and open diagnostics;
+3. if convertible, load the returned source `content` into the Lexical editor;
+4. retain the original Markdown, converter version, source hash, and
+   preconditions in ephemeral migration state;
+5. mark the draft dirty and allow the existing draft autosave to persist
+   `content + text + contentFormat: lexical`;
+6. do not update the published source until the normal save action.
+
+### 15.3 Draft behavior
+
+A Lexical draft backed by a Markdown published source is valid. It represents a
+staged format transition.
+
+Draft autosave stores the active Lexical pair but does not migrate AI
+translations. AI translations are coupled to the published source, not the
+private draft.
+
+If the page reloads and Admin restores a Lexical draft over a Markdown source,
+the write view reconstructs a staged migration state and reruns dry-run before
+the next published save.
+
+### 15.4 Restore before publish
+
+While the published source remains Markdown, Admin may expose
+“Restore original Markdown” for this staged conversion. This action restores
+the captured source buffer; it is not a general Lexical-to-Markdown converter.
+
+After the published source is Lexical, the restore action disappears. Any
+rollback then uses an explicit migration-audit workflow and requires separate
+user confirmation.
+
+### 15.5 Diagnostics
+
+Diagnostics are grouped by migration member:
+
+```text
+Source
+  line 18–31   ::: masonry        unsupported layout node
+
+AI translation: ja
+  line 47      <script>           unsafe raw script
+```
+
+The panel supports:
+
+- click-to-source for active-buffer issues;
+- language and translation-row identification;
+- issue code and required capability;
+- recheck after converter upgrades;
+- no disabled dead end.
+
+## 16. Published Save and Commit
+
+### 16.1 Save payload
+
+The existing post/note/page write payload carries an optional migration
+descriptor when the persisted source is Markdown and the submitted source is
+Lexical:
+
+```ts
+interface MarkdownToLexicalMigrationDescriptor {
+  profile: 'yohaku-v1'
+  converterVersion: string
+  sourceMarkdown: string
+  sourceHash: string
+  preconditions: MigrationMemberPrecondition[]
+}
+```
+
+`sourceMarkdown` is the exact buffer converted during dry-run. It is not the
+post-conversion `text` projection.
+
+The normal lexical fields remain:
+
+```ts
+{
+  contentFormat: 'lexical',
+  content: serializedLexical,
+  text: markdownProjection,
+  migration: MarkdownToLexicalMigrationDescriptor
+}
+```
+
+### 16.2 Transition detection
+
+Core enters the migration path only when:
+
+```text
+persisted source format = markdown
+submitted source format = lexical
+migration descriptor is present
+```
+
+A direct Markdown-to-Lexical write without the descriptor fails validation.
+This prevents third-party callers from producing a mixed source/translation
+state.
+
+Lexical-to-Lexical writes remain on the normal path.
+
+### 16.3 Transaction
+
+`ContentMigrationService.commitMarkdownToLexical()` performs:
+
+1. authorize the same write permission as the source update;
+2. reload source, linked current draft, and all translations with transaction
+   locks;
+3. verify every dry-run precondition;
+4. rerun source and translation conversion with the named converter version;
+5. validate the submitted Lexical state and `text` projection pair;
+6. normalize and validate source root block IDs;
+7. align and persist every translation as Lexical;
+8. rebuild source block snapshots, source meta hashes, and translation hashes;
+9. update the source and current draft;
+10. insert one migration audit record;
+11. commit;
+12. trigger cache, search, file-reference, enrichment, and event work after
+    commit.
+
+Any failure rolls back the entire published transition.
+
+### 16.4 Pure migration versus edited migration
+
+Core compares the submitted Lexical state with the dry-run baseline using a
+semantic fingerprint that ignores editor-only transient fields.
+
+| Case                          | Timestamp/event behavior                                             |
+| ----------------------------- | -------------------------------------------------------------------- |
+| Pure representation migration | Preserve business `modifiedAt`; emit migration-specific invalidation |
+| Migration plus semantic edits | Apply normal write timestamp and content-update behavior             |
+
+Both cases invalidate render and search caches.
+
+### 16.5 Idempotence
+
+If a retry reaches a source already migrated by the same successful operation,
+Core returns the current source when audit/precondition hashes prove
+equivalence.
+
+A source already Lexical for an unrelated reason returns a conflict rather
+than applying stale migration data.
+
+## 17. Persistence and Audit
+
+The preferred design adds a compact audit table:
+
+```ts
+export const contentMigrationRecords = pgTable('content_migration_records', {
+  id: pkText(),
+  createdAt: createdAt(),
+  refType: text('ref_type').notNull(),
+  refId: refText('ref_id').notNull(),
+  fromFormat: text('from_format').notNull(),
+  toFormat: text('to_format').notNull(),
+  profile: text('profile').notNull(),
+  converterVersion: text('converter_version').notNull(),
+  sourceHash: text('source_hash').notNull(),
+  originalPayload: jsonb('original_payload').notNull(),
+  resultHashes: jsonb('result_hashes').notNull(),
+})
+```
+
+`originalPayload` contains only the source/draft/translation fields needed for
+manual recovery. It is admin-only and never returned from public APIs.
+
+The table supports:
+
+- recovery investigation;
+- idempotent retry evidence;
+- converter-version audits;
+- migration coverage reporting.
+
+It does not create an automatic rollback endpoint in the first release.
+
+## 18. Error Model
+
+| Code                                     | HTTP                      | Trigger                                                             |
+| ---------------------------------------- | ------------------------- | ------------------------------------------------------------------- |
+| `MARKDOWN_MIGRATION_BLOCKED`             | 422 on commit             | A source or translation contains unsupported syntax                 |
+| `MARKDOWN_MIGRATION_STALE`               | 409                       | A source, draft, or translation precondition changed                |
+| `MARKDOWN_MIGRATION_ALIGNMENT_FAILED`    | 422                       | Translation blocks cannot be aligned safely                         |
+| `MARKDOWN_MIGRATION_CONTENT_MISMATCH`    | 400                       | Submitted Lexical content/projection is invalid                     |
+| `MARKDOWN_MIGRATION_DESCRIPTOR_REQUIRED` | 400                       | Markdown persisted source attempts a direct Lexical save            |
+| `MARKDOWN_MIGRATION_ALREADY_APPLIED`     | 409 or idempotent success | Source is already Lexical; outcome depends on matching audit hashes |
+
+Dry-run reports expected blocked states in its response rather than throwing
+`MARKDOWN_MIGRATION_BLOCKED`.
+
+Admin behavior:
+
+| Failure             | UI behavior                                        |
+| ------------------- | -------------------------------------------------- |
+| Blocked dry-run     | Keep Markdown; show diagnostics                    |
+| Stale commit        | Keep local Lexical buffer; rerun dry-run           |
+| Network failure     | Keep current buffer and migration metadata         |
+| Transaction failure | Keep source/translation database state unchanged   |
+| Projection mismatch | Keep local content; report save validation failure |
+
+## 19. Security
+
+- Dry-run and commit require normal Admin write authorization.
+- Translation content is loaded by Core; the client cannot substitute another
+  translation row.
+- Raw Markdown and translated text are never written to logs or telemetry.
+- `script`, `style`, unknown HTML, and unknown component forms block migration.
+- Diagnostic snippets are bounded and escaped before rendering.
+- Migration audit payload is admin-only and excluded from general collection
+  endpoints.
+- Converter parsing must avoid catastrophic regular-expression backtracking;
+  custom rules use bounded or non-backtracking forms.
+- Commit reruns conversion and never trusts a client-only `convertible` flag.
+
+## 20. Observability
+
+Metrics:
+
+| Metric                                 | Dimensions                    |
+| -------------------------------------- | ----------------------------- |
+| `markdown_migration_dry_run_total`     | ref type, result              |
+| `markdown_migration_issue_total`       | feature, issue code           |
+| `markdown_migration_commit_total`      | ref type, result, pure/edited |
+| `markdown_migration_translation_total` | language, result              |
+| `markdown_migration_duration_ms`       | dry-run/commit                |
+| `markdown_migration_stale_total`       | member kind                   |
+
+Structured logs contain IDs, hashes, converter version, counts, and issue codes
+only. They do not contain source text.
+
+The Admin Markdown management page may later aggregate:
+
+- remaining Markdown source count;
+- convertible count by current converter version;
+- blocked count by feature;
+- migrated count;
+- translation blocker count.
+
+## 21. Testing Strategy
+
+Tests validate observable conversion and runtime behavior. They do not snapshot
+static feature tables or transformer arrays.
+
+### 21.1 Converter tests
+
+| Case                                                | Expected behavior                                        |
+| --------------------------------------------------- | -------------------------------------------------------- |
+| Plain standard Markdown                             | Convertible Lexical content preserves semantic structure |
+| Nested inline custom tokens                         | Formats/nodes preserve visible nesting                   |
+| Known gallery/banner containers                     | Correct target node and properties                       |
+| Unknown container                                   | Blocked with exact source range                          |
+| Table with alignment before alignment support       | Blocked rather than alignment loss                       |
+| Fence with unknown attrs                            | Blocked rather than attr loss                            |
+| Raw script/style                                    | Blocked                                                  |
+| Malformed custom token rendered literally by Yohaku | Preserved as literal text                                |
+| Repeated identical conversion                       | Equivalent content and stable block IDs                  |
+| Lexical-to-Markdown projection                      | Projection represents converted content without throwing |
+
+### 21.2 Translation tests
+
+| Case                                                        | Expected behavior                                                           |
+| ----------------------------------------------------------- | --------------------------------------------------------------------------- |
+| Source and translation have matching structures             | Translation receives source block IDs                                       |
+| Translation inserts an unmatched block                      | Blocked in the first release                                                |
+| Translation omits a source block with safe partial fallback | Eligibility follows the explicit alignment rule                             |
+| One translation contains unsupported syntax                 | Whole migration unit is blocked                                             |
+| No translation rows                                         | Source remains eligible                                                     |
+| Submitted source is edited after staging                    | Translation becomes Lexical but stale/partial and regeneration is scheduled |
+| Translation changes between dry-run and commit              | Commit returns stale conflict and writes nothing                            |
+
+### 21.3 Core transaction tests
+
+| Case                                        | Expected behavior                            |
+| ------------------------------------------- | -------------------------------------------- |
+| Source plus three translations succeeds     | All rows become Lexical in one transaction   |
+| Second translation update fails             | Source and every translation remain Markdown |
+| Preconditions changed                       | No writes; 409 stale                         |
+| Pure representation migration               | Business modified timestamp preserved        |
+| Migration plus edits                        | Normal modified timestamp behavior           |
+| Retry after committed response loss         | Idempotent success when audit hashes match   |
+| Direct format transition without descriptor | Validation failure                           |
+
+### 21.4 Admin tests
+
+| Case                                             | Expected behavior                                             |
+| ------------------------------------------------ | ------------------------------------------------------------- |
+| Non-empty Markdown document                      | Highlighted conversion action is visible and enabled          |
+| Blocked document                                 | Action remains clickable and opens diagnostics                |
+| Convertible document                             | Editor changes to Lexical without publishing                  |
+| Draft autosave after staging                     | Draft stores Lexical `content + text`                         |
+| Reload staged Lexical draft over Markdown source | Migration state is reconstructed and rechecked before publish |
+| Restore before publish                           | Original Markdown buffer returns without reverse conversion   |
+| Stale save response                              | Local Lexical buffer is preserved                             |
+| Published Lexical source                         | No Markdown format switch is offered                          |
+
+### 21.5 Yohaku parity tests
+
+Use the current Yohaku syntax fixtures plus focused interaction tests:
+
+- historical heading hashes still navigate;
+- standalone links preserve enrichment;
+- footnote tooltip, scrolling, and self-LinkCard work;
+- gallery and banner layouts match;
+- image/video decisions match;
+- Mermaid and Excalidraw render;
+- table alignment and rich cells match when enabled;
+- unsupported script documents never reach the Lexical renderer.
+
+Visual regression tests are appropriate for layout-heavy features. They are
+behavioral outputs, not implementation snapshots.
+
+## 22. Deployment
+
+| Phase | Deliverable                                                           | Gate                                    |
+| ----- | --------------------------------------------------------------------- | --------------------------------------- |
+| 1     | `yohaku-v1` converter, diagnostics, stable IDs, and behavior fixtures | Package tests                           |
+| 2     | Yohaku parity for the initial supported feature set                   | Yohaku behavior tests                   |
+| 3     | Core dry-run, migration-aware save, transaction, and audit            | Core integration tests                  |
+| 4     | Admin highlighted action, diagnostics, staged draft flow              | Admin tests                             |
+| 5     | Feature flag enabled for internal documents                           | Error and blocker telemetry             |
+| 6     | Add support for high-frequency blockers                               | Per-feature behavior tests              |
+| 7     | Default new Admin documents to Lexical                                | Stable conversion/save metrics          |
+| 8     | Add batch migration view using the same APIs                          | Per-document path proven                |
+| 9     | Remove Markdown article write path                                    | Remaining eligible source count is zero |
+
+Core support must deploy before the Admin action is enabled. Yohaku must render
+every feature declared supported by that converter version before Admin can
+produce it.
+
+The Markdown renderer remains available throughout the progressive rollout.
+
+## 23. Rollback and Recovery
+
+Operational rollback:
+
+1. disable the Admin migration feature flag;
+2. stop new conversions;
+3. leave successfully migrated Lexical documents on the normal Lexical path;
+4. inspect failed or disputed migrations through audit records;
+5. require explicit user confirmation before any record-level restoration.
+
+There is no bulk automatic rollback. A conversion bug is corrected by:
+
+- fixing the converter/renderer;
+- identifying affected audit records by converter version;
+- previewing a repair;
+- explicitly applying the repair.
+
+## 24. Future Extensions
+
+- Explicitly discard and regenerate an unsupported AI translation.
+- Add Tabs, Grid, Masonry, component/DLS, and safe typed HTML nodes.
+- Add batch migration to the Admin Markdown management page.
+- Convert Markdown imports directly into Lexical.
+- Expose conversion dry-run through Admin Agent as a frontend-controlled tool.
+- Remove the Markdown article renderer after all stored sources and active
+  translations have migrated.
+
+If exposed through Admin Agent, dry-run remains read-only and the user must
+explicitly approve the write action. Agent integration reuses the same Core
+contracts and does not own an alternate migration implementation.
+
+## 25. Acceptance Criteria
+
+- Every non-empty Markdown post, note, or page displays a highlighted,
+  interactive conversion action.
+- A document using only supported syntax can enter the Lexical editor without
+  waiting for unrelated syntax support.
+- A blocked document remains Markdown and receives exact, actionable
+  diagnostics.
+- Unsupported syntax is never silently dropped, flattened, or executed.
+- Conversion does not publish content by itself.
+- A staged Lexical draft can coexist safely with a Markdown published source.
+- Published Markdown-to-Lexical transition atomically migrates all existing AI
+  translations.
+- Any transaction failure leaves the published source and translations in
+  their prior formats.
+- Migrated translation blocks share stable IDs with aligned source blocks.
+- `content` and `text` remain a consistent writer-owned pair.
+- Pure representation migration does not create a false business-content
+  modification.
+- Yohaku renders every declared-supported feature with equivalent observable
+  behavior.
+- Draft histories remain unchanged.
+- The implementation can add support for a new feature without changing the
+  eligibility semantics or Admin interaction model.
+
+## 26. Implementation Notes Deferred to Planning
+
+- Exact internal file layout of the converter and diagnostics modules.
+- Exact UUID namespace or stable-ID encoding.
+- Exact Admin diagnostics panel placement and visual tokens.
+- Exact audit JSON shape and retention policy.
+- Whether converter-version pinning uses an exported constant or build
+  metadata.
+- Whether dry-run conversion results are recomputed on every request or cached
+  briefly by source and translation hashes.
+
+These choices may be finalized in the implementation plan without changing the
+decisions or invariants in this design.

--- a/packages/editor/package.json
+++ b/packages/editor/package.json
@@ -51,6 +51,8 @@
     "@haklex/rich-headless": "0.31.1",
     "@haklex/rich-litexml": "0.31.1",
     "@lexical/headless": "^0.48.0",
+    "@lexical/markdown": "^0.48.0",
+    "@noble/hashes": "2.2.0",
     "lexical": "^0.48.0"
   },
   "devDependencies": {

--- a/packages/editor/src/core/index.ts
+++ b/packages/editor/src/core/index.ts
@@ -1,5 +1,6 @@
 export * from './errors'
 export * from './litexml'
 export * from './markdown'
+export * from './markdown-conversion'
 export * from './nodes'
 export * from './types'

--- a/packages/editor/src/core/markdown-conversion.ts
+++ b/packages/editor/src/core/markdown-conversion.ts
@@ -1,0 +1,1110 @@
+import { allHeadlessNodes } from '@haklex/rich-headless'
+import { createHeadlessEditor } from '@lexical/headless'
+import {
+  $convertFromMarkdownString,
+  CHECK_LIST,
+  type TextFormatTransformer,
+  TRANSFORMERS,
+} from '@lexical/markdown'
+import { sha256 } from '@noble/hashes/sha2.js'
+import { bytesToHex, utf8ToBytes } from '@noble/hashes/utils.js'
+
+import { mxLexicalToMarkdown } from './markdown'
+import type { SerializedMxEditorState } from './types'
+
+export const MX_MARKDOWN_CONVERTER_VERSION = '0.1.0'
+
+export type MarkdownConversionProfile = 'yohaku-v1'
+
+export interface MarkdownSourcePosition {
+  line: number
+  column: number
+  offset: number
+}
+
+export interface MarkdownSourceRange {
+  start: MarkdownSourcePosition
+  end: MarkdownSourcePosition
+}
+
+export interface MarkdownConversionIssue {
+  code: string
+  feature: string
+  message: string
+  range: MarkdownSourceRange
+  severity: 'blocking'
+  details?: Record<string, unknown>
+}
+
+export interface MarkdownFeatureOccurrence {
+  feature: string
+  range: MarkdownSourceRange
+  targetNode?: string
+}
+
+export type MarkdownConversionResult =
+  | {
+      status: 'convertible'
+      converterVersion: string
+      profile: MarkdownConversionProfile
+      sourceHash: string
+      features: MarkdownFeatureOccurrence[]
+      content: SerializedMxEditorState
+      text: string
+    }
+  | {
+      status: 'blocked'
+      converterVersion: string
+      profile: MarkdownConversionProfile
+      sourceHash: string
+      features: MarkdownFeatureOccurrence[]
+      issues: MarkdownConversionIssue[]
+    }
+
+export interface AnalyzeMxMarkdownOptions {
+  profile: MarkdownConversionProfile
+  blockIdFactory?: (path: string) => string
+}
+
+interface SourceSpan {
+  start: number
+  end: number
+}
+
+interface SourceLine extends SourceSpan {
+  index: number
+  text: string
+  fullEnd: number
+}
+
+interface SerializedNode {
+  type?: string
+  children?: SerializedNode[]
+  text?: string
+  format?: unknown
+  [key: string]: unknown
+}
+
+interface SourceReplacement extends SourceSpan {
+  placeholder: string
+  node: SerializedNode
+  block: boolean
+}
+
+const INSERT_TRANSFORMER: TextFormatTransformer = {
+  format: ['underline'],
+  tag: '++',
+  type: 'text-format',
+}
+
+const IMPORT_TRANSFORMERS = [CHECK_LIST, INSERT_TRANSFORMER, ...TRANSFORMERS]
+const INLINE_CODE_FORMAT = 1 << 4
+
+function sourceHash(markdown: string): string {
+  return `sha256:${bytesToHex(sha256(utf8ToBytes(markdown)))}`
+}
+
+function getLines(source: string): SourceLine[] {
+  const lines: SourceLine[] = []
+  let start = 0
+  let index = 0
+
+  while (start <= source.length) {
+    const newline = source.indexOf('\n', start)
+    const fullEnd = newline === -1 ? source.length : newline + 1
+    let end = newline === -1 ? source.length : newline
+    if (end > start && source[end - 1] === '\r') end--
+    lines.push({
+      start,
+      end,
+      fullEnd,
+      index,
+      text: source.slice(start, end),
+    })
+    index++
+    if (newline === -1) break
+    start = newline + 1
+  }
+
+  return lines
+}
+
+function getLineStarts(lines: SourceLine[]): number[] {
+  return lines.map((line) => line.start)
+}
+
+function positionAt(
+  source: string,
+  lineStarts: number[],
+  rawOffset: number,
+): MarkdownSourcePosition {
+  const offset = Math.max(0, Math.min(rawOffset, source.length))
+  let low = 0
+  let high = lineStarts.length - 1
+
+  while (low <= high) {
+    const middle = Math.floor((low + high) / 2)
+    if (lineStarts[middle] <= offset) low = middle + 1
+    else high = middle - 1
+  }
+
+  const lineIndex = Math.max(0, high)
+  return {
+    line: lineIndex + 1,
+    column: offset - lineStarts[lineIndex] + 1,
+    offset,
+  }
+}
+
+function toRange(
+  source: string,
+  lineStarts: number[],
+  span: SourceSpan,
+): MarkdownSourceRange {
+  return {
+    start: positionAt(source, lineStarts, span.start),
+    end: positionAt(source, lineStarts, span.end),
+  }
+}
+
+function overlaps(a: SourceSpan, b: SourceSpan): boolean {
+  return a.start < b.end && b.start < a.end
+}
+
+function isCovered(span: SourceSpan, ignored: SourceSpan[]): boolean {
+  return ignored.some((candidate) => overlaps(span, candidate))
+}
+
+function cloneNode<T>(node: T): T {
+  return structuredClone(node)
+}
+
+function parseFenceOpening(value: string): {
+  fenceLength: number
+  indentLength: number
+  info: string
+  marker: '`' | '~'
+} | null {
+  let indentLength = 0
+  while (value[indentLength] === ' ' || value[indentLength] === '\t') {
+    indentLength++
+  }
+
+  const marker = value[indentLength]
+  if (marker !== '`' && marker !== '~') return null
+
+  let fenceEnd = indentLength
+  while (value[fenceEnd] === marker) fenceEnd++
+  const fenceLength = fenceEnd - indentLength
+  if (fenceLength < 3) return null
+
+  return {
+    fenceLength,
+    indentLength,
+    info: value.slice(fenceEnd).trim(),
+    marker,
+  }
+}
+
+function parseSingleLineKatex(value: string): string | null {
+  let indentLength = 0
+  while (value[indentLength] === ' ') indentLength++
+  if (indentLength > 3) return null
+
+  const content = value.slice(indentLength).trimEnd()
+  if (
+    content.length <= 4 ||
+    !content.startsWith('$$') ||
+    !content.endsWith('$$')
+  ) {
+    return null
+  }
+  return content.slice(2, -2).trim()
+}
+
+function isTableDivider(value: string): boolean {
+  let content = value.trim()
+  if (content.startsWith('|')) content = content.slice(1)
+  if (content.endsWith('|')) content = content.slice(0, -1)
+
+  const cells = content.split('|')
+  return (
+    cells.length >= 2 && cells.every((cell) => /^:?-+:?$/.test(cell.trim()))
+  )
+}
+
+function textNode(text: string, template?: SerializedNode): SerializedNode {
+  return {
+    detail: typeof template?.detail === 'number' ? template.detail : 0,
+    format: typeof template?.format === 'number' ? template.format : 0,
+    mode: typeof template?.mode === 'string' ? template.mode : 'normal',
+    style: typeof template?.style === 'string' ? template.style : '',
+    text,
+    type: 'text',
+    version: 1,
+  }
+}
+
+function nestedTextNode(text: string): SerializedNode {
+  return textNode(text)
+}
+
+function spoilerNode(text: string): SerializedNode {
+  return {
+    children: [nestedTextNode(text)],
+    direction: 'ltr',
+    format: '',
+    indent: 0,
+    type: 'spoiler',
+    version: 1,
+  }
+}
+
+function mentionNode(
+  platform: string,
+  handle: string,
+  displayName?: string,
+): SerializedNode {
+  return {
+    handle,
+    platform,
+    type: 'mention',
+    version: 1,
+    ...(displayName ? { displayName } : {}),
+  }
+}
+
+function autoLinkNode(url: string, template?: SerializedNode): SerializedNode {
+  return {
+    children: [textNode(url, template)],
+    direction: 'ltr',
+    format: '',
+    indent: 0,
+    isUnlinked: false,
+    rel: null,
+    target: null,
+    title: null,
+    type: 'autolink',
+    url,
+    version: 1,
+  }
+}
+
+function katexInlineNode(equation: string): SerializedNode {
+  return { equation, type: 'katex-inline', version: 1 }
+}
+
+function katexBlockNode(equation: string): SerializedNode {
+  return { equation, type: 'katex-block', version: 1 }
+}
+
+function imageNode(
+  src: string,
+  altText: string,
+  caption?: string,
+): SerializedNode {
+  return {
+    altText,
+    src,
+    type: 'image',
+    version: 1,
+    ...(caption ? { caption } : {}),
+  }
+}
+
+function replacementText(
+  source: string,
+  replacement: SourceReplacement,
+): string {
+  if (!replacement.block) return replacement.placeholder
+  const original = source.slice(replacement.start, replacement.end)
+  const newlineCount = original.match(/\n/g)?.length ?? 0
+  return replacement.placeholder + '\n'.repeat(newlineCount)
+}
+
+function applyReplacements(
+  source: string,
+  replacements: SourceReplacement[],
+): string {
+  let output = source
+  const ordered = [...replacements].sort((a, b) => b.start - a.start)
+  for (const replacement of ordered) {
+    output =
+      output.slice(0, replacement.start) +
+      replacementText(source, replacement) +
+      output.slice(replacement.end)
+  }
+  return output
+}
+
+function getSerializedState(markdown: string): SerializedMxEditorState {
+  const editor = createHeadlessEditor({
+    nodes: allHeadlessNodes,
+    onError: (error) => {
+      throw error
+    },
+  })
+
+  editor.update(
+    () => {
+      $convertFromMarkdownString(
+        markdown,
+        IMPORT_TRANSFORMERS,
+        undefined,
+        false,
+        true,
+      )
+    },
+    { discrete: true },
+  )
+
+  return editor.getEditorState().toJSON() as SerializedMxEditorState
+}
+
+function nodeText(node: SerializedNode): string {
+  if (node.type === 'text')
+    return typeof node.text === 'string' ? node.text : ''
+  if (node.type === 'linebreak') return '\n'
+  if (node.type === 'mention') {
+    if (typeof node.displayName === 'string') return node.displayName
+    return typeof node.handle === 'string' ? node.handle : ''
+  }
+  if (node.type === 'katex-inline' || node.type === 'katex-block') {
+    return typeof node.equation === 'string' ? node.equation : ''
+  }
+  if (node.type === 'image') {
+    if (typeof node.altText === 'string') return node.altText
+    return typeof node.caption === 'string' ? node.caption : ''
+  }
+  if (node.type === 'code-block') {
+    return typeof node.code === 'string' ? node.code : ''
+  }
+  if (!Array.isArray(node.children)) return ''
+
+  const separator =
+    node.type === 'root' || node.type === 'list' || node.type === 'listitem'
+      ? '\n'
+      : ''
+  return node.children.map(nodeText).filter(Boolean).join(separator)
+}
+
+function findNextPlaceholder(
+  value: string,
+  placeholders: Map<string, SourceReplacement>,
+): { index: number; replacement: SourceReplacement } | null {
+  let result: { index: number; replacement: SourceReplacement } | null = null
+  for (const [placeholder, replacement] of placeholders) {
+    const index = value.indexOf(placeholder)
+    if (index === -1 || (result && result.index <= index)) continue
+    result = { index, replacement }
+  }
+  return result
+}
+
+function trimUrlPunctuation(raw: string): { url: string; suffix: string } {
+  let url = raw
+  let suffix = ''
+  const punctuation = /[!,.:;?。！，：；？]$/
+
+  while (punctuation.test(url)) {
+    suffix = url.slice(-1) + suffix
+    url = url.slice(0, -1)
+  }
+
+  while (url.endsWith(')')) {
+    const opens = (url.match(/\(/g) ?? []).length
+    const closes = (url.match(/\)/g) ?? []).length
+    if (closes <= opens) break
+    suffix = ')' + suffix
+    url = url.slice(0, -1)
+  }
+
+  return { url, suffix }
+}
+
+function splitBareUrls(node: SerializedNode, value: string): SerializedNode[] {
+  const format = typeof node.format === 'number' ? node.format : 0
+  if (format & INLINE_CODE_FORMAT) return [textNode(value, node)]
+
+  const output: SerializedNode[] = []
+  const pattern = /https?:\/\/[^\s<>]+/g
+  let cursor = 0
+
+  for (const match of value.matchAll(pattern)) {
+    const start = match.index
+    if (start > cursor) output.push(textNode(value.slice(cursor, start), node))
+    const { url, suffix } = trimUrlPunctuation(match[0])
+    if (url) output.push(autoLinkNode(url, node))
+    if (suffix) output.push(textNode(suffix, node))
+    cursor = start + match[0].length
+  }
+
+  if (cursor < value.length) output.push(textNode(value.slice(cursor), node))
+  return output.length > 0 ? output : [textNode(value, node)]
+}
+
+function applyInheritedTextFormat(
+  replacement: SerializedNode,
+  template: SerializedNode,
+): SerializedNode {
+  if (replacement.type !== 'spoiler' || !replacement.children?.length) {
+    return replacement
+  }
+  const child = replacement.children[0]
+  if (child.type !== 'text') return replacement
+  child.format = typeof template.format === 'number' ? template.format : 0
+  child.style = typeof template.style === 'string' ? template.style : ''
+  return replacement
+}
+
+function postprocessTextNode(
+  node: SerializedNode,
+  placeholders: Map<string, SourceReplacement>,
+  insideLink: boolean,
+): SerializedNode[] {
+  const value = typeof node.text === 'string' ? node.text : ''
+  const output: SerializedNode[] = []
+  let remaining = value
+
+  while (remaining) {
+    const next = findNextPlaceholder(remaining, placeholders)
+    if (!next) {
+      output.push(
+        ...(insideLink
+          ? [textNode(remaining, node)]
+          : splitBareUrls(node, remaining)),
+      )
+      break
+    }
+
+    if (next.index > 0) {
+      const prefix = remaining.slice(0, next.index)
+      output.push(
+        ...(insideLink
+          ? [textNode(prefix, node)]
+          : splitBareUrls(node, prefix)),
+      )
+    }
+
+    if (next.replacement.block) {
+      throw new Error('Block placeholder was imported inside a text node')
+    }
+    output.push(
+      applyInheritedTextFormat(cloneNode(next.replacement.node), node),
+    )
+    remaining = remaining.slice(
+      next.index + next.replacement.placeholder.length,
+    )
+  }
+
+  return output.length > 0 ? output : [textNode('', node)]
+}
+
+function postprocessNode(
+  node: SerializedNode,
+  placeholders: Map<string, SourceReplacement>,
+  insideLink = false,
+): SerializedNode[] {
+  if (node.type === 'text') {
+    return postprocessTextNode(node, placeholders, insideLink)
+  }
+
+  if (node.type === 'code') {
+    const code = Array.isArray(node.children)
+      ? node.children.map(nodeText).join('')
+      : ''
+    const language = typeof node.language === 'string' ? node.language : ''
+    if (language.toLowerCase() === 'mermaid') {
+      return [{ diagram: code, type: 'mermaid', version: 1 }]
+    }
+    return [{ code, language, type: 'code-block', version: 1 }]
+  }
+
+  if (!Array.isArray(node.children)) return [node]
+  const childInsideLink =
+    insideLink || node.type === 'link' || node.type === 'autolink'
+  return [
+    {
+      ...node,
+      children: node.children.flatMap((child) =>
+        postprocessNode(child, placeholders, childInsideLink),
+      ),
+    },
+  ]
+}
+
+function postprocessState(
+  state: SerializedMxEditorState,
+  replacements: SourceReplacement[],
+  blockIdFactory?: (path: string) => string,
+): SerializedMxEditorState {
+  const placeholders = new Map(
+    replacements.map((replacement) => [replacement.placeholder, replacement]),
+  )
+  const root = state.root as SerializedNode
+  const children = (root.children ?? []).flatMap((child) => {
+    if (child.type === 'paragraph' && Array.isArray(child.children)) {
+      const value = child.children.map(nodeText).join('')
+      const replacement = placeholders.get(value)
+      if (replacement?.block) return [cloneNode(replacement.node)]
+    }
+    return postprocessNode(child, placeholders)
+  })
+
+  if (blockIdFactory) {
+    children.forEach((child, index) => {
+      const blockId = blockIdFactory(`root.children[${index}]`).trim()
+      if (!blockId) return
+      const stateValue =
+        child.$ && typeof child.$ === 'object' && !Array.isArray(child.$)
+          ? (child.$ as Record<string, unknown>)
+          : {}
+      child.$ = { ...stateValue, blockId }
+    })
+  }
+
+  return {
+    root: {
+      ...state.root,
+      children,
+    },
+  }
+}
+
+function containsPlaceholder(
+  node: SerializedNode,
+  placeholders: Map<string, SourceReplacement>,
+): boolean {
+  if (node.type === 'text' && typeof node.text === 'string') {
+    return [...placeholders.keys()].some((placeholder) =>
+      node.text!.includes(placeholder),
+    )
+  }
+  return (
+    Array.isArray(node.children) &&
+    node.children.some((child) => containsPlaceholder(child, placeholders))
+  )
+}
+
+export function analyzeMxMarkdown(
+  markdown: string,
+  options: AnalyzeMxMarkdownOptions,
+): MarkdownConversionResult {
+  const hash = sourceHash(markdown)
+  const lines = getLines(markdown)
+  const lineStarts = getLineStarts(lines)
+  const features: MarkdownFeatureOccurrence[] = []
+  const issues: MarkdownConversionIssue[] = []
+  const ignored: SourceSpan[] = []
+  const replacements: SourceReplacement[] = []
+  let placeholderIndex = 0
+
+  const addFeature = (
+    feature: string,
+    span: SourceSpan,
+    targetNode?: string,
+  ) => {
+    features.push({
+      feature,
+      range: toRange(markdown, lineStarts, span),
+      ...(targetNode ? { targetNode } : {}),
+    })
+  }
+
+  const addIssue = (
+    code: string,
+    feature: string,
+    message: string,
+    span: SourceSpan,
+    details?: Record<string, unknown>,
+  ) => {
+    issues.push({
+      code,
+      feature,
+      message,
+      range: toRange(markdown, lineStarts, span),
+      severity: 'blocking',
+      ...(details ? { details } : {}),
+    })
+  }
+
+  const createReplacement = (
+    span: SourceSpan,
+    node: SerializedNode,
+    block: boolean,
+  ) => {
+    let placeholder: string
+    do {
+      placeholder = `MXMIGRATION${hash.slice(7, 19)}TOKEN${placeholderIndex++}`
+    } while (markdown.includes(placeholder))
+    const replacement = { ...span, placeholder, node, block }
+    replacements.push(replacement)
+    return replacement
+  }
+
+  // Fences are recognized first so their bodies cannot trigger syntax scans.
+  for (let index = 0; index < lines.length; index++) {
+    const line = lines[index]
+    const opening = parseFenceOpening(line.text)
+    if (!opening) continue
+
+    const { marker, fenceLength } = opening
+    let closingIndex = -1
+    const closingPattern = new RegExp(
+      `^[ \\t]*${marker}{${fenceLength},}[ \\t]*$`,
+    )
+    for (let candidate = index + 1; candidate < lines.length; candidate++) {
+      if (closingPattern.test(lines[candidate].text)) {
+        closingIndex = candidate
+        break
+      }
+    }
+
+    const span = {
+      start: line.start,
+      end: closingIndex === -1 ? markdown.length : lines[closingIndex].fullEnd,
+    }
+    ignored.push(span)
+
+    const { info } = opening
+    addFeature(
+      info.toLowerCase() === 'mermaid' ? 'mermaid' : 'code-fence',
+      span,
+      info.toLowerCase() === 'mermaid' ? 'mermaid' : 'code-block',
+    )
+
+    if (marker !== '`') {
+      addIssue(
+        'unsupported-fence-marker',
+        'code-fence',
+        'Tilde code fences are not yet supported by the Lexical importer.',
+        span,
+      )
+    }
+    if (opening.indentLength > 0) {
+      addIssue(
+        'unsupported-nested-code-fence',
+        'code-fence',
+        'Indented or nested code fences require structural-parent parity.',
+        span,
+      )
+    }
+    if (info && !/^[\w-]+$/.test(info)) {
+      addIssue(
+        'unsupported-code-fence-attributes',
+        'code-fence-attributes',
+        'Code-fence attributes cannot be represented without loss.',
+        { start: line.start, end: line.end },
+        { info },
+      )
+    }
+    if (closingIndex === -1) {
+      addIssue(
+        'unclosed-code-fence',
+        'code-fence',
+        'The code fence is not closed.',
+        span,
+      )
+      break
+    }
+    index = closingIndex
+  }
+
+  const lineIsIgnored = (line: SourceLine) => isCovered(line, ignored)
+
+  // Block KaTeX is protected before inline-dollar analysis.
+  for (let index = 0; index < lines.length; index++) {
+    const line = lines[index]
+    if (lineIsIgnored(line)) continue
+    const oneLine = parseSingleLineKatex(line.text)
+    if (oneLine !== null) {
+      const span = { start: line.start, end: line.fullEnd }
+      addFeature('katex-block', span, 'katex-block')
+      createReplacement(span, katexBlockNode(oneLine), true)
+      ignored.push(span)
+      continue
+    }
+    if (!/^ {0,3}\$\$\s*$/.test(line.text)) continue
+
+    let closingIndex = -1
+    for (let candidate = index + 1; candidate < lines.length; candidate++) {
+      if (/^ {0,3}\$\$\s*$/.test(lines[candidate].text)) {
+        closingIndex = candidate
+        break
+      }
+    }
+    const span = {
+      start: line.start,
+      end: closingIndex === -1 ? markdown.length : lines[closingIndex].fullEnd,
+    }
+    addFeature('katex-block', span, 'katex-block')
+    ignored.push(span)
+    if (closingIndex === -1) {
+      addIssue(
+        'unclosed-katex-block',
+        'katex-block',
+        'The block KaTeX delimiter is not closed.',
+        span,
+      )
+      break
+    }
+    const equation = markdown
+      .slice(lines[index + 1].start, lines[closingIndex].start)
+      .trim()
+    if (!equation) {
+      addIssue(
+        'empty-katex-block',
+        'katex-block',
+        'An empty block KaTeX expression cannot be migrated.',
+        span,
+      )
+    } else {
+      createReplacement(span, katexBlockNode(equation), true)
+    }
+    index = closingIndex
+  }
+
+  // Standalone images map to the rich ImageNode. Other image shapes block.
+  const imagePattern =
+    // eslint-disable-next-line unicorn/better-regex -- Escaping the closing bracket keeps the expression valid in Unicode mode.
+    /^ {0,3}!\[([^\]]*)\]\((?:<([^>]+)>|([^\s)]+))(?:\s+(?:"([^"]*)"|'([^']*)'|\(([^)]*)\)))?\)\s*$/
+  for (const line of lines) {
+    if (lineIsIgnored(line) || !line.text.includes('![')) continue
+    const match = imagePattern.exec(line.text)
+    const span = { start: line.start, end: line.fullEnd }
+    if (!match) {
+      addIssue(
+        'unsupported-image-shape',
+        'image',
+        'Only standalone inline-destination images are currently supported.',
+        span,
+      )
+      continue
+    }
+    const src = match[2] || match[3]
+    const caption = match[4] || match[5] || match[6] || undefined
+    addFeature('image', span, 'image')
+    createReplacement(span, imageNode(src, match[1], caption), true)
+    ignored.push(span)
+  }
+
+  // Horizontal rules need a dedicated node because Lexical's core importer
+  // intentionally does not include a thematic-break transformer.
+  for (let index = 0; index < lines.length; index++) {
+    const line = lines[index]
+    if (lineIsIgnored(line)) continue
+    if (!/^ {0,3}(?:-{3,}|\*{3,}|_{3,})\s*$/.test(line.text)) continue
+
+    const previous = index > 0 ? lines[index - 1] : undefined
+    const isSetext =
+      /^ {0,3}-{3,}\s*$/.test(line.text) &&
+      previous !== undefined &&
+      previous.text.trim() !== '' &&
+      !lineIsIgnored(previous)
+    const span = isSetext
+      ? { start: previous.start, end: line.fullEnd }
+      : { start: line.start, end: line.fullEnd }
+    if (isSetext) {
+      addFeature('setext-heading', span, 'heading')
+      addIssue(
+        'unsupported-heading-anchor-parity',
+        'heading',
+        'Heading migration is blocked until legacy Yohaku anchor IDs are preserved.',
+        span,
+      )
+      ignored.push(span)
+      continue
+    }
+
+    addFeature('horizontal-rule', span, 'horizontalrule')
+    createReplacement(span, { type: 'horizontalrule', version: 1 }, true)
+    ignored.push(span)
+  }
+
+  // Inline code is ignored by custom-token and unsupported-construct scans.
+  const inlineCodePattern = /(`+)([^\n]*?)\1/g
+  for (const match of markdown.matchAll(inlineCodePattern)) {
+    const span = { start: match.index, end: match.index + match[0].length }
+    if (!isCovered(span, ignored)) ignored.push(span)
+  }
+
+  // Structural constructs that are rendered by Markdown today but do not yet
+  // have proven Lexical behavioral parity.
+  for (const line of lines) {
+    if (lineIsIgnored(line)) continue
+    const span = { start: line.start, end: line.fullEnd }
+    const container = /^\s*:::\s*([\w-]+)?/.exec(line.text)
+    if (container && container[1]) {
+      addFeature('container', span)
+      addIssue(
+        'unsupported-container',
+        'container',
+        `The ::: ${container[1]} container is not yet supported by the migration profile.`,
+        span,
+        { name: container[1] },
+      )
+    }
+
+    const heading = /^ {0,3}(#{1,6})\s+/.exec(line.text)
+    if (heading) {
+      addFeature('atx-heading', span, 'heading')
+      addIssue(
+        'unsupported-heading-anchor-parity',
+        'heading',
+        'Heading migration is blocked until legacy Yohaku anchor IDs are preserved.',
+        span,
+        { level: heading[1].length },
+      )
+    }
+
+    // eslint-disable-next-line unicorn/better-regex -- Escaping the closing bracket keeps the expression valid in Unicode mode.
+    const alert = /^\s*>\s*\[!(NOTE|TIP|IMPORTANT|WARNING|CAUTION)\]\s*$/i.exec(
+      line.text,
+    )
+    if (alert) {
+      addFeature('gfm-alert', span, 'alert-quote')
+      addIssue(
+        'unsupported-gfm-alert',
+        'gfm-alert',
+        'GFM alert migration requires nested-block renderer parity.',
+        span,
+        { type: alert[1].toLowerCase() },
+      )
+    } else if (/^\s*>\s*>/.test(line.text)) {
+      addIssue(
+        'unsupported-nested-blockquote',
+        'blockquote',
+        'Nested blockquotes are not yet represented without loss.',
+        span,
+      )
+    } else if (/^\s*>\s*(?:[*+-] |\d+\. |```)/.test(line.text)) {
+      addIssue(
+        'unsupported-structured-blockquote',
+        'blockquote',
+        'Structured content nested inside a blockquote is not yet supported.',
+        span,
+      )
+    }
+
+    if (/^ {1,3}(?:[*+-] |\d+\. )/.test(line.text)) {
+      addIssue(
+        'unsupported-list-indentation',
+        'list',
+        'Nested list indentation must be a multiple of four spaces for this converter.',
+        span,
+      )
+    }
+  }
+
+  for (const line of lines) {
+    if (lineIsIgnored(line) || !isTableDivider(line.text)) continue
+    const span = { start: line.start, end: line.fullEnd }
+    addFeature('gfm-table', span, 'table')
+    addIssue(
+      'unsupported-table',
+      'table',
+      'GFM tables remain blocked until rich-cell and alignment parity is available.',
+      span,
+    )
+  }
+
+  const scanPattern = (
+    pattern: RegExp,
+    callback: (match: RegExpMatchArray, span: SourceSpan) => void,
+  ) => {
+    for (const match of markdown.matchAll(pattern)) {
+      const span = { start: match.index, end: match.index + match[0].length }
+      if (!isCovered(span, ignored)) callback(match, span)
+    }
+  }
+
+  // eslint-disable-next-line unicorn/better-regex -- Escaping the closing bracket keeps the expression valid in Unicode mode.
+  scanPattern(/\[\^[^\]\s]+\]:?/g, (_match, span) => {
+    addFeature('footnote', span, 'footnote')
+    addIssue(
+      'unsupported-footnote',
+      'footnote',
+      'Footnotes remain blocked until tooltip and navigation parity is available.',
+      span,
+    )
+  })
+
+  // eslint-disable-next-line unicorn/better-regex -- Escaping the closing bracket keeps the expression valid in Unicode mode.
+  scanPattern(/^ {0,3}\[[^\]\n]+\]:\s*\S.*$/gm, (_match, span) => {
+    addFeature('reference-definition', span)
+    addIssue(
+      'unsupported-reference-definition',
+      'reference-link',
+      'Reference links and images are not yet supported by the Lexical importer.',
+      span,
+    )
+  })
+
+  scanPattern(/<(https?:\/\/[^\s>]+)>/g, (match, span) => {
+    addFeature('autolink', span, 'autolink')
+    createReplacement(span, autoLinkNode(match[1]), false)
+    ignored.push(span)
+  })
+
+  scanPattern(/<[^\n>@]*@[^\n>]*>/g, (_match, span) => {
+    addIssue(
+      'unsupported-email-autolink',
+      'email-autolink',
+      'Email autolinks are not yet supported by the migration profile.',
+      span,
+    )
+  })
+
+  scanPattern(/<!--.*?-->/gs, (_match, span) => {
+    addFeature('html-comment', span, 'comment')
+    addIssue(
+      'unsupported-html-comment',
+      'html-comment',
+      'HTML comments are blocked until comment-node round-trip parity is verified.',
+      span,
+    )
+    ignored.push(span)
+  })
+
+  scanPattern(/<\/?([a-z][\w-]*)(?:\s[^<>]*?)?\/?>/gi, (match, span) => {
+    const element = match[1].toLowerCase()
+    addFeature('raw-html', span)
+    addIssue(
+      element === 'script' || element === 'style'
+        ? 'unsafe-raw-html'
+        : 'unsupported-raw-html',
+      'raw-html',
+      element === 'script' || element === 'style'
+        ? `Raw <${element}> content requires a separate security decision.`
+        : `The <${element}> element does not yet have verified Lexical parity.`,
+      span,
+      { element },
+    )
+  })
+
+  // Spoilers are protected before mentions and math so nested Markdown cannot
+  // be flattened accidentally.
+  scanPattern(/\|\|([^\n]+?)\|\|/g, (match, span) => {
+    const value = match[1]
+    addFeature('spoiler', span, 'spoiler')
+    const nestedMarkup =
+      // eslint-disable-next-line unicorn/better-regex -- Escaped delimiters avoid non-Unicode parsing ambiguities.
+      /\*\*[^*]+\*\*|__[^_]+__|~~[^~]+~~|==[^=]+==|\+\+[^+]+\+\+|`[^`]+`|\[[^\]]+\]\([^)]+\)|\{(?:GH|TW|TG)@|\$[^$]+\$/.test(
+        value,
+      )
+    if (nestedMarkup) {
+      addIssue(
+        'unsupported-nested-spoiler-markdown',
+        'spoiler',
+        'Markdown nested inside a spoiler is blocked until inline-child parity is implemented.',
+        span,
+      )
+    } else {
+      createReplacement(span, spoilerNode(value), false)
+    }
+    ignored.push(span)
+  })
+
+  scanPattern(/\|\|[^\n]*\n.*?\|\|/gs, (_match, span) => {
+    addFeature('spoiler', span, 'spoiler')
+    addIssue(
+      'unsupported-multiline-spoiler',
+      'spoiler',
+      'Multiline spoilers are not yet supported by the migration profile.',
+      span,
+    )
+    ignored.push(span)
+  })
+
+  scanPattern(
+    // eslint-disable-next-line unicorn/better-regex -- Escaped delimiters avoid non-Unicode parsing ambiguities.
+    /(?:\[([^\]\n]*)\])?\{(GH|TW|TG)@(\w+)\}[ \t]?/g,
+    (match, span) => {
+      addFeature('mention', span, 'mention')
+      createReplacement(
+        span,
+        mentionNode(match[2], match[3], match[1] || undefined),
+        false,
+      )
+      ignored.push(span)
+    },
+  )
+
+  scanPattern(/(?<!\$)\$([^\n$]+)\$(?=[^$]|$)/g, (match, span) => {
+    addFeature('katex-inline', span, 'katex-inline')
+    createReplacement(span, katexInlineNode(match[1]), false)
+    ignored.push(span)
+  })
+
+  scanPattern(/\+\+[^\n+]+\+\+/g, (_match, span) => {
+    addFeature('insert', span, 'text')
+  })
+  scanPattern(/==[^\n=]+==/g, (_match, span) => {
+    addFeature('highlight', span, 'text')
+  })
+
+  features.sort((a, b) => a.range.start.offset - b.range.start.offset)
+  issues.sort(
+    (a, b) =>
+      a.range.start.offset - b.range.start.offset ||
+      a.code.localeCompare(b.code),
+  )
+
+  if (issues.length > 0) {
+    return {
+      status: 'blocked',
+      converterVersion: MX_MARKDOWN_CONVERTER_VERSION,
+      profile: options.profile,
+      sourceHash: hash,
+      features,
+      issues,
+    }
+  }
+
+  try {
+    const prepared = applyReplacements(markdown, replacements)
+    const imported = getSerializedState(prepared)
+    const content = postprocessState(
+      imported,
+      replacements,
+      options.blockIdFactory,
+    )
+    const placeholderMap = new Map(
+      replacements.map((replacement) => [replacement.placeholder, replacement]),
+    )
+    if (containsPlaceholder(content.root as SerializedNode, placeholderMap)) {
+      throw new Error('A migration placeholder remained after conversion')
+    }
+
+    return {
+      status: 'convertible',
+      converterVersion: MX_MARKDOWN_CONVERTER_VERSION,
+      profile: options.profile,
+      sourceHash: hash,
+      features,
+      content,
+      text: mxLexicalToMarkdown(content),
+    }
+  } catch (error) {
+    const span = { start: 0, end: markdown.length }
+    return {
+      status: 'blocked',
+      converterVersion: MX_MARKDOWN_CONVERTER_VERSION,
+      profile: options.profile,
+      sourceHash: hash,
+      features,
+      issues: [
+        {
+          code: 'conversion-failed',
+          feature: 'document',
+          message: 'The Markdown document could not be converted safely.',
+          range: toRange(markdown, lineStarts, span),
+          severity: 'blocking',
+          details: {
+            reason: error instanceof Error ? error.message : String(error),
+          },
+        },
+      ],
+    }
+  }
+}

--- a/packages/editor/test/markdown-conversion.test.ts
+++ b/packages/editor/test/markdown-conversion.test.ts
@@ -1,0 +1,233 @@
+import { describe, expect, it } from 'vitest'
+
+import { analyzeMxMarkdown, mxLexicalToMarkdown } from '../src'
+
+function convertible(markdown: string) {
+  const result = analyzeMxMarkdown(markdown, { profile: 'yohaku-v1' })
+  if (result.status !== 'convertible') {
+    throw new Error(
+      result.issues
+        .map((issue) => `${issue.code}: ${JSON.stringify(issue.details)}`)
+        .join(', '),
+    )
+  }
+  expect(result.status).toBe('convertible')
+  return result
+}
+
+describe('analyzeMxMarkdown', () => {
+  it('converts standard inline formats, links, and task lists behaviorally', () => {
+    const result = convertible(`A **bold** ++insert++ ==mark== [link](https://example.com "title")
+
+- [x] done
+- [ ] pending`)
+
+    const [paragraph, list] = result.content.root.children as any[]
+    expect(paragraph.type).toBe('paragraph')
+    expect(
+      paragraph.children
+        .filter((node: any) => node.type === 'text')
+        .map((node: any) => [node.text, node.format]),
+    ).toEqual(
+      expect.arrayContaining([
+        ['bold', 1],
+        ['insert', 8],
+        ['mark', 128],
+      ]),
+    )
+    expect(paragraph.children).toContainEqual(
+      expect.objectContaining({
+        type: 'link',
+        title: 'title',
+        url: 'https://example.com',
+      }),
+    )
+    expect(list).toMatchObject({ listType: 'check', type: 'list' })
+    expect(list.children.map((item: any) => item.checked)).toEqual([true, false])
+    expect(result.text).toContain(
+      'A **bold** ++insert++ ==mark== [link](https://example.com "title")',
+    )
+  })
+
+  it('merges CommonMark soft line breaks while preserving explicit hard breaks', () => {
+    const result = convertible('soft line\ncontinues here\n\nhard line  \nbreak')
+    const [soft, hard] = result.content.root.children as any[]
+
+    expect(soft.children.map((node: any) => node.text ?? '\n').join('')).toBe(
+      'soft line continues here',
+    )
+    expect(hard.children.map((node: any) => node.type)).toContain('linebreak')
+  })
+
+  it('converts Yohaku mention, spoiler, inline KaTeX, and bare URL syntax', () => {
+    const source =
+      'See [Innei]{GH@Innei}and ||secret||; $E = mc^2$ at https://example.com.'
+    const result = analyzeMxMarkdown(source, {
+      profile: 'yohaku-v1',
+      blockIdFactory: (path) => `migration:${path}`,
+    })
+
+    expect(result.status).toBe('convertible')
+    if (result.status !== 'convertible') return
+
+    const paragraph = result.content.root.children[0] as any
+    expect(paragraph.$.blockId).toBe('migration:root.children[0]')
+    expect(paragraph.children).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          displayName: 'Innei',
+          handle: 'Innei',
+          platform: 'GH',
+          type: 'mention',
+        }),
+        expect.objectContaining({ type: 'spoiler' }),
+        expect.objectContaining({ equation: 'E = mc^2', type: 'katex-inline' }),
+        expect.objectContaining({
+          type: 'autolink',
+          url: 'https://example.com',
+        }),
+      ]),
+    )
+    expect(result.features.map((feature) => feature.feature)).toEqual([
+      'mention',
+      'spoiler',
+      'katex-inline',
+    ])
+
+    const repeated = analyzeMxMarkdown(source, { profile: 'yohaku-v1' })
+    expect(repeated.sourceHash).toBe(result.sourceHash)
+    expect(result.sourceHash).toMatch(/^sha256:[a-f\d]{64}$/)
+  })
+
+  it('converts exact rich blocks and projects them back through the shared serializer', () => {
+    const source = `\`\`\`ts
+const answer = 42
+\`\`\`
+
+\`\`\`mermaid
+flowchart LR
+  A --> B
+\`\`\`
+
+$$
+x^2 + y^2
+$$
+
+---
+
+![Sea](https://example.com/sea.png "Caption")`
+    const result = convertible(source)
+    const children = result.content.root.children as any[]
+
+    expect(children.map((node) => node.type)).toEqual([
+      'code-block',
+      'mermaid',
+      'katex-block',
+      'horizontalrule',
+      'image',
+    ])
+    expect(children[0]).toMatchObject({
+      code: 'const answer = 42',
+      language: 'ts',
+    })
+    expect(children[1].diagram).toBe('flowchart LR\n  A --> B')
+    expect(children[2].equation).toBe('x^2 + y^2')
+    expect(children[4]).toMatchObject({
+      altText: 'Sea',
+      caption: 'Caption',
+      src: 'https://example.com/sea.png',
+    })
+
+    const projected = mxLexicalToMarkdown(result.content)
+    expect(projected).toContain('const answer = 42')
+    expect(projected).toContain('```mermaid')
+    expect(projected).toContain('https://example.com/sea.png')
+  })
+
+  it('returns source-located blockers for constructs without renderer parity', () => {
+    const result = analyzeMxMarkdown(`# Legacy anchor
+
+| A | B |
+| :- | -: |
+| 1 | 2 |
+
+Footnote[^1]
+
+[^1]: note
+
+::: gallery
+![x](https://example.com/x.png)
+:::
+
+<Tabs></Tabs>`, { profile: 'yohaku-v1' })
+
+    expect(result.status).toBe('blocked')
+    if (result.status !== 'blocked') return
+
+    const codes = result.issues.map((issue) => issue.code)
+    expect(codes).toEqual(
+      expect.arrayContaining([
+        'unsupported-heading-anchor-parity',
+        'unsupported-table',
+        'unsupported-footnote',
+        'unsupported-reference-definition',
+        'unsupported-container',
+        'unsupported-raw-html',
+      ]),
+    )
+    expect(result.issues[0].range.start).toMatchObject({
+      column: 1,
+      line: 1,
+      offset: 0,
+    })
+    expect(
+      result.issues.every(
+        (issue) => issue.range.end.offset >= issue.range.start.offset,
+      ),
+    ).toBe(true)
+  })
+
+  it('does not treat unsupported-looking content inside a code fence as syntax', () => {
+    const result = convertible(`\`\`\`md
+# heading
+::: gallery
+<script>alert(1)</script>
+[^1]
+\`\`\``)
+
+    expect(result.content.root.children).toEqual([
+      expect.objectContaining({
+        code: '# heading\n::: gallery\n<script>alert(1)</script>\n[^1]',
+        language: 'md',
+        type: 'code-block',
+      }),
+    ])
+  })
+
+  it('keeps malformed custom tokens literal instead of interpreting them more aggressively', () => {
+    const result = convertible('Literal {XX@name}, {GH@dash-name}, and unclosed ||text.')
+    const paragraph = result.content.root.children[0] as any
+    expect(paragraph.children.map((node: any) => node.text).join('')).toBe(
+      'Literal {XX@name}, {GH@dash-name}, and unclosed ||text.',
+    )
+  })
+
+  it('distinguishes a thematic break from an unsupported Setext heading', () => {
+    expect(convertible('Before\n\n---\n\nAfter').content.root.children).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ type: 'horizontalrule' }),
+      ]),
+    )
+
+    const setext = analyzeMxMarkdown('Heading\n---', {
+      profile: 'yohaku-v1',
+    })
+    expect(setext.status).toBe('blocked')
+    if (setext.status === 'blocked') {
+      expect(setext.issues[0]).toMatchObject({
+        code: 'unsupported-heading-anchor-parity',
+        range: { start: { line: 1 }, end: { line: 2 } },
+      })
+    }
+  })
+})

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1158,6 +1158,12 @@ importers:
       '@lexical/headless':
         specifier: 0.48.0
         version: 0.48.0(typescript@6.0.3)
+      '@lexical/markdown':
+        specifier: 0.48.0
+        version: 0.48.0(typescript@6.0.3)
+      '@noble/hashes':
+        specifier: 2.2.0
+        version: 2.2.0
       lexical:
         specifier: 0.48.0
         version: 0.48.0(typescript@6.0.3)


### PR DESCRIPTION
## Summary

- add a versioned, document-level Markdown analyzer and deterministic Lexical converter
- expose an interactive Admin migration flow with source-located blocking diagnostics and draft-only staging
- transition posts, notes, pages, and their valid AI translations to Lexical atomically under a shared format lock
- raise shared modal headers when a subtitle is present and align the close action with the title row

## Why

Existing non-empty Markdown documents could not switch formats. This change permits progressive migration when every syntax region in the active migration unit has a behavior-preserving mapping, while keeping unsupported documents in Markdown with actionable diagnostics.

## Impact

Supported documents can be staged as Lexical without publishing immediately. Publishing the staged document commits the source and existing AI translations as one guarded transition; unsupported syntax remains unchanged.

## Validation

- `pnpm -C packages/editor exec vitest run test/markdown-conversion.test.ts` — 8 tests passed
- `pnpm -C apps/core exec vitest run ...content-migration... note.service.spec.ts post.service.spec.ts` — 25 tests passed
- `pnpm -C apps/core exec vitest run test/src/modules/ai/ai-translation.repository.pg.e2e.spec.ts` — 3 tests passed
- Admin, Core, and Editor TypeScript checks passed
- ESLint and staged diff checks passed
- Browser verification measured a 65 px subtitle header and a 0 px title/close center-line delta
