### PR TITLE
fix(ios): recover pairing and refine glass actions

### DIFF
--- a/apps/ios/Packages/SpaceCore/Sources/SpaceCore/PairingService.swift
+++ b/apps/ios/Packages/SpaceCore/Sources/SpaceCore/PairingService.swift
@@ -1,4 +1,5 @@
 import Foundation
+import OpenAPIRuntime
 
 public struct PairingSession: Sendable, Equatable {
     public let deviceCode: String
@@ -92,37 +93,51 @@ public actor PairingService {
             guard now() < session.expiresAt else { throw PairingError.expired }
             try await sleep(interval)
 
-            let output = try await client.pollDeviceToken(
-                .init(
-                    body: .json(
-                        .init(
-                            grantType: .urn_colon_ietf_colon_params_colon_oauth_colon_grantType_colon_deviceCode,
-                            deviceCode: session.deviceCode,
-                            clientId: PairingService.clientID
+            do {
+                let output = try await client.pollDeviceToken(
+                    .init(
+                        body: .json(
+                            .init(
+                                grantType: .urn_colon_ietf_colon_params_colon_oauth_colon_grantType_colon_deviceCode,
+                                deviceCode: session.deviceCode,
+                                clientId: PairingService.clientID
+                            )
                         )
                     )
                 )
-            )
 
-            switch output {
-            case let .ok(response):
-                try tokenStore.write(try response.body.json.accessToken)
-                return
-            case let .clientError(_, response):
-                let payload = try response.body.json
-                switch payload.error {
-                case .authorizationPending:
-                    continue
-                case .slowDown:
-                    // RFC 8628 §3.5: back off by five seconds and keep polling.
-                    interval += .seconds(5)
-                default:
-                    throw PairingService.mapError(payload)
+                switch output {
+                case let .ok(response):
+                    try tokenStore.write(try response.body.json.accessToken)
+                    return
+                case let .clientError(_, response):
+                    let payload = try response.body.json
+                    switch payload.error {
+                    case .authorizationPending:
+                        continue
+                    case .slowDown:
+                        // RFC 8628 §3.5: back off by five seconds and keep polling.
+                        interval += .seconds(5)
+                    default:
+                        throw PairingService.mapError(payload)
+                    }
+                case let .serverError(statusCode, response):
+                    // A rolling deployment can briefly surface gateway errors.
+                    // They are safe to retry because the device code remains the
+                    // idempotency key for this polling operation.
+                    if [502, 503, 504].contains(statusCode) {
+                        continue
+                    }
+                    throw PairingService.mapError(try response.body.json)
+                case let .undocumented(statusCode, _):
+                    throw PairingError.server("unexpected status \(statusCode)")
                 }
-            case let .serverError(_, response):
-                throw PairingService.mapError(try response.body.json)
-            case let .undocumented(statusCode, _):
-                throw PairingError.server("unexpected status \(statusCode)")
+            } catch {
+                guard PairingService.isRetryableTransportError(error) else { throw error }
+                // The normal polling interval is applied again at the top of
+                // the loop, avoiding a tight retry while keeping the current
+                // pairing session and user code intact.
+                continue
             }
         }
     }
@@ -146,6 +161,25 @@ public actor PairingService {
         case .expiredToken: .expired
         case .invalidClient: .rejectedClient
         default: .server(payload.errorDescription ?? payload.error.rawValue)
+        }
+    }
+
+    private static func isRetryableTransportError(_ error: any Error) -> Bool {
+        let underlying = (error as? OpenAPIRuntime.ClientError)?.underlyingError ?? error
+        let nsError = underlying as NSError
+        guard nsError.domain == NSURLErrorDomain else { return false }
+
+        return switch URLError.Code(rawValue: nsError.code) {
+        case .timedOut,
+             .cannotFindHost,
+             .cannotConnectToHost,
+             .networkConnectionLost,
+             .dnsLookupFailed,
+             .notConnectedToInternet,
+             .resourceUnavailable:
+            true
+        default:
+            false
         }
     }
 }

--- a/apps/ios/Packages/SpaceCore/Tests/SpaceCoreTests/PairingServiceTests.swift
+++ b/apps/ios/Packages/SpaceCore/Tests/SpaceCoreTests/PairingServiceTests.swift
@@ -1,4 +1,6 @@
 import Foundation
+import HTTPTypes
+import OpenAPIRuntime
 import Testing
 
 @testable import SpaceCore
@@ -133,6 +135,37 @@ import Testing
         #expect(clock.slept == [.seconds(5), .seconds(10)])
     }
 
+    @Test func transientConnectionLossDoesNotAbortApprovalPolling() async throws {
+        let clock = TestClock(now: start)
+        let store = InMemoryTokenStore()
+        let scripted = StubTransport([
+            codeReply,
+            .init(
+                status: .ok,
+                json: #"{"access_token":"tok","token_type":"Bearer","expires_in":10}"#
+            ),
+        ])
+        let transport = FailFirstTokenPollTransport(scripted)
+        let client = Client(
+            serverURL: baseURL.appending(path: "api/v3"),
+            configuration: SpaceClient.configuration,
+            transport: transport
+        )
+        let service = PairingService(
+            client: client,
+            baseURL: baseURL,
+            tokenStore: store,
+            now: { clock.now },
+            sleep: { clock.advance(by: $0) }
+        )
+
+        let session = try await service.requestSession()
+        try await service.waitForApproval(session)
+
+        #expect(try store.read() == "tok")
+        #expect(clock.slept == [.seconds(5), .seconds(5)])
+    }
+
     @Test func deniedApprovalStopsPolling() async throws {
         let store = InMemoryTokenStore()
         let (service, _) = makeService(
@@ -160,6 +193,38 @@ import Testing
         // Nothing was polled — the deadline is checked before each request.
         #expect(transport.remainingCount == 0)
         #expect(transport.requestBodies.count == 1)
+    }
+}
+
+private final class FailFirstTokenPollTransport: ClientTransport, @unchecked Sendable {
+    private let lock = NSLock()
+    private var hasFailed = false
+    private let underlying: StubTransport
+
+    init(_ underlying: StubTransport) {
+        self.underlying = underlying
+    }
+
+    func send(
+        _ request: HTTPRequest,
+        body: HTTPBody?,
+        baseURL: URL,
+        operationID: String
+    ) async throws -> (HTTPResponse, HTTPBody?) {
+        let shouldFail = lock.withLock {
+            guard operationID == Operations.PollDeviceToken.id, !hasFailed else { return false }
+            hasFailed = true
+            return true
+        }
+        if shouldFail {
+            throw URLError(.networkConnectionLost)
+        }
+        return try await underlying.send(
+            request,
+            body: body,
+            baseURL: baseURL,
+            operationID: operationID
+        )
     }
 }
 

--- a/apps/ios/Packages/SpaceUI/Sources/SpaceUI/PrimaryGlassButton.swift
+++ b/apps/ios/Packages/SpaceUI/Sources/SpaceUI/PrimaryGlassButton.swift
@@ -1,0 +1,34 @@
+import UIKit
+
+/// The shared primary action used by full-page flows.
+///
+/// `prominentGlass` preserves the visual hierarchy of a primary action while
+/// the explicit intrinsic height keeps the control comfortably tappable.
+public final class PrimaryGlassButton: UIButton {
+    public static let minimumHeight: CGFloat = 52
+
+    public init(title: String) {
+        super.init(frame: .zero)
+
+        var configuration = UIButton.Configuration.prominentGlass()
+        configuration.title = title
+        configuration.cornerStyle = .capsule
+        configuration.contentInsets = NSDirectionalEdgeInsets(
+            top: Spacing.regular,
+            leading: Spacing.loose,
+            bottom: Spacing.regular,
+            trailing: Spacing.loose
+        )
+        self.configuration = configuration
+        titleLabel?.adjustsFontForContentSizeCategory = true
+    }
+
+    @available(*, unavailable)
+    required init?(coder: NSCoder) { fatalError("init(coder:) has not been implemented") }
+
+    public override var intrinsicContentSize: CGSize {
+        var size = super.intrinsicContentSize
+        size.height = max(size.height, Self.minimumHeight)
+        return size
+    }
+}

--- a/apps/ios/Packages/SpaceUI/Tests/SpaceUITests/GlassComponentTests.swift
+++ b/apps/ios/Packages/SpaceUI/Tests/SpaceUITests/GlassComponentTests.swift
@@ -29,4 +29,10 @@ import UIKit
     @Test func glassIsDisallowedWhenTransparencyIsReduced() {
         #expect(GlassAvailability.isGlassAllowed == !UIAccessibility.isReduceTransparencyEnabled)
     }
+
+    @Test func primaryButtonKeepsALargeTapTarget() {
+        let button = PrimaryGlassButton(title: "Continue")
+
+        #expect(button.intrinsicContentSize.height >= PrimaryGlassButton.minimumHeight)
+    }
 }

--- a/apps/ios/Space/Pairing/PairingCodeViewController.swift
+++ b/apps/ios/Space/Pairing/PairingCodeViewController.swift
@@ -8,7 +8,7 @@ final class PairingCodeViewController: UIViewController {
     private let qrView = UIImageView()
     private let statusLabel = UILabel()
     private let copyButton = UIButton(configuration: .plain())
-    private let openButton = UIButton(configuration: .borderedProminent())
+    private let openButton = PrimaryGlassButton(title: "Open approval page")
     private let spinner = UIActivityIndicatorView(style: .medium)
 
     private let endpoint: ServerEndpoint
@@ -55,7 +55,6 @@ final class PairingCodeViewController: UIViewController {
         statusLabel.accessibilityIdentifier = "pairing.status"
         statusLabel.text = "Requesting a code…"
 
-        openButton.setTitle("Open approval page", for: .normal)
         openButton.addTarget(self, action: #selector(openVerification), for: .touchUpInside)
         openButton.isHidden = true
 

--- a/apps/ios/Space/Pairing/ServerSetupViewController.swift
+++ b/apps/ios/Space/Pairing/ServerSetupViewController.swift
@@ -6,7 +6,7 @@ final class ServerSetupViewController: UIViewController {
     private let stepLabel = UILabel()
     private let headingLabel = UILabel()
     private let field = UITextField()
-    private let continueButton = UIButton(configuration: .borderedProminent())
+    private let continueButton = PrimaryGlassButton(title: "Continue")
     private let statusLabel = UILabel()
     private let spinner = UIActivityIndicatorView(style: .medium)
 
@@ -44,7 +44,6 @@ final class ServerSetupViewController: UIViewController {
         field.clearButtonMode = .whileEditing
         field.addTarget(self, action: #selector(submit), for: .editingDidEndOnExit)
 
-        continueButton.setTitle("Continue", for: .normal)
         continueButton.addTarget(self, action: #selector(submit), for: .touchUpInside)
 
         statusLabel.numberOfLines = 0


### PR DESCRIPTION
## Summary

- keep RFC 8628 device-token polling alive across transient URLSession disconnects and rolling-deploy gateway errors
- add a regression test for the observed `NSURLErrorNetworkConnectionLost (-1005)` path
- replace the Step 1 and Step 2 solid primary actions with a shared 52pt system glass button

## Validation

- [x] `swift test --package-path apps/ios/Packages/SpaceCore --filter PairingServiceTests`
- [x] `make -C apps/ios test`
- [x] `make -C apps/ios build`
- [x] simulator visual check on iPhone 17 Pro / iOS 26.5

## Context

The original error occurred while production was switching containers for v13.22.0. Production is now stable, but the client should not terminate an otherwise valid pairing session when one poll loses its connection.