### PR TITLE
feat(ai): add Google Vertex provider adapters

### DIFF
--- a/apps/admin/src/features/settings/components/ai/AIConfigEditor.tsx
+++ b/apps/admin/src/features/settings/components/ai/AIConfigEditor.tsx
@@ -29,6 +29,7 @@ import { formatAIProviderLabel } from '../../utils/settings'
 import { EmptyState, FieldShell, SettingsSection } from '../SettingsPrimitives'
 import { AIModelAssignmentField } from './AIModelAssignmentField'
 import { AIProviderDrawer } from './AIProviderDrawer'
+import { presentAIProviderPresetModal } from './AIProviderPresetModal'
 import { AITextListField } from './AITextListField'
 import { TtsVoiceField } from './TtsVoiceField'
 
@@ -113,8 +114,12 @@ export function AIConfigEditor(props: {
     })
   }
 
-  const addProviderFromPreset = (preset: AIProviderPreset) => {
-    const provider = createProviderFromPreset(preset)
+  const addProviderFromPreset = async (preset: AIProviderPreset) => {
+    const values = preset.templateFields?.length
+      ? await presentAIProviderPresetModal(preset)
+      : {}
+    if (values === undefined) return
+    const provider = createProviderFromPreset(preset, values)
     updateConfig({ providers: [...providers, provider] })
     setEditingId(provider.id)
   }
@@ -171,7 +176,7 @@ export function AIConfigEditor(props: {
                         <DropdownMenu.Item
                           className="items-start py-2"
                           key={preset.id}
-                          onClick={() => addProviderFromPreset(preset)}
+                          onClick={() => void addProviderFromPreset(preset)}
                         >
                           <span className="flex min-w-0 flex-col gap-0.5">
                             <span className="truncate font-medium">

--- a/apps/admin/src/features/settings/components/ai/AIProviderDrawer.tsx
+++ b/apps/admin/src/features/settings/components/ai/AIProviderDrawer.tsx
@@ -13,7 +13,11 @@ import { SelectField } from '~/ui/primitives/select'
 import { Switch } from '~/ui/primitives/switch'
 import { TextInput } from '~/ui/primitives/text-field'
 
-import { findAIProviderPreset } from '../../config/aiProviderPresets'
+import {
+  aiProviderPresets,
+  findAIProviderPreset,
+  interpolatePresetTemplate,
+} from '../../config/aiProviderPresets'
 import { aiProviderTypeOptions } from '../../constants'
 import type {
   AIProviderConfig,
@@ -52,6 +56,7 @@ export function AIProviderDrawer(props: {
   const provider = props.provider
   const textEnabled = provider?.capabilities?.text ?? true
   const matchedPreset = provider ? findAIProviderPreset(provider) : undefined
+  const isGoogleVertex = provider?.type === 'google-vertex'
 
   const showEndpoint = Boolean(provider)
   const piProviderId =
@@ -64,7 +69,18 @@ export function AIProviderDrawer(props: {
     staleTime: REGISTRY_STALE_MS,
   })
 
-  const registryModels = registryQuery.data ?? []
+  const registryModels = useMemo(
+    () =>
+      isGoogleVertex
+        ? (registryQuery.data ?? []).map((model) => ({
+            ...model,
+            id: model.id.startsWith('google/')
+              ? model.id
+              : `google/${model.id}`,
+          }))
+        : (registryQuery.data ?? []),
+    [isGoogleVertex, registryQuery.data],
+  )
   const modelOptions = useMemo(
     () => mergeModelOptions(props.providerModels, registryModels),
     [props.providerModels, registryModels],
@@ -297,19 +313,39 @@ export function AIProviderDrawer(props: {
               ) : null}
             </div>
           ) : null}
+          {isGoogleVertex ? (
+            <TextInput
+              label={t('settings.ai.field.projectId')}
+              onChange={(projectId) => {
+                const preset = aiProviderPresets.find(
+                  (item) => item.id === 'googleVertex',
+                )
+                props.onChange({
+                  projectId,
+                  endpoint:
+                    interpolatePresetTemplate(preset?.endpoint, {
+                      projectId,
+                    }) ?? provider.endpoint,
+                })
+              }}
+              placeholder={t('settings.ai.preset.modal.projectIdPlaceholder')}
+              spellCheck={false}
+              value={provider.projectId ?? ''}
+            />
+          ) : null}
           {showEndpoint ? (
             <TextInput
               label={t('settings.ai.field.endpoint')}
               onChange={(endpoint) => props.onChange({ endpoint })}
               placeholder={
-                provider.type === 'openai-compatible'
+                provider.type === 'openai-compatible' || isGoogleVertex
                   ? t('settings.ai.placeholder.endpointCompatible')
                   : t('settings.ai.placeholder.endpointDefault')
               }
               value={provider.endpoint ?? ''}
             />
           ) : null}
-          {textEnabled && provider.type !== 'anthropic' ? (
+          {textEnabled && provider.type !== 'anthropic' && !isGoogleVertex ? (
             <>
               <TextInput
                 label={t('settings.ai.field.modelListUrl')}
@@ -324,7 +360,7 @@ export function AIProviderDrawer(props: {
               />
             </>
           ) : null}
-          {provider.capabilities?.speech ? (
+          {provider.capabilities?.speech && !isGoogleVertex ? (
             <TextInput
               label={t('settings.ai.field.voiceListUrl')}
               onChange={(voiceListUrl) => props.onChange({ voiceListUrl })}

--- a/apps/admin/src/features/settings/components/ai/AIProviderPresetModal.tsx
+++ b/apps/admin/src/features/settings/components/ai/AIProviderPresetModal.tsx
@@ -1,0 +1,90 @@
+import { CloudCog } from 'lucide-react'
+import { useState } from 'react'
+import { toast } from 'sonner'
+
+import { useI18n } from '~/i18n'
+import { ModalFooter, ModalHeader } from '~/ui/feedback/modal'
+import { present, useModal } from '~/ui/feedback/modal-imperative'
+import { Button } from '~/ui/primitives/button'
+import { TextInput } from '~/ui/primitives/text-field'
+
+import {
+  type AIProviderPreset,
+  type AIProviderPresetTemplateValues,
+  interpolatePresetTemplate,
+} from '../../config/aiProviderPresets'
+
+function AIProviderPresetModal(props: { preset: AIProviderPreset }) {
+  const { t } = useI18n()
+  const modal = useModal<AIProviderPresetTemplateValues>()
+  const [values, setValues] = useState<AIProviderPresetTemplateValues>({})
+  const endpoint = interpolatePresetTemplate(props.preset.endpoint, values)
+
+  const submit = () => {
+    const missingRequiredField = props.preset.templateFields?.some(
+      (field) => field.required && !values[field.key]?.trim(),
+    )
+    if (missingRequiredField) {
+      toast.warning(t('settings.ai.preset.modal.requiredField'))
+      return
+    }
+    modal.close(values)
+  }
+
+  return (
+    <form
+      className="flex w-[min(92vw,30rem)] flex-col"
+      onSubmit={(event) => {
+        event.preventDefault()
+        submit()
+      }}
+    >
+      <ModalHeader
+        icon={CloudCog}
+        subtitle={t('settings.ai.preset.modal.description')}
+        title={t('settings.ai.preset.modal.title')}
+      />
+      <div className="space-y-4 px-5 py-5">
+        {props.preset.templateFields?.map((field) => (
+          <div className="space-y-1.5" key={field.key}>
+            <TextInput
+              autoFocus
+              label={t('settings.ai.field.projectId')}
+              onChange={(projectId) =>
+                setValues((current) => ({ ...current, projectId }))
+              }
+              placeholder={t('settings.ai.preset.modal.projectIdPlaceholder')}
+              required={field.required}
+              spellCheck={false}
+              value={values.projectId ?? ''}
+            />
+            <p className="text-xs leading-5 text-fg-muted">
+              {t('settings.ai.preset.modal.projectIdHelp')}
+            </p>
+          </div>
+        ))}
+        <div className="rounded-md border border-border bg-surface-inset px-3 py-2.5">
+          <div className="mb-1 text-xs font-medium text-fg-muted">
+            {t('settings.ai.preset.modal.endpointPreview')}
+          </div>
+          <div className="break-all font-mono text-xs leading-5 text-fg">
+            {endpoint}
+          </div>
+        </div>
+      </div>
+      <ModalFooter>
+        <Button onClick={() => modal.dismiss()} type="button" variant="subtle">
+          {t('common.cancel')}
+        </Button>
+        <Button type="submit">{t('settings.ai.preset.modal.add')}</Button>
+      </ModalFooter>
+    </form>
+  )
+}
+
+export function presentAIProviderPresetModal(preset: AIProviderPreset) {
+  return present<{ preset: AIProviderPreset }, AIProviderPresetTemplateValues>(
+    AIProviderPresetModal,
+    { preset },
+  )
+}

--- a/apps/admin/src/features/settings/config/aiProviderPresets.test.ts
+++ b/apps/admin/src/features/settings/config/aiProviderPresets.test.ts
@@ -59,15 +59,6 @@ describe('createProviderFromPreset', () => {
         'https://generativelanguage.googleapis.com/v1beta/openai/models',
       name: 'Google AI (Gemini)',
     },
-    {
-      defaultModel: 'google/gemini-3.6-flash',
-      endpoint:
-        'https://aiplatform.googleapis.com/v1/projects/PROJECT_ID/locations/global/endpoints/openapi',
-      id: 'googleVertex',
-      modelListUrl:
-        'https://aiplatform.googleapis.com/v1/projects/PROJECT_ID/locations/global/endpoints/openapi/models',
-      name: 'Google Vertex AI',
-    },
   ])('creates the $name compatibility provider', (expected) => {
     vi.stubGlobal('crypto', {
       randomUUID: () => `${expected.id}-uuid`,
@@ -87,6 +78,27 @@ describe('createProviderFromPreset', () => {
       name: expected.name,
       type: 'openai-compatible',
     })
+  })
+
+  it('interpolates the Vertex project and enables all supported capabilities', () => {
+    vi.stubGlobal('crypto', {
+      randomUUID: () => 'vertex-uuid',
+    })
+    const preset = aiProviderPresets.find(({ id }) => id === 'googleVertex')
+    const provider = createProviderFromPreset(preset!, {
+      projectId: 'example-project-123',
+    })
+
+    expect(provider).toMatchObject({
+      capabilities: { image: true, speech: true, text: true },
+      defaultModel: 'google/gemini-3.6-flash',
+      endpoint:
+        'https://aiplatform.googleapis.com/v1/projects/example-project-123/locations/global/endpoints/openapi',
+      modelListUrl: undefined,
+      projectId: 'example-project-123',
+      type: 'google-vertex',
+    })
+    expect(provider.endpoint).not.toContain('{{')
   })
 })
 

--- a/apps/admin/src/features/settings/config/aiProviderPresets.ts
+++ b/apps/admin/src/features/settings/config/aiProviderPresets.ts
@@ -4,6 +4,15 @@ import { getDefaultAIModel } from '../utils/settings'
 export type AIProviderPresetCategory =
   'aggregator' | 'cn_official' | 'custom' | 'official'
 
+export interface AIProviderPresetTemplateField {
+  key: 'projectId'
+  required?: boolean
+}
+
+export type AIProviderPresetTemplateValues = Partial<
+  Record<AIProviderPresetTemplateField['key'], string>
+>
+
 export interface AIProviderPreset {
   apiKeyUrl?: string
   appendV1?: boolean
@@ -14,6 +23,7 @@ export interface AIProviderPreset {
   id: string
   modelListUrl?: string
   name: string
+  templateFields?: readonly AIProviderPresetTemplateField[]
   type: AIProviderType
   websiteUrl?: string
 }
@@ -21,6 +31,12 @@ export interface AIProviderPreset {
 const TEXT_ONLY: AIProviderConfig['capabilities'] = {
   image: false,
   speech: false,
+  text: true,
+}
+
+const ALL_CAPABILITIES: AIProviderConfig['capabilities'] = {
+  image: true,
+  speech: true,
   text: true,
 }
 
@@ -65,16 +81,16 @@ export const aiProviderPresets: readonly AIProviderPreset[] = [
   {
     id: 'googleVertex',
     name: 'Google Vertex AI',
-    type: 'openai-compatible',
+    type: 'google-vertex',
     endpoint:
-      'https://aiplatform.googleapis.com/v1/projects/PROJECT_ID/locations/global/endpoints/openapi',
-    modelListUrl:
-      'https://aiplatform.googleapis.com/v1/projects/PROJECT_ID/locations/global/endpoints/openapi/models',
+      'https://aiplatform.googleapis.com/v1/projects/{{projectId}}/locations/global/endpoints/openapi',
     appendV1: false,
     defaultModel: 'google/gemini-3.6-flash',
     category: 'official',
     websiteUrl: 'https://console.cloud.google.com/vertex-ai',
-    capabilities: TEXT_ONLY,
+    apiKeyUrl: 'https://console.cloud.google.com/apis/credentials',
+    capabilities: ALL_CAPABILITIES,
+    templateFields: [{ key: 'projectId', required: true }],
   },
   {
     id: 'deepseek',
@@ -153,7 +169,9 @@ export const AI_PROVIDER_PRESET_CATEGORY_ORDER: readonly AIProviderPresetCategor
 
 export function createProviderFromPreset(
   preset: AIProviderPreset,
+  values: AIProviderPresetTemplateValues = {},
 ): AIProviderConfig {
+  const projectId = values.projectId?.trim()
   return {
     apiKey: '',
     appendV1: preset.appendV1,
@@ -164,12 +182,37 @@ export function createProviderFromPreset(
     },
     defaultModel: preset.defaultModel,
     enabled: true,
-    endpoint: preset.endpoint?.trim() || undefined,
+    endpoint: interpolatePresetTemplate(preset.endpoint, values),
     id: crypto.randomUUID(),
     modelListUrl: preset.modelListUrl,
     name: preset.id === 'custom' ? '' : preset.name,
+    projectId: projectId || undefined,
     type: preset.type,
   }
+}
+
+export function interpolatePresetTemplate(
+  template: string | undefined,
+  values: AIProviderPresetTemplateValues,
+): string | undefined {
+  const normalized = template?.trim()
+  if (!normalized) return undefined
+
+  let cursor = 0
+  let result = ''
+  while (cursor < normalized.length) {
+    const start = normalized.indexOf('{{', cursor)
+    if (start === -1) return result + normalized.slice(cursor)
+    const end = normalized.indexOf('}}', start + 2)
+    if (end === -1) return result + normalized.slice(cursor)
+
+    const key = normalized.slice(start + 2, end).trim()
+    const value = values[key as keyof AIProviderPresetTemplateValues]?.trim()
+    result += normalized.slice(cursor, start)
+    result += value ? encodeURIComponent(value) : ''
+    cursor = end + 2
+  }
+  return result
 }
 
 export function findAIProviderPreset(

--- a/apps/admin/src/features/settings/constants.ts
+++ b/apps/admin/src/features/settings/constants.ts
@@ -64,6 +64,7 @@ export const aiProviderTypeOptions: Array<{
     labelKey: 'settings.ai.providerType.openaiCompatible',
     value: 'openai-compatible',
   },
+  { labelKey: 'settings.ai.providerType.googleVertex', value: 'google-vertex' },
   { labelKey: 'settings.ai.providerType.anthropic', value: 'anthropic' },
   { labelKey: 'settings.ai.providerType.generic', value: 'generic' },
 ]

--- a/apps/admin/src/features/settings/types/settings.ts
+++ b/apps/admin/src/features/settings/types/settings.ts
@@ -3,7 +3,8 @@ import type { LucideIcon } from 'lucide-react'
 import type { ConfigFormGroup } from '~/api/options'
 import type { TranslationKey } from '~/i18n/types'
 
-export type AIProviderType = 'anthropic' | 'generic' | 'openai-compatible'
+export type AIProviderType =
+  'anthropic' | 'generic' | 'google-vertex' | 'openai-compatible'
 export type AIProviderCapability = 'image' | 'speech' | 'text'
 
 export interface AIProviderCapabilities {
@@ -24,6 +25,7 @@ export interface AIProviderConfig {
   maxTokens?: number | null
   modelListUrl?: string
   name: string
+  projectId?: string
   type: AIProviderType
   voiceListUrl?: string
 }

--- a/apps/admin/src/features/settings/utils/settings.test.ts
+++ b/apps/admin/src/features/settings/utils/settings.test.ts
@@ -169,6 +169,34 @@ describe('coerceAIProviderType', () => {
 })
 
 describe('normalizeAIConfig', () => {
+  it('upgrades the legacy Vertex preset to the dedicated three-capability provider', () => {
+    const config = normalizeAIConfig({
+      version: 2,
+      providers: [
+        {
+          apiKey: 'vertex-key',
+          capabilities: { image: false, speech: false, text: true },
+          defaultModel: 'google/gemini-3.6-flash',
+          enabled: true,
+          endpoint:
+            'https://aiplatform.googleapis.com/v1/projects/example-project/locations/global/endpoints/openapi',
+          id: 'vertex',
+          modelListUrl:
+            'https://aiplatform.googleapis.com/v1/projects/example-project/locations/global/endpoints/openapi/models',
+          name: 'Google Vertex AI',
+          type: 'openai-compatible',
+        },
+      ],
+    })
+
+    expect(config.providers?.[0]).toMatchObject({
+      capabilities: { image: true, speech: true, text: true },
+      modelListUrl: '',
+      projectId: 'example-project',
+      type: 'google-vertex',
+    })
+  })
+
   it('upgrades legacy providers with text capability defaults while preserving media routes', () => {
     const config = normalizeAIConfig({
       providers: [

--- a/apps/admin/src/features/settings/utils/settings.ts
+++ b/apps/admin/src/features/settings/utils/settings.ts
@@ -123,29 +123,61 @@ export function normalizeAIConfig(value: unknown): AIConfig {
   return {
     ...config,
     version: 2,
-    providers: (config.providers ?? []).map((provider) => ({
-      apiKey: provider.apiKey ?? '',
-      appendV1: provider.appendV1 ?? true,
-      contextWindow: provider.contextWindow ?? undefined,
-      defaultModel: provider.defaultModel ?? '',
-      enabled: Boolean(provider.enabled),
-      endpoint: provider.endpoint ?? '',
-      id: provider.id || crypto.randomUUID(),
-      maxTokens: provider.maxTokens ?? undefined,
-      modelListUrl: provider.modelListUrl ?? '',
-      name: provider.name ?? '',
-      type: coerceAIProviderType(provider.type),
-      capabilities: {
-        text: provider.capabilities?.text ?? true,
-        image: provider.capabilities?.image ?? false,
-        speech: provider.capabilities?.speech ?? false,
-      },
-    })),
+    providers: (config.providers ?? []).map((provider) => {
+      const endpoint = provider.endpoint ?? ''
+      const isLegacyVertex =
+        provider.type === 'openai-compatible' && isVertexEndpoint(endpoint)
+      return {
+        apiKey: provider.apiKey ?? '',
+        appendV1: provider.appendV1 ?? true,
+        contextWindow: provider.contextWindow ?? undefined,
+        defaultModel: provider.defaultModel ?? '',
+        enabled: Boolean(provider.enabled),
+        endpoint,
+        id: provider.id || crypto.randomUUID(),
+        maxTokens: provider.maxTokens ?? undefined,
+        modelListUrl: isLegacyVertex ? '' : (provider.modelListUrl ?? ''),
+        name: provider.name ?? '',
+        projectId: provider.projectId ?? extractVertexProjectId(endpoint) ?? '',
+        type: isLegacyVertex
+          ? ('google-vertex' as const)
+          : coerceAIProviderType(provider.type),
+        capabilities: isLegacyVertex
+          ? { image: true, speech: true, text: true }
+          : {
+              text: provider.capabilities?.text ?? true,
+              image: provider.capabilities?.image ?? false,
+              speech: provider.capabilities?.speech ?? false,
+            },
+      }
+    }),
+  }
+}
+
+function isVertexEndpoint(endpoint: string): boolean {
+  try {
+    const url = new URL(endpoint)
+    return (
+      url.hostname === 'aiplatform.googleapis.com' &&
+      url.pathname.endsWith('/endpoints/openapi')
+    )
+  } catch {
+    return false
+  }
+}
+
+function extractVertexProjectId(endpoint: string): string | undefined {
+  try {
+    const match = new URL(endpoint).pathname.match(/\/projects\/([^/]+)/)
+    return match?.[1] ? decodeURIComponent(match[1]) : undefined
+  } catch {
+    return undefined
   }
 }
 
 export function coerceAIProviderType(value: unknown): AIProviderType {
-  if (value === 'anthropic' || value === 'generic') return value
+  if (value === 'anthropic' || value === 'generic' || value === 'google-vertex')
+    return value
   return 'openai-compatible'
 }
 
@@ -166,6 +198,9 @@ export function getDefaultAIModel(type: AIProviderType) {
     case 'generic': {
       return ''
     }
+    case 'google-vertex': {
+      return 'google/gemini-3.6-flash'
+    }
     case 'openai-compatible': {
       return ''
     }
@@ -183,6 +218,9 @@ export function getAIProviderNamePlaceholder(
     case 'generic': {
       return t('settings.ai.placeholder.nameCompatible')
     }
+    case 'google-vertex': {
+      return 'Google Vertex AI'
+    }
     case 'openai-compatible': {
       return t('settings.ai.placeholder.nameCompatible')
     }
@@ -198,6 +236,9 @@ export function getAIProviderKeyPlaceholder(type: AIProviderType) {
     case 'openai-compatible': {
       return 'sk-...'
     }
+    case 'google-vertex': {
+      return 'AQ.…'
+    }
   }
 }
 
@@ -212,6 +253,9 @@ export function getAIProviderModelPlaceholder(
     case 'generic': {
       return t('settings.ai.placeholder.modelCompatible')
     }
+    case 'google-vertex': {
+      return 'google/gemini-3.6-flash'
+    }
     case 'openai-compatible': {
       return t('settings.ai.placeholder.modelCompatible')
     }
@@ -223,6 +267,7 @@ const PI_PROVIDER_HOSTNAMES: Record<string, string> = {
   'api.deepseek.com': 'deepseek',
   'api.openai.com': 'openai',
   'openrouter.ai': 'openrouter',
+  'aiplatform.googleapis.com': 'google-vertex',
 }
 
 export function resolvePiProviderId(provider: {
@@ -244,6 +289,9 @@ export function resolvePiProviderId(provider: {
     }
     case 'openai-compatible': {
       return 'openai'
+    }
+    case 'google-vertex': {
+      return 'google-vertex'
     }
     case 'generic': {
       return null

--- a/apps/admin/src/i18n/resources/en-US.ts
+++ b/apps/admin/src/i18n/resources/en-US.ts
@@ -2023,6 +2023,7 @@ export const enUS = {
   'settings.ai.field.maxTokens': 'Max output tokens',
   'settings.ai.field.modelListUrl': 'Model list URL',
   'settings.ai.field.providerType': 'Provider type',
+  'settings.ai.field.projectId': 'Google Cloud Project ID',
   'settings.ai.field.speed': 'Speech speed',
   'settings.ai.field.voice': 'Voice ID',
   'settings.ai.field.voiceListUrl': 'Voice list URL',
@@ -2053,7 +2054,18 @@ export const enUS = {
   'settings.ai.provider.row.empty': 'No model assigned',
   'settings.ai.providerType.anthropic': 'Anthropic',
   'settings.ai.providerType.generic': 'Generic',
+  'settings.ai.providerType.googleVertex': 'Google Vertex AI',
   'settings.ai.providerType.openaiCompatible': 'OpenAI compatible',
+  'settings.ai.preset.modal.add': 'Add provider',
+  'settings.ai.preset.modal.description':
+    'Complete the project fields to generate the Vertex endpoint. The API key can be entered in the provider details.',
+  'settings.ai.preset.modal.endpointPreview': 'Generated endpoint',
+  'settings.ai.preset.modal.projectIdHelp':
+    'Use a Google Cloud project with the Vertex AI API enabled.',
+  'settings.ai.preset.modal.projectIdPlaceholder':
+    'e.g. my-google-cloud-project',
+  'settings.ai.preset.modal.requiredField': 'Enter the Google Cloud Project ID',
+  'settings.ai.preset.modal.title': 'Configure Google Vertex AI',
   'settings.ai.voiceDiscovery.empty':
     'No voices discovered. Enter a provider voice ID manually.',
   'settings.ai.voiceDiscovery.error':

--- a/apps/admin/src/i18n/resources/zh-CN.ts
+++ b/apps/admin/src/i18n/resources/zh-CN.ts
@@ -1933,6 +1933,7 @@ export const zhCN = {
   'settings.ai.field.maxTokens': '最大输出 tokens',
   'settings.ai.field.modelListUrl': '模型列表地址',
   'settings.ai.field.providerType': '服务类型',
+  'settings.ai.field.projectId': 'Google Cloud Project ID',
   'settings.ai.field.speed': '语速',
   'settings.ai.field.voice': '音色 ID',
   'settings.ai.field.voiceListUrl': '音色列表地址',
@@ -1961,7 +1962,18 @@ export const zhCN = {
   'settings.ai.provider.row.empty': '未指定模型',
   'settings.ai.providerType.anthropic': 'Anthropic',
   'settings.ai.providerType.generic': '通用兼容服务',
+  'settings.ai.providerType.googleVertex': 'Google Vertex AI',
   'settings.ai.providerType.openaiCompatible': 'OpenAI 兼容服务',
+  'settings.ai.preset.modal.add': '添加服务商',
+  'settings.ai.preset.modal.description':
+    '填写项目字段后，系统将生成 Vertex Endpoint；API Key 可在服务商详情中继续填写。',
+  'settings.ai.preset.modal.endpointPreview': '生成的 Endpoint',
+  'settings.ai.preset.modal.projectIdHelp':
+    '使用已启用 Vertex AI API 的 Google Cloud 项目 ID。',
+  'settings.ai.preset.modal.projectIdPlaceholder':
+    '例如 my-google-cloud-project',
+  'settings.ai.preset.modal.requiredField': '请填写 Google Cloud Project ID',
+  'settings.ai.preset.modal.title': '配置 Google Vertex AI',
   'settings.ai.voiceDiscovery.empty': '未发现音色，可手动输入服务商音色 ID。',
   'settings.ai.voiceDiscovery.error':
     '音色发现失败：{error}。仍可手动输入音色 ID。',

--- a/apps/core/src/modules/ai/ai-agent/ai-agent-chat.service.ts
+++ b/apps/core/src/modules/ai/ai-agent/ai-agent-chat.service.ts
@@ -13,15 +13,10 @@ import { AppErrorCode, createAppException } from '~/common/errors'
 import { ConfigsService } from '~/modules/configs/configs.service'
 
 import type { AIProviderConfig } from '../ai.types'
-import { AIProviderType } from '../ai.types'
-import { createModelRuntime, resolveOpenAICompatibleBaseUrl } from '../runtime'
+import type { RuntimeProviderInfo } from '../runtime'
+import { createModelRuntime } from '../runtime'
 import { convert as convertJsonSchema } from '../runtime/json-schema-to-typebox'
 import { AiAgentConversationRepository } from './ai-agent-conversation.repository'
-
-const AI_SDK_ATTRIBUTION_HEADERS = {
-  'X-Title': 'Mix Space',
-  'HTTP-Referer': 'https://github.com/mx-space/core',
-} as const
 
 interface ChatToolInput {
   name: string
@@ -82,7 +77,10 @@ export class AiAgentChatService {
       parameters: convertJsonSchema(t.parameters, { toolName: t.name }),
     }))
 
-    const { systemPrompt, piMessages } = this.toPiMessages(options.messages)
+    const { systemPrompt, piMessages } = toPiMessages(
+      options.messages,
+      runtime.providerInfo,
+    )
 
     const events = runtime.streamMessage({
       messages: piMessages,
@@ -177,8 +175,7 @@ export class AiAgentChatService {
           this.buildDraftAssistantMessage({
             slots,
             usage: finalUsage,
-            provider,
-            model: options.model,
+            runtime: runtime.providerInfo,
             terminated: terminated ?? 'abort',
           })
         await this.persistAssistantMessage(options.conversationId, draft).catch(
@@ -191,99 +188,10 @@ export class AiAgentChatService {
     }
   }
 
-  private toPiMessages(messages: Record<string, unknown>[]): {
-    systemPrompt: string | undefined
-    piMessages: PiMessage[]
-  } {
-    const systemParts: string[] = []
-    const piMessages: PiMessage[] = []
-    const ts = Date.now()
-
-    for (const m of messages) {
-      const role = String(m.role ?? '')
-      if (role === 'system') {
-        if (typeof m.content === 'string') systemParts.push(m.content)
-        continue
-      }
-      if (role === 'user') {
-        piMessages.push({
-          role: 'user',
-          content: typeof m.content === 'string' ? m.content : '',
-          timestamp: ts,
-        })
-        continue
-      }
-      if (role === 'assistant') {
-        piMessages.push({
-          role: 'assistant',
-          content: [{ type: 'text', text: String(m.content ?? '') }],
-          api: 'openai-completions',
-          provider: 'openai',
-          model: '',
-          usage: zeroUsage(),
-          stopReason: 'stop',
-          timestamp: ts,
-        } as AssistantMessage)
-        continue
-      }
-      if (role === 'assistant_tool_call') {
-        const toolCalls = Array.isArray(m.toolCalls) ? m.toolCalls : []
-        const content: AssistantMessage['content'] = []
-        if (typeof m.content === 'string' && m.content.length > 0) {
-          content.push({ type: 'text', text: m.content })
-        }
-        for (const tc of toolCalls as Array<Record<string, unknown>>) {
-          let args: unknown = tc.arguments
-          if (typeof args === 'string') {
-            try {
-              args = JSON.parse(args)
-            } catch {
-              args = {}
-            }
-          }
-          content.push({
-            type: 'toolCall',
-            id: String(tc.id ?? ''),
-            name: String(tc.name ?? ''),
-            arguments: (args ?? {}) as Record<string, unknown>,
-          })
-        }
-        piMessages.push({
-          role: 'assistant',
-          content,
-          api: 'openai-completions',
-          provider: 'openai',
-          model: '',
-          usage: zeroUsage(),
-          stopReason: 'toolUse',
-          timestamp: ts,
-        } as AssistantMessage)
-        continue
-      }
-      if (role === 'tool_result') {
-        piMessages.push({
-          role: 'toolResult',
-          toolCallId: String(m.toolCallId ?? ''),
-          toolName: String(m.toolName ?? ''),
-          content: [{ type: 'text', text: String(m.content ?? '') }],
-          isError: Boolean(m.isError),
-          timestamp: ts,
-        })
-        continue
-      }
-    }
-
-    return {
-      systemPrompt: systemParts.length > 0 ? systemParts.join('\n') : undefined,
-      piMessages,
-    }
-  }
-
   private buildDraftAssistantMessage(args: {
     slots: Map<number, ContentSlot>
     usage: Usage | undefined
-    provider: AIProviderConfig
-    model: string
+    runtime: RuntimeProviderInfo
     terminated: 'done' | 'error' | 'abort'
   }): AssistantMessage {
     const indexes = [...args.slots.keys()].sort((a, b) => a - b)
@@ -312,12 +220,9 @@ export class AiAgentChatService {
     return {
       role: 'assistant',
       content,
-      api:
-        args.provider.type === AIProviderType.Anthropic
-          ? 'anthropic-messages'
-          : 'openai-completions',
-      provider: args.provider.id,
-      model: args.model,
+      api: args.runtime.api ?? 'openai-completions',
+      provider: args.runtime.id,
+      model: args.runtime.model,
       usage: args.usage ?? zeroUsage(),
       stopReason: args.terminated === 'abort' ? 'aborted' : 'stop',
       timestamp: Date.now(),
@@ -334,165 +239,96 @@ export class AiAgentChatService {
       messages: [...existing.messages, message],
     })
   }
+}
 
-  /**
-   * Legacy fetch-based proxy. Retained until step-12 rewires the controller to
-   * consume streamChat directly; do not extend.
-   */
-  buildRequestBody(
-    provider: AIProviderConfig,
-    model: string,
-    messages: Record<string, unknown>[],
-    tools?: ChatToolInput[],
-  ): { url: string; headers: Record<string, string>; body: string } {
-    if (provider.type === AIProviderType.Anthropic) {
-      return this.buildClaudeRequest(provider, model, messages, tools)
+export function toPiMessages(
+  messages: Record<string, unknown>[],
+  runtime: RuntimeProviderInfo,
+): {
+  systemPrompt: string | undefined
+  piMessages: PiMessage[]
+} {
+  const systemParts: string[] = []
+  const piMessages: PiMessage[] = []
+  const ts = Date.now()
+
+  for (const m of messages) {
+    const role = String(m.role ?? '')
+    if (role === 'system') {
+      if (typeof m.content === 'string') systemParts.push(m.content)
+      continue
     }
-    return this.buildOpenAIRequest(provider, model, messages, tools)
-  }
-
-  private buildClaudeRequest(
-    provider: AIProviderConfig,
-    model: string,
-    messages: Record<string, unknown>[],
-    tools?: ChatToolInput[],
-  ) {
-    const systemMsgs = messages.filter((m) => m.role === 'system')
-    const nonSystemMsgs = messages.filter((m) => m.role !== 'system')
-
-    const claudeMessages = nonSystemMsgs.map((m) => {
-      if (m.role === 'user') return { role: 'user', content: m.content }
-      if (m.role === 'assistant')
-        return { role: 'assistant', content: m.content }
-      if (m.role === 'assistant_tool_call') {
-        return {
-          role: 'assistant',
-          content: (m.toolCalls as any[]).map((tc) => ({
-            type: 'tool_use',
-            id: tc.id,
-            name: tc.name,
-            input: JSON.parse(tc.arguments as string),
-          })),
-        }
+    if (role === 'user') {
+      piMessages.push({
+        role: 'user',
+        content: typeof m.content === 'string' ? m.content : '',
+        timestamp: ts,
+      })
+      continue
+    }
+    if (role === 'assistant') {
+      piMessages.push({
+        role: 'assistant',
+        content: [{ type: 'text', text: String(m.content ?? '') }],
+        api: runtime.api ?? 'openai-completions',
+        provider: runtime.id,
+        model: runtime.model,
+        usage: zeroUsage(),
+        stopReason: 'stop',
+        timestamp: ts,
+      } as AssistantMessage)
+      continue
+    }
+    if (role === 'assistant_tool_call') {
+      const toolCalls = Array.isArray(m.toolCalls) ? m.toolCalls : []
+      const content: AssistantMessage['content'] = []
+      if (typeof m.content === 'string' && m.content.length > 0) {
+        content.push({ type: 'text', text: m.content })
       }
-      if (m.role === 'tool_result') {
-        return {
-          role: 'user',
-          content: [
-            {
-              type: 'tool_result',
-              tool_use_id: m.toolCallId,
-              content: m.content,
-              is_error: m.isError,
-            },
-          ],
+      for (const tc of toolCalls as Array<Record<string, unknown>>) {
+        let args: unknown = tc.arguments
+        if (typeof args === 'string') {
+          try {
+            args = JSON.parse(args)
+          } catch {
+            args = {}
+          }
         }
+        content.push({
+          type: 'toolCall',
+          id: String(tc.id ?? ''),
+          name: String(tc.name ?? ''),
+          arguments: (args ?? {}) as Record<string, unknown>,
+        })
       }
-      return { role: m.role, content: m.content }
-    })
-
-    const claudeTools = tools?.map((t) => ({
-      name: t.name,
-      description: t.description,
-      input_schema: t.parameters,
-    }))
-
-    const body: Record<string, unknown> = {
-      model,
-      max_tokens: 4096,
-      stream: true,
-      messages: claudeMessages,
+      piMessages.push({
+        role: 'assistant',
+        content,
+        api: runtime.api ?? 'openai-completions',
+        provider: runtime.id,
+        model: runtime.model,
+        usage: zeroUsage(),
+        stopReason: 'toolUse',
+        timestamp: ts,
+      } as AssistantMessage)
+      continue
     }
-
-    if (systemMsgs.length > 0) {
-      body.system = systemMsgs.map((m) => ({ type: 'text', text: m.content }))
-    }
-    if (claudeTools?.length) {
-      body.tools = claudeTools
-    }
-    if (model.includes('opus') || model.includes('sonnet')) {
-      body.thinking = { type: 'enabled', budget_tokens: 2048 }
-    }
-
-    const baseUrl = provider.endpoint || 'https://api.anthropic.com/v1'
-
-    return {
-      url: `${baseUrl}/messages`,
-      headers: {
-        'Content-Type': 'application/json',
-        'x-api-key': provider.apiKey,
-        'anthropic-version': '2023-06-01',
-        'anthropic-beta': 'interleaved-thinking-2025-05-14',
-        ...AI_SDK_ATTRIBUTION_HEADERS,
-      },
-      body: JSON.stringify(body),
+    if (role === 'tool_result') {
+      piMessages.push({
+        role: 'toolResult',
+        toolCallId: String(m.toolCallId ?? ''),
+        toolName: String(m.toolName ?? ''),
+        content: [{ type: 'text', text: String(m.content ?? '') }],
+        isError: Boolean(m.isError),
+        timestamp: ts,
+      })
+      continue
     }
   }
 
-  private buildOpenAIRequest(
-    provider: AIProviderConfig,
-    model: string,
-    messages: Record<string, unknown>[],
-    tools?: ChatToolInput[],
-  ) {
-    const openaiMessages = messages.map((m) => {
-      if (m.role === 'system') return { role: 'system', content: m.content }
-      if (m.role === 'user') return { role: 'user', content: m.content }
-      if (m.role === 'assistant')
-        return { role: 'assistant', content: m.content }
-      if (m.role === 'assistant_tool_call') {
-        return {
-          role: 'assistant',
-          content: null,
-          tool_calls: (m.toolCalls as any[]).map((tc) => ({
-            id: tc.id,
-            type: 'function',
-            function: { name: tc.name, arguments: tc.arguments },
-          })),
-        }
-      }
-      if (m.role === 'tool_result') {
-        return {
-          role: 'tool',
-          tool_call_id: m.toolCallId,
-          content: m.content,
-        }
-      }
-      return { role: m.role, content: m.content }
-    })
-
-    const openaiTools = tools?.map((t) => ({
-      type: 'function' as const,
-      function: {
-        name: t.name,
-        description: t.description,
-        parameters: t.parameters,
-      },
-    }))
-
-    const body: Record<string, unknown> = {
-      model,
-      stream: true,
-      messages: openaiMessages,
-    }
-    if (openaiTools?.length) {
-      body.tools = openaiTools
-    }
-
-    const baseUrl = resolveOpenAICompatibleBaseUrl(
-      provider.endpoint,
-      provider.appendV1 ?? true,
-    )
-
-    return {
-      url: `${baseUrl}/chat/completions`,
-      headers: {
-        'Content-Type': 'application/json',
-        Authorization: `Bearer ${provider.apiKey}`,
-        ...AI_SDK_ATTRIBUTION_HEADERS,
-      },
-      body: JSON.stringify(body),
-    }
+  return {
+    systemPrompt: systemParts.length > 0 ? systemParts.join('\n') : undefined,
+    piMessages,
   }
 }
 

--- a/apps/core/src/modules/ai/ai-image/ai-image.controller.ts
+++ b/apps/core/src/modules/ai/ai-image/ai-image.controller.ts
@@ -8,7 +8,9 @@ import { ConfigsService } from '../../configs/configs.service'
 import { DraftRepository } from '../../draft/draft.repository'
 import { AI_PROMPTS, COVER_STYLE_PRESETS } from '../ai.prompts'
 import { AiService } from '../ai.service'
+import { AIProviderType } from '../ai.types'
 import { AiTaskService } from '../ai-task/ai-task.service'
+import { getVertexMediaModels } from '../vertex/vertex-model-catalog'
 import {
   DraftImagePromptDto,
   type GenerateImageDto,
@@ -103,10 +105,16 @@ export class AiImageController {
     )
     if (!resolved) return []
 
-    const models = await getImageCatalog({
-      endpoint: resolved.provider.endpoint,
-      apiKey: resolved.provider.apiKey,
-    })
+    const models =
+      resolved.provider.type === AIProviderType.GoogleVertex
+        ? getVertexMediaModels('image').map((model) => ({
+            ...model,
+            supportedParameters: {},
+          }))
+        : await getImageCatalog({
+            endpoint: resolved.provider.endpoint,
+            apiKey: resolved.provider.apiKey,
+          })
     return models.map((m) =>
       AiImageViews.model.parse({
         id: m.id,

--- a/apps/core/src/modules/ai/ai-image/ai-image.service.ts
+++ b/apps/core/src/modules/ai/ai-image/ai-image.service.ts
@@ -76,6 +76,8 @@ export class AiImageService implements OnModuleInit {
           apiKey: resolved.provider.apiKey,
           endpoint: resolved.provider.endpoint,
           model,
+          projectId: resolved.provider.projectId,
+          providerType: resolved.provider.type,
         })
 
         await context.appendLog(

--- a/apps/core/src/modules/ai/ai-image/image-protocol.registry.ts
+++ b/apps/core/src/modules/ai/ai-image/image-protocol.registry.ts
@@ -1,0 +1,44 @@
+import { AIProviderType } from '../ai.types'
+import { ProtocolAdapterRegistry } from '../runtime/protocol-adapter.registry'
+import type {
+  IImageRuntime,
+  ImageRuntimeAdapterConfig,
+} from './image-runtime.interface'
+import { OpenAiCompatibleImageProtocolAdapter } from './openai-compatible-image-protocol.adapter'
+import {
+  normalizeVertexModel,
+  VertexGeminiImageProtocolAdapter,
+  VertexImagenImageProtocolAdapter,
+} from './vertex-image-protocol.adapter'
+
+export function createImageProtocolAdapterRegistry(): ProtocolAdapterRegistry<
+  ImageRuntimeAdapterConfig,
+  IImageRuntime
+> {
+  return new ProtocolAdapterRegistry<ImageRuntimeAdapterConfig, IImageRuntime>()
+    .register({
+      id: 'vertex-gemini-generate-content',
+      matches: (config) =>
+        config.providerType === AIProviderType.GoogleVertex &&
+        normalizeVertexModel(config.model).startsWith('gemini-'),
+      create: (config) => new VertexGeminiImageProtocolAdapter(config),
+    })
+    .register({
+      id: 'vertex-imagen-predict',
+      matches: (config) =>
+        config.providerType === AIProviderType.GoogleVertex &&
+        normalizeVertexModel(config.model).startsWith('imagen-'),
+      create: (config) => new VertexImagenImageProtocolAdapter(config),
+    })
+    .register({
+      id: 'openai-compatible-images',
+      matches: (config) =>
+        config.providerType === undefined ||
+        config.providerType === AIProviderType.Generic ||
+        config.providerType === AIProviderType.OpenAICompatible,
+      create: (config) => new OpenAiCompatibleImageProtocolAdapter(config),
+    })
+}
+
+export const defaultImageProtocolAdapterRegistry =
+  createImageProtocolAdapterRegistry()

--- a/apps/core/src/modules/ai/ai-image/image-runtime.adapter.ts
+++ b/apps/core/src/modules/ai/ai-image/image-runtime.adapter.ts
@@ -1,105 +1,34 @@
-import type {
-  ImageContent,
-  ImagesContext,
-  ImagesModel,
-  TextContent,
-} from '@earendil-works/pi-ai'
-
 import { AppErrorCode, createAppException } from '~/common/errors'
 
-import { resolveOpenRouterImagesBaseUrl } from './image-catalog'
+import { defaultImageProtocolAdapterRegistry } from './image-protocol.registry'
 import type {
-  GeneratedImage,
   IImageRuntime,
   ImageGenerateOptions,
+  ImageRuntimeAdapterConfig,
 } from './image-runtime.interface'
-import {
-  generateOpenRouterImages,
-  OPENROUTER_IMAGES_API,
-  type OpenRouterImagesApi,
-  type OpenRouterImagesOptions,
-} from './openrouter-images-api'
 
-export interface ImageRuntimeAdapterConfig {
-  provider: string
-  apiKey: string
-  endpoint?: string
-  model: string
-}
+export type { ImageRuntimeAdapterConfig } from './image-runtime.interface'
 
 export class ImageRuntimeAdapter implements IImageRuntime {
-  private readonly model: ImagesModel<OpenRouterImagesApi>
-  private readonly apiKey: string
+  private readonly protocolAdapter: IImageRuntime
 
   constructor(config: ImageRuntimeAdapterConfig) {
-    this.apiKey = config.apiKey
-    this.model = {
-      id: config.model,
-      name: config.model,
-      api: OPENROUTER_IMAGES_API,
-      provider: config.provider,
-      baseUrl: resolveOpenRouterImagesBaseUrl(config.endpoint),
-      input: ['text', 'image'],
-      output: ['image'],
-      cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
-    }
+    this.protocolAdapter = defaultImageProtocolAdapterRegistry.resolve(config)
   }
 
   async generateImage(
     opts: ImageGenerateOptions,
-  ): Promise<{ images: GeneratedImage[] }> {
-    const context: ImagesContext = { input: this.buildInput(opts) }
-    const options: OpenRouterImagesOptions = {
-      apiKey: this.apiKey,
-      signal: opts.signal,
-      aspectRatio: opts.aspectRatio,
-      quality: opts.quality,
-      outputFormat: opts.format,
-      providerParams: opts.providerParams,
-    }
-
-    const result = await generateOpenRouterImages(this.model, context, options)
-
-    if (result.stopReason !== 'stop') {
+  ): Promise<Awaited<ReturnType<IImageRuntime['generateImage']>>> {
+    try {
+      return await this.protocolAdapter.generateImage(opts)
+    } catch (error) {
       throw createAppException(AppErrorCode.IMAGE_GENERATION_FAILED, {
-        message:
-          result.errorMessage ??
-          `image generation ended with stopReason "${result.stopReason}"`,
+        message: error instanceof Error ? error.message : String(error),
       })
     }
-
-    const images = result.output
-      .filter((content): content is ImageContent => content.type === 'image')
-      .map((content): GeneratedImage | null => {
-        // content.data is typed string but reaches here from an unvalidated cast
-        // of upstream JSON — this runtime check is not redundant with the type.
-        if (typeof content.data !== 'string') return null
-        const buffer = Buffer.from(content.data, 'base64')
-        if (buffer.length === 0) return null
-        return { buffer, mimeType: content.mimeType }
-      })
-      .filter((image): image is GeneratedImage => image !== null)
-
-    return { images }
   }
 
   async listModels(): Promise<{ id: string; provider: string }[]> {
-    return [{ id: this.model.id, provider: this.model.provider }]
-  }
-
-  private buildInput(
-    opts: ImageGenerateOptions,
-  ): (TextContent | ImageContent)[] {
-    const input: (TextContent | ImageContent)[] = [
-      { type: 'text', text: opts.prompt },
-    ]
-    for (const ref of opts.referenceImages ?? []) {
-      input.push({
-        type: 'image',
-        data: ref.data.toString('base64'),
-        mimeType: ref.mimeType,
-      })
-    }
-    return input
+    return (await this.protocolAdapter.listModels?.()) ?? []
   }
 }

--- a/apps/core/src/modules/ai/ai-image/image-runtime.interface.ts
+++ b/apps/core/src/modules/ai/ai-image/image-runtime.interface.ts
@@ -1,3 +1,14 @@
+import type { AIProviderType } from '../ai.types'
+
+export interface ImageRuntimeAdapterConfig {
+  apiKey: string
+  endpoint?: string
+  model: string
+  projectId?: string
+  provider: string
+  providerType?: AIProviderType
+}
+
 export interface ImageGenerateOptions {
   prompt: string
   aspectRatio?: '1:1' | '3:2' | '2:3' | '4:3' | '3:4' | '16:9' | '9:16'

--- a/apps/core/src/modules/ai/ai-image/openai-compatible-image-protocol.adapter.ts
+++ b/apps/core/src/modules/ai/ai-image/openai-compatible-image-protocol.adapter.ts
@@ -1,0 +1,89 @@
+import type {
+  ImageContent,
+  ImagesContext,
+  ImagesModel,
+  TextContent,
+} from '@earendil-works/pi-ai'
+
+import { resolveOpenRouterImagesBaseUrl } from './image-catalog'
+import type {
+  GeneratedImage,
+  IImageRuntime,
+  ImageGenerateOptions,
+  ImageRuntimeAdapterConfig,
+} from './image-runtime.interface'
+import {
+  generateOpenRouterImages,
+  OPENROUTER_IMAGES_API,
+  type OpenRouterImagesApi,
+  type OpenRouterImagesOptions,
+} from './openrouter-images-api'
+
+export class OpenAiCompatibleImageProtocolAdapter implements IImageRuntime {
+  private readonly model: ImagesModel<OpenRouterImagesApi>
+
+  constructor(private readonly config: ImageRuntimeAdapterConfig) {
+    this.model = {
+      id: config.model,
+      name: config.model,
+      api: OPENROUTER_IMAGES_API,
+      provider: config.provider,
+      baseUrl: resolveOpenRouterImagesBaseUrl(config.endpoint),
+      input: ['text', 'image'],
+      output: ['image'],
+      cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+    }
+  }
+
+  async generateImage(
+    opts: ImageGenerateOptions,
+  ): Promise<{ images: GeneratedImage[] }> {
+    const context: ImagesContext = { input: this.buildInput(opts) }
+    const options: OpenRouterImagesOptions = {
+      apiKey: this.config.apiKey,
+      signal: opts.signal,
+      aspectRatio: opts.aspectRatio,
+      quality: opts.quality,
+      outputFormat: opts.format,
+      providerParams: opts.providerParams,
+    }
+    const result = await generateOpenRouterImages(this.model, context, options)
+    if (result.stopReason !== 'stop') {
+      throw new Error(
+        result.errorMessage ??
+          `image generation ended with stopReason "${result.stopReason}"`,
+      )
+    }
+
+    const images = result.output
+      .filter((content): content is ImageContent => content.type === 'image')
+      .map((content): GeneratedImage | null => {
+        if (typeof content.data !== 'string') return null
+        const buffer = Buffer.from(content.data, 'base64')
+        if (buffer.length === 0) return null
+        return { buffer, mimeType: content.mimeType }
+      })
+      .filter((image): image is GeneratedImage => image !== null)
+    return { images }
+  }
+
+  async listModels(): Promise<{ id: string; provider: string }[]> {
+    return [{ id: this.model.id, provider: this.model.provider }]
+  }
+
+  private buildInput(
+    opts: ImageGenerateOptions,
+  ): (TextContent | ImageContent)[] {
+    const input: (TextContent | ImageContent)[] = [
+      { type: 'text', text: opts.prompt },
+    ]
+    for (const ref of opts.referenceImages ?? []) {
+      input.push({
+        type: 'image',
+        data: ref.data.toString('base64'),
+        mimeType: ref.mimeType,
+      })
+    }
+    return input
+  }
+}

--- a/apps/core/src/modules/ai/ai-image/vertex-image-api.ts
+++ b/apps/core/src/modules/ai/ai-image/vertex-image-api.ts
@@ -1,0 +1,171 @@
+import sharp from 'sharp'
+
+import {
+  buildVertexPublisherModelUrl,
+  getVertexHeaders,
+  readVertexError,
+  type VertexConnectionConfig,
+} from '../vertex/vertex-api'
+import type {
+  GeneratedImage,
+  ImageGenerateOptions,
+} from './image-runtime.interface'
+
+export async function generateVertexImagenImage(input: {
+  apiKey: string
+  connection: VertexConnectionConfig
+  model: string
+  options: ImageGenerateOptions
+}): Promise<GeneratedImage[]> {
+  if (input.options.referenceImages?.length) {
+    throw new Error('Vertex Imagen reference images are not supported')
+  }
+  const mimeType = input.options.format === 'jpeg' ? 'image/jpeg' : 'image/png'
+  const response = await fetch(
+    buildVertexPublisherModelUrl({
+      config: input.connection,
+      method: 'predict',
+      model: input.model,
+      version: 'v1',
+    }),
+    {
+      method: 'POST',
+      headers: getVertexHeaders(input.apiKey),
+      body: JSON.stringify({
+        instances: [{ prompt: input.options.prompt }],
+        parameters: {
+          sampleCount: 1,
+          ...(input.options.aspectRatio
+            ? { aspectRatio: input.options.aspectRatio }
+            : {}),
+          outputOptions: { mimeType },
+          ...input.options.providerParams,
+        },
+      }),
+      signal: input.options.signal,
+    },
+  )
+
+  if (!response.ok) {
+    throw new Error(
+      `Vertex image request failed (${response.status}): ${await readVertexError(response)}`,
+    )
+  }
+
+  const payload = (await response.json()) as {
+    predictions?: Array<{
+      bytesBase64Encoded?: unknown
+      mimeType?: unknown
+    }>
+  }
+  const images = (payload.predictions ?? [])
+    .map((prediction): GeneratedImage | null => {
+      if (typeof prediction.bytesBase64Encoded !== 'string') return null
+      const buffer = Buffer.from(prediction.bytesBase64Encoded, 'base64')
+      if (buffer.length === 0) return null
+      return {
+        buffer,
+        mimeType:
+          typeof prediction.mimeType === 'string'
+            ? prediction.mimeType
+            : mimeType,
+      }
+    })
+    .filter((image): image is GeneratedImage => image !== null)
+  return transcodeVertexImages(images, input.options)
+}
+
+export async function generateVertexGeminiImage(input: {
+  apiKey: string
+  connection: VertexConnectionConfig
+  model: string
+  options: ImageGenerateOptions
+}): Promise<GeneratedImage[]> {
+  const parts: Array<Record<string, unknown>> = [
+    { text: input.options.prompt },
+    ...(input.options.referenceImages ?? []).map((image) => ({
+      inline_data: {
+        data: image.data.toString('base64'),
+        mime_type: image.mimeType,
+      },
+    })),
+  ]
+  const response = await fetch(
+    buildVertexPublisherModelUrl({
+      config: input.connection,
+      location: 'global',
+      method: 'generateContent',
+      model: input.model,
+      version: 'v1',
+    }),
+    {
+      method: 'POST',
+      headers: getVertexHeaders(input.apiKey),
+      body: JSON.stringify({
+        contents: { role: 'user', parts },
+        generation_config: {
+          response_modalities: ['TEXT', 'IMAGE'],
+          ...(input.options.aspectRatio
+            ? { image_config: { aspect_ratio: input.options.aspectRatio } }
+            : {}),
+        },
+        ...input.options.providerParams,
+      }),
+      signal: input.options.signal,
+    },
+  )
+  if (!response.ok) {
+    throw new Error(
+      `Vertex image request failed (${response.status}): ${await readVertexError(response)}`,
+    )
+  }
+  const payload = (await response.json()) as {
+    candidates?: Array<{
+      content?: {
+        parts?: Array<{
+          inlineData?: { data?: unknown; mimeType?: unknown }
+          inline_data?: { data?: unknown; mime_type?: unknown }
+        }>
+      }
+    }>
+  }
+  const images = (payload.candidates ?? [])
+    .flatMap((candidate) => candidate.content?.parts ?? [])
+    .map((part): GeneratedImage | null => {
+      const data = part.inlineData?.data ?? part.inline_data?.data
+      const mimeType =
+        part.inlineData?.mimeType ?? part.inline_data?.mime_type ?? 'image/png'
+      if (typeof data !== 'string' || typeof mimeType !== 'string') return null
+      const buffer = Buffer.from(data, 'base64')
+      return buffer.length > 0 ? { buffer, mimeType } : null
+    })
+    .filter((image): image is GeneratedImage => image !== null)
+  return transcodeVertexImages(images, input.options)
+}
+
+async function transcodeVertexImages(
+  images: GeneratedImage[],
+  options: ImageGenerateOptions,
+): Promise<GeneratedImage[]> {
+  const targetMimeType =
+    options.format === 'jpeg'
+      ? 'image/jpeg'
+      : options.format === 'webp'
+        ? 'image/webp'
+        : 'image/png'
+  const quality =
+    options.quality === 'low' ? 65 : options.quality === 'high' ? 95 : 82
+  return Promise.all(
+    images.map(async (image) => {
+      if (image.mimeType === targetMimeType) return image
+      const pipeline = sharp(image.buffer)
+      const buffer =
+        targetMimeType === 'image/jpeg'
+          ? await pipeline.jpeg({ quality }).toBuffer()
+          : targetMimeType === 'image/webp'
+            ? await pipeline.webp({ quality }).toBuffer()
+            : await pipeline.png().toBuffer()
+      return { buffer, mimeType: targetMimeType }
+    }),
+  )
+}

--- a/apps/core/src/modules/ai/ai-image/vertex-image-protocol.adapter.ts
+++ b/apps/core/src/modules/ai/ai-image/vertex-image-protocol.adapter.ts
@@ -1,0 +1,60 @@
+import { getVertexMediaModels } from '../vertex/vertex-model-catalog'
+import type {
+  GeneratedImage,
+  IImageRuntime,
+  ImageGenerateOptions,
+  ImageRuntimeAdapterConfig,
+} from './image-runtime.interface'
+import {
+  generateVertexGeminiImage,
+  generateVertexImagenImage,
+} from './vertex-image-api'
+
+abstract class VertexImageProtocolAdapter implements IImageRuntime {
+  constructor(protected readonly config: ImageRuntimeAdapterConfig) {}
+
+  abstract generateImage(
+    opts: ImageGenerateOptions,
+  ): Promise<{ images: GeneratedImage[] }>
+
+  async listModels(): Promise<{ id: string; provider: string }[]> {
+    return getVertexMediaModels('image').map((model) => ({
+      id: model.id,
+      provider: this.config.provider,
+    }))
+  }
+}
+
+export class VertexGeminiImageProtocolAdapter extends VertexImageProtocolAdapter {
+  async generateImage(
+    options: ImageGenerateOptions,
+  ): Promise<{ images: GeneratedImage[] }> {
+    return {
+      images: await generateVertexGeminiImage({
+        apiKey: this.config.apiKey,
+        connection: this.config,
+        model: normalizeVertexModel(this.config.model),
+        options,
+      }),
+    }
+  }
+}
+
+export class VertexImagenImageProtocolAdapter extends VertexImageProtocolAdapter {
+  async generateImage(
+    options: ImageGenerateOptions,
+  ): Promise<{ images: GeneratedImage[] }> {
+    return {
+      images: await generateVertexImagenImage({
+        apiKey: this.config.apiKey,
+        connection: this.config,
+        model: normalizeVertexModel(this.config.model),
+        options,
+      }),
+    }
+  }
+}
+
+export function normalizeVertexModel(model: string): string {
+  return model.replace(/^google\//, '').trim()
+}

--- a/apps/core/src/modules/ai/ai-tts/ai-tts.service.ts
+++ b/apps/core/src/modules/ai/ai-tts/ai-tts.service.ts
@@ -153,6 +153,8 @@ export class AiTtsService implements OnModuleInit {
         provider: provider.id,
         apiKey: provider.apiKey,
         endpoint: provider.endpoint || undefined,
+        projectId: provider.projectId,
+        providerType: provider.type,
       },
       refId: payload.refId,
       sourceLang,

--- a/apps/core/src/modules/ai/ai-tts/ai-tts.types.ts
+++ b/apps/core/src/modules/ai/ai-tts/ai-tts.types.ts
@@ -120,6 +120,8 @@ export interface TtsProviderConfig {
   provider: string
   apiKey: string
   endpoint?: string
+  projectId?: string
+  providerType?: import('../ai.types').AIProviderType
 }
 
 export interface TtsLanguageResult {

--- a/apps/core/src/modules/ai/ai-tts/openai-compatible-tts-protocol.adapter.ts
+++ b/apps/core/src/modules/ai/ai-tts/openai-compatible-tts-protocol.adapter.ts
@@ -1,0 +1,66 @@
+import { wrapPcmAsWav } from './tts-audio'
+import { resolveTtsBaseUrl } from './tts-base-url'
+import type {
+  ITtsProtocolAdapter,
+  TtsProtocolAdapterConfig,
+  TtsProtocolRequest,
+} from './tts-protocol.types'
+import { TtsProtocolHttpError } from './tts-protocol.types'
+
+export class OpenAiCompatibleTtsProtocolAdapter implements ITtsProtocolAdapter {
+  private readonly baseUrl: string
+
+  constructor(private readonly config: TtsProtocolAdapterConfig) {
+    this.baseUrl = resolveTtsBaseUrl(config.provider, config.endpoint)
+  }
+
+  async generateSpeech({
+    input,
+    languageControl,
+    options,
+  }: TtsProtocolRequest): Promise<{ buffer: Buffer; mimeType: string }> {
+    const response = await fetch(`${this.baseUrl}/audio/speech`, {
+      method: 'POST',
+      headers: {
+        authorization: `Bearer ${this.config.apiKey}`,
+        'content-type': 'application/json',
+      },
+      body: JSON.stringify({
+        model: this.config.model,
+        input,
+        voice: options.voice,
+        speed: options.speed,
+        response_format: languageControl?.responseFormat ?? 'mp3',
+        ...languageControl?.requestParams,
+        ...options.providerParams,
+      }),
+      signal: options.signal,
+    })
+
+    if (!response.ok) {
+      throw new TtsProtocolHttpError(response.status, await safeText(response))
+    }
+
+    const mimeType = response.headers.get('content-type') ?? ''
+    if (!mimeType.startsWith('audio/')) {
+      throw new TtsProtocolHttpError(response.status, await safeText(response))
+    }
+
+    const buffer = Buffer.from(await response.arrayBuffer())
+    if (languageControl?.responseFormat === 'pcm') {
+      return {
+        buffer: wrapPcmAsWav(buffer, mimeType),
+        mimeType: 'audio/wav',
+      }
+    }
+    return { buffer, mimeType }
+  }
+}
+
+async function safeText(response: Response): Promise<string> {
+  try {
+    return await response.text()
+  } catch {
+    return ''
+  }
+}

--- a/apps/core/src/modules/ai/ai-tts/tts-base-url.ts
+++ b/apps/core/src/modules/ai/ai-tts/tts-base-url.ts
@@ -1,0 +1,16 @@
+import { AppErrorCode, createAppException } from '~/common/errors'
+
+const PRESET_BASE_URLS: Record<string, string> = {
+  openrouter: 'https://openrouter.ai/api/v1',
+  openai: 'https://api.openai.com/v1',
+}
+
+export function resolveTtsBaseUrl(provider: string, endpoint?: string): string {
+  const trimmed = endpoint?.trim().replace(/\/+$/, '')
+  if (trimmed) return trimmed
+  const preset = PRESET_BASE_URLS[provider]
+  if (!preset) {
+    throw createAppException(AppErrorCode.TTS_PROVIDER_NOT_CONFIGURED)
+  }
+  return preset
+}

--- a/apps/core/src/modules/ai/ai-tts/tts-language-strategy.ts
+++ b/apps/core/src/modules/ai/ai-tts/tts-language-strategy.ts
@@ -170,6 +170,17 @@ const MINIMAX_LANGUAGE_BOOSTS: Readonly<Record<string, string>> = {
 export const defaultTtsLanguageStrategyRegistry =
   new TtsLanguageStrategyRegistry()
     .register({
+      id: 'google-vertex-gemini-prompt',
+      version: 1,
+      matches: (context) =>
+        hostnameOf(context.baseUrl) === 'aiplatform.googleapis.com' &&
+        /^gemini-.*tts(?:-|$)/.test(modelName(context.model)),
+      buildRequestParams: () => ({}),
+      audioFormat: 'wav',
+      responseFormat: 'pcm',
+      transformInput: buildGeminiInput,
+    })
+    .register({
       id: 'openrouter-google-gemini-prompt',
       version: 1,
       matches: (context) =>

--- a/apps/core/src/modules/ai/ai-tts/tts-protocol.registry.ts
+++ b/apps/core/src/modules/ai/ai-tts/tts-protocol.registry.ts
@@ -1,0 +1,36 @@
+import { AIProviderType } from '../ai.types'
+import { ProtocolAdapterRegistry } from '../runtime/protocol-adapter.registry'
+import { OpenAiCompatibleTtsProtocolAdapter } from './openai-compatible-tts-protocol.adapter'
+import type {
+  ITtsProtocolAdapter,
+  TtsProtocolAdapterConfig,
+} from './tts-protocol.types'
+import { VertexTtsProtocolAdapter } from './vertex-tts-protocol.adapter'
+
+export function createTtsProtocolAdapterRegistry(): ProtocolAdapterRegistry<
+  TtsProtocolAdapterConfig,
+  ITtsProtocolAdapter
+> {
+  return new ProtocolAdapterRegistry<
+    TtsProtocolAdapterConfig,
+    ITtsProtocolAdapter
+  >()
+    .register({
+      id: 'vertex-gemini-tts',
+      matches: (config) =>
+        config.providerType === AIProviderType.GoogleVertex &&
+        /(?:^|\/)gemini-.*tts(?:-|$)/.test(config.model.toLowerCase()),
+      create: (config) => new VertexTtsProtocolAdapter(config),
+    })
+    .register({
+      id: 'openai-compatible-speech',
+      matches: (config) =>
+        config.providerType === undefined ||
+        config.providerType === AIProviderType.Generic ||
+        config.providerType === AIProviderType.OpenAICompatible,
+      create: (config) => new OpenAiCompatibleTtsProtocolAdapter(config),
+    })
+}
+
+export const defaultTtsProtocolAdapterRegistry =
+  createTtsProtocolAdapterRegistry()

--- a/apps/core/src/modules/ai/ai-tts/tts-protocol.types.ts
+++ b/apps/core/src/modules/ai/ai-tts/tts-protocol.types.ts
@@ -1,0 +1,29 @@
+import type { TtsLanguageStrategyResolution } from './tts-language-strategy'
+import type {
+  TtsGenerateOptions,
+  TtsRuntimeAdapterConfig,
+} from './tts-runtime.interface'
+
+export interface TtsProtocolRequest {
+  input: string
+  languageControl?: TtsLanguageStrategyResolution
+  options: TtsGenerateOptions
+}
+
+export interface ITtsProtocolAdapter {
+  generateSpeech: (
+    request: TtsProtocolRequest,
+  ) => Promise<{ buffer: Buffer; mimeType: string }>
+}
+
+export type TtsProtocolAdapterConfig = TtsRuntimeAdapterConfig
+
+export class TtsProtocolHttpError extends Error {
+  constructor(
+    readonly status: number,
+    body: string,
+  ) {
+    super(`tts request failed (${status}): ${body.slice(0, 300)}`)
+    this.name = 'TtsProtocolHttpError'
+  }
+}

--- a/apps/core/src/modules/ai/ai-tts/tts-runtime.adapter.ts
+++ b/apps/core/src/modules/ai/ai-tts/tts-runtime.adapter.ts
@@ -1,50 +1,26 @@
 import { AppErrorCode, createAppException } from '~/common/errors'
 import { sleep } from '~/utils/tool.util'
 
-import { wrapPcmAsWav } from './tts-audio'
+import { resolveTtsBaseUrl } from './tts-base-url'
 import {
   defaultTtsLanguageStrategyRegistry,
   type TtsLanguageStrategyResolution,
 } from './tts-language-strategy'
+import { defaultTtsProtocolAdapterRegistry } from './tts-protocol.registry'
+import type { ITtsProtocolAdapter } from './tts-protocol.types'
+import { TtsProtocolHttpError } from './tts-protocol.types'
+import type {
+  ITtsRuntime,
+  TtsGenerateOptions,
+  TtsRuntimeAdapterConfig,
+} from './tts-runtime.interface'
 
-export interface TtsGenerateOptions {
-  input: string
-  language?: string
-  voice: string
-  speed: number
-  providerParams?: Record<string, unknown>
-  signal?: AbortSignal
-}
-
-export interface ITtsRuntime {
-  generateSpeech: (
-    opts: TtsGenerateOptions,
-  ) => Promise<{ buffer: Buffer; mimeType: string }>
-}
-
-export interface TtsRuntimeAdapterConfig {
-  provider: string
-  apiKey: string
-  endpoint?: string
-  model: string
-  maxAttempts?: number
-  retryDelayMs?: number
-}
-
-const PRESET_BASE_URLS: Record<string, string> = {
-  openrouter: 'https://openrouter.ai/api/v1',
-  openai: 'https://api.openai.com/v1',
-}
-
-export function resolveTtsBaseUrl(provider: string, endpoint?: string): string {
-  const trimmed = endpoint?.trim().replace(/\/+$/, '')
-  if (trimmed) return trimmed
-  const preset = PRESET_BASE_URLS[provider]
-  if (!preset) {
-    throw createAppException(AppErrorCode.TTS_PROVIDER_NOT_CONFIGURED)
-  }
-  return preset
-}
+export { resolveTtsBaseUrl } from './tts-base-url'
+export type {
+  ITtsRuntime,
+  TtsGenerateOptions,
+  TtsRuntimeAdapterConfig,
+} from './tts-runtime.interface'
 
 export function resolveTtsLanguageControl(
   config: Pick<TtsRuntimeAdapterConfig, 'endpoint' | 'model' | 'provider'>,
@@ -58,12 +34,12 @@ export function resolveTtsLanguageControl(
 }
 
 export class TtsRuntimeAdapter implements ITtsRuntime {
-  private readonly baseUrl: string
   private readonly maxAttempts: number
+  private readonly protocolAdapter: ITtsProtocolAdapter
   private readonly retryDelayMs: number
 
   constructor(private readonly config: TtsRuntimeAdapterConfig) {
-    this.baseUrl = resolveTtsBaseUrl(config.provider, config.endpoint)
+    this.protocolAdapter = defaultTtsProtocolAdapterRegistry.resolve(config)
     this.maxAttempts = config.maxAttempts ?? 3
     this.retryDelayMs = config.retryDelayMs ?? 500
   }
@@ -78,7 +54,6 @@ export class TtsRuntimeAdapter implements ITtsRuntime {
         return await this.requestOnce(opts)
       } catch (error) {
         lastError = error as Error
-        // an aborted signal is caller cancellation, not a transient failure — fail fast.
         if (
           opts.signal?.aborted ||
           !isRetryable(error) ||
@@ -99,67 +74,17 @@ export class TtsRuntimeAdapter implements ITtsRuntime {
       ? resolveTtsLanguageControl(this.config, opts.language)
       : undefined
     const input = languageControl?.transformInput?.(opts.input) ?? opts.input
-    const response = await fetch(`${this.baseUrl}/audio/speech`, {
-      method: 'POST',
-      headers: {
-        authorization: `Bearer ${this.config.apiKey}`,
-        'content-type': 'application/json',
-      },
-      body: JSON.stringify({
-        model: this.config.model,
-        input,
-        voice: opts.voice,
-        speed: opts.speed,
-        // response_format defaults to pcm on OpenRouter; mp3 must be explicit.
-        response_format: languageControl?.responseFormat ?? 'mp3',
-        ...languageControl?.requestParams,
-        ...opts.providerParams,
-      }),
-      signal: opts.signal,
+    return this.protocolAdapter.generateSpeech({
+      input,
+      languageControl,
+      options: opts,
     })
-
-    if (!response.ok) {
-      throw new HttpStatusError(response.status, await safeText(response))
-    }
-
-    // some providers respond 200 with a JSON error body instead of audio.
-    const mimeType = response.headers.get('content-type') ?? ''
-    if (!mimeType.startsWith('audio/')) {
-      throw new HttpStatusError(response.status, await safeText(response))
-    }
-
-    const buffer = Buffer.from(await response.arrayBuffer())
-    if (languageControl?.responseFormat === 'pcm') {
-      return {
-        buffer: wrapPcmAsWav(buffer, mimeType),
-        mimeType: 'audio/wav',
-      }
-    }
-
-    return { buffer, mimeType }
-  }
-}
-
-class HttpStatusError extends Error {
-  constructor(
-    readonly status: number,
-    body: string,
-  ) {
-    super(`tts request failed (${status}): ${body.slice(0, 300)}`)
   }
 }
 
 function isRetryable(error: unknown): boolean {
-  if (error instanceof HttpStatusError) {
+  if (error instanceof TtsProtocolHttpError) {
     return error.status >= 500 || error.status === 429
   }
   return true
-}
-
-async function safeText(response: Response): Promise<string> {
-  try {
-    return await response.text()
-  } catch {
-    return ''
-  }
 }

--- a/apps/core/src/modules/ai/ai-tts/tts-runtime.interface.ts
+++ b/apps/core/src/modules/ai/ai-tts/tts-runtime.interface.ts
@@ -1,0 +1,27 @@
+import type { AIProviderType } from '../ai.types'
+
+export interface TtsGenerateOptions {
+  input: string
+  language?: string
+  providerParams?: Record<string, unknown>
+  signal?: AbortSignal
+  speed: number
+  voice: string
+}
+
+export interface ITtsRuntime {
+  generateSpeech: (
+    opts: TtsGenerateOptions,
+  ) => Promise<{ buffer: Buffer; mimeType: string }>
+}
+
+export interface TtsRuntimeAdapterConfig {
+  apiKey: string
+  endpoint?: string
+  maxAttempts?: number
+  model: string
+  projectId?: string
+  provider: string
+  providerType?: AIProviderType
+  retryDelayMs?: number
+}

--- a/apps/core/src/modules/ai/ai-tts/tts-voice-catalog.service.ts
+++ b/apps/core/src/modules/ai/ai-tts/tts-voice-catalog.service.ts
@@ -2,7 +2,9 @@ import { Injectable } from '@nestjs/common'
 
 import { AppErrorCode, createAppException } from '~/common/errors'
 import type { AIProviderConfig } from '~/modules/ai/ai.types'
+import { AIProviderType } from '~/modules/ai/ai.types'
 import { createModelRuntime } from '~/modules/ai/runtime'
+import { getVertexMediaModels } from '~/modules/ai/vertex/vertex-model-catalog'
 import { ConfigsService } from '~/modules/configs/configs.service'
 
 const VOICE_LIST_TIMEOUT_MS = 5000
@@ -85,6 +87,17 @@ export async function discoverTtsVoices(
   model: string,
   supportedVoices: string[] = [],
 ): Promise<TtsVoiceDiscoveryResult> {
+  if (provider.type === AIProviderType.GoogleVertex) {
+    const modelInfo = getVertexMediaModels('speech').find(
+      (item) => item.id.toLowerCase() === model.trim().toLowerCase(),
+    )
+    return resultFromBuiltin(
+      normalizeRemoteVoices(modelInfo?.supportedVoices ?? []).map((voice) => ({
+        ...voice,
+        kind: 'builtin',
+      })),
+    )
+  }
   const builtinVoices = getBuiltinTtsVoices(model)
   const modelVoices = normalizeRemoteVoices(supportedVoices)
   if (!provider.voiceListUrl?.trim()) {

--- a/apps/core/src/modules/ai/ai-tts/vertex-tts-protocol.adapter.ts
+++ b/apps/core/src/modules/ai/ai-tts/vertex-tts-protocol.adapter.ts
@@ -1,0 +1,104 @@
+import {
+  buildVertexPublisherModelUrl,
+  getVertexHeaders,
+  readVertexError,
+} from '../vertex/vertex-api'
+import { wrapPcmAsWav } from './tts-audio'
+import type {
+  ITtsProtocolAdapter,
+  TtsProtocolAdapterConfig,
+  TtsProtocolRequest,
+} from './tts-protocol.types'
+import { TtsProtocolHttpError } from './tts-protocol.types'
+
+export class VertexTtsProtocolAdapter implements ITtsProtocolAdapter {
+  constructor(private readonly config: TtsProtocolAdapterConfig) {}
+
+  async generateSpeech({
+    input,
+    options,
+  }: TtsProtocolRequest): Promise<{ buffer: Buffer; mimeType: string }> {
+    const spokenInput =
+      options.speed === 1
+        ? input
+        : `Speak at ${options.speed} times the normal speed.\n\n${input}`
+    const response = await fetch(
+      buildVertexPublisherModelUrl({
+        config: this.config,
+        method: 'generateContent',
+        model: this.config.model,
+        version: 'v1beta1',
+      }),
+      {
+        method: 'POST',
+        headers: getVertexHeaders(this.config.apiKey),
+        body: JSON.stringify({
+          contents: {
+            role: 'user',
+            parts: { text: spokenInput },
+          },
+          generation_config: {
+            response_modalities: ['AUDIO'],
+            speech_config: {
+              ...(options.language
+                ? { language_code: normalizeVertexLanguage(options.language) }
+                : {}),
+              voice_config: {
+                prebuilt_voice_config: { voice_name: options.voice },
+              },
+            },
+          },
+          ...options.providerParams,
+        }),
+        signal: options.signal,
+      },
+    )
+
+    if (!response.ok) {
+      throw new TtsProtocolHttpError(
+        response.status,
+        await readVertexError(response),
+      )
+    }
+    const payload = (await response.json()) as {
+      candidates?: Array<{
+        content?: {
+          parts?: Array<{
+            inlineData?: { data?: unknown; mimeType?: unknown }
+            inline_data?: { data?: unknown; mime_type?: unknown }
+          }>
+        }
+      }>
+    }
+    const inline = payload.candidates?.[0]?.content?.parts?.[0]
+    const data = inline?.inlineData?.data ?? inline?.inline_data?.data
+    const mimeType =
+      inline?.inlineData?.mimeType ?? inline?.inline_data?.mime_type
+    if (typeof data !== 'string' || !data) {
+      throw new TtsProtocolHttpError(
+        response.status,
+        'response contained no audio',
+      )
+    }
+    const pcm = Buffer.from(data, 'base64')
+    return {
+      buffer: wrapPcmAsWav(
+        pcm,
+        typeof mimeType === 'string'
+          ? mimeType
+          : 'audio/pcm;rate=24000;channels=1',
+      ),
+      mimeType: 'audio/wav',
+    }
+  }
+}
+
+function normalizeVertexLanguage(language: string): string {
+  const normalized = language.trim().replace('_', '-')
+  const defaults: Record<string, string> = {
+    en: 'en-US',
+    ja: 'ja-JP',
+    zh: 'zh-CN',
+  }
+  return defaults[normalized.toLowerCase()] ?? normalized
+}

--- a/apps/core/src/modules/ai/ai.types.ts
+++ b/apps/core/src/modules/ai/ai.types.ts
@@ -2,6 +2,7 @@ export enum AIProviderType {
   OpenAICompatible = 'openai-compatible',
   Anthropic = 'anthropic',
   Generic = 'generic',
+  GoogleVertex = 'google-vertex',
 }
 
 export enum AIFeatureKey {
@@ -33,6 +34,8 @@ export interface AIProviderConfig {
   apiKey: string
   /** Custom endpoint (required for OpenAI-compatible) */
   endpoint?: string
+  /** Google Cloud project used by Vertex AI */
+  projectId?: string
   /** Full URL to fetch the model list from; falls back to the pi registry when empty */
   modelListUrl?: string
   /** Full URL to fetch speech voices from; falls back to the built-in catalog when empty */

--- a/apps/core/src/modules/ai/runtime/ai-provider.factory.ts
+++ b/apps/core/src/modules/ai/runtime/ai-provider.factory.ts
@@ -23,6 +23,7 @@ export function createModelRuntime(
 
   switch (config.type) {
     case AIProviderType.Anthropic:
+    case AIProviderType.GoogleVertex:
     case AIProviderType.OpenAICompatible:
     case AIProviderType.Generic: {
       return new PiRuntimeAdapter({

--- a/apps/core/src/modules/ai/runtime/ai-provider.factory.ts
+++ b/apps/core/src/modules/ai/runtime/ai-provider.factory.ts
@@ -1,8 +1,11 @@
-import type { AIProviderConfig, AIReasoningEffort } from '../ai.types'
-import { AIProviderType } from '../ai.types'
+import type {
+  AIProviderConfig,
+  AIProviderType,
+  AIReasoningEffort,
+} from '../ai.types'
 import type { IModelRuntime } from './model-runtime.interface'
-import { PiRuntimeAdapter } from './pi-runtime.adapter'
-import type { RuntimeConfig } from './types'
+import type { TextProtocolAdapterConfig } from './text-protocol.registry'
+import { defaultTextProtocolAdapterRegistry } from './text-protocol.registry'
 
 export function createModelRuntime(
   config: AIProviderConfig,
@@ -11,7 +14,7 @@ export function createModelRuntime(
 ): IModelRuntime {
   const model = modelOverride || config.defaultModel
 
-  const runtimeConfig: RuntimeConfig = {
+  const runtimeConfig: TextProtocolAdapterConfig = {
     apiKey: config.apiKey,
     endpoint: config.endpoint,
     modelListUrl: config.modelListUrl,
@@ -19,25 +22,12 @@ export function createModelRuntime(
     model,
     providerType: config.type,
     providerId: config.id,
+    contextWindow: config.contextWindow ?? undefined,
+    maxTokens: config.maxTokens ?? undefined,
+    reasoningEffort: options?.reasoningEffort,
   }
 
-  switch (config.type) {
-    case AIProviderType.Anthropic:
-    case AIProviderType.GoogleVertex:
-    case AIProviderType.OpenAICompatible:
-    case AIProviderType.Generic: {
-      return new PiRuntimeAdapter({
-        ...runtimeConfig,
-        contextWindow: config.contextWindow ?? undefined,
-        maxTokens: config.maxTokens ?? undefined,
-        reasoningEffort: options?.reasoningEffort,
-      })
-    }
-
-    default: {
-      throw new Error(`Unsupported provider type: ${config.type as string}`)
-    }
-  }
+  return defaultTextProtocolAdapterRegistry.resolve(runtimeConfig)
 }
 
 export function createRuntimeForModelList(

--- a/apps/core/src/modules/ai/runtime/index.ts
+++ b/apps/core/src/modules/ai/runtime/index.ts
@@ -5,4 +5,9 @@ export {
   PiRuntimeAdapter,
   resolveOpenAICompatibleBaseUrl,
 } from './pi-runtime.adapter'
+export type { TextProtocolAdapterConfig } from './text-protocol.registry'
+export {
+  createTextProtocolAdapterRegistry,
+  defaultTextProtocolAdapterRegistry,
+} from './text-protocol.registry'
 export * from './types'

--- a/apps/core/src/modules/ai/runtime/pi-runtime.adapter.ts
+++ b/apps/core/src/modules/ai/runtime/pi-runtime.adapter.ts
@@ -277,6 +277,10 @@ interface PiRuntimeAdapterConfig extends RuntimeConfig {
   reasoningEffort?: ReasoningEffort
 }
 
+export interface PiRuntimeAdapterOptions {
+  api?: Api
+}
+
 export class PiRuntimeAdapter implements IModelRuntime {
   readonly providerInfo: RuntimeProviderInfo
   private readonly logger = new Logger(PiRuntimeAdapter.name)
@@ -289,8 +293,13 @@ export class PiRuntimeAdapter implements IModelRuntime {
   private readonly configuredReasoningEffort?: ReasoningEffort
   private readonly providerType: AIProviderType
 
-  constructor(config: PiRuntimeAdapterConfig) {
+  constructor(
+    config: PiRuntimeAdapterConfig,
+    options: PiRuntimeAdapterOptions = {},
+  ) {
+    this.api = options.api ?? providerTypeToApi(config.providerType)
     this.providerInfo = {
+      api: this.api,
       id: config.providerId,
       type: config.providerType,
       model: config.model,
@@ -298,7 +307,6 @@ export class PiRuntimeAdapter implements IModelRuntime {
     this.apiKey = config.apiKey
     this.providerType = config.providerType
     this.modelListUrl = config.modelListUrl?.trim() || undefined
-    this.api = providerTypeToApi(config.providerType)
     this.piProviderId = deriveProviderId(config.endpoint, config.providerType)
     this.inferredModelListUrl = this.inferModelListUrl(
       config.endpoint,

--- a/apps/core/src/modules/ai/runtime/pi-runtime.adapter.ts
+++ b/apps/core/src/modules/ai/runtime/pi-runtime.adapter.ts
@@ -24,6 +24,7 @@ import { isDev } from '~/global/env.global'
 
 import type { AIProviderCapability } from '../ai.types'
 import { AIProviderType } from '../ai.types'
+import { getVertexMediaModels } from '../vertex/vertex-model-catalog'
 import type { IModelRuntime } from './model-runtime.interface'
 import type {
   GenerateStructuredOptions,
@@ -53,6 +54,7 @@ const HOSTNAME_TO_PROVIDER_ID: Record<string, string> = {
   'api.deepseek.com': 'deepseek',
   'api.openai.com': 'openai',
   'api.anthropic.com': 'anthropic',
+  'aiplatform.googleapis.com': 'google-vertex',
 }
 
 function fallbackProviderId(type: AIProviderType): string {
@@ -62,6 +64,9 @@ function fallbackProviderId(type: AIProviderType): string {
     }
     case AIProviderType.OpenAICompatible: {
       return 'openai'
+    }
+    case AIProviderType.GoogleVertex: {
+      return 'google-vertex'
     }
     default: {
       return 'openai-compat'
@@ -282,6 +287,7 @@ export class PiRuntimeAdapter implements IModelRuntime {
   private readonly modelListUrl?: string
   private readonly inferredModelListUrl?: string
   private readonly configuredReasoningEffort?: ReasoningEffort
+  private readonly providerType: AIProviderType
 
   constructor(config: PiRuntimeAdapterConfig) {
     this.providerInfo = {
@@ -290,6 +296,7 @@ export class PiRuntimeAdapter implements IModelRuntime {
       model: config.model,
     }
     this.apiKey = config.apiKey
+    this.providerType = config.providerType
     this.modelListUrl = config.modelListUrl?.trim() || undefined
     this.api = providerTypeToApi(config.providerType)
     this.piProviderId = deriveProviderId(config.endpoint, config.providerType)
@@ -311,6 +318,7 @@ export class PiRuntimeAdapter implements IModelRuntime {
     endpoint: string | undefined,
     appendV1: boolean,
   ): string | undefined {
+    if (this.providerType === AIProviderType.GoogleVertex) return undefined
     if (this.api !== 'openai-completions') return undefined
     const trimmed = endpoint?.trim()
     if (!trimmed) return undefined
@@ -349,15 +357,20 @@ export class PiRuntimeAdapter implements IModelRuntime {
           }
         : model
     try {
+      const catalogModelId =
+        this.providerType === AIProviderType.GoogleVertex
+          ? modelId.replace(/^google\//, '')
+          : modelId
       const registered = getBuiltinModel(
         this.piProviderId as never,
-        modelId as never,
+        catalogModelId as never,
       ) as Model<Api> | undefined
       if (registered) {
         if (!baseUrl) return markReasoningOffUnsupported(registered)
 
         return markReasoningOffUnsupported({
           ...registered,
+          id: modelId,
           api: this.api,
           provider: this.piProviderId,
           baseUrl,
@@ -461,6 +474,12 @@ export class PiRuntimeAdapter implements IModelRuntime {
       maxRetries: opts.maxRetries,
       signal: opts.signal,
       ...thinking,
+    }
+    if (this.providerType === AIProviderType.GoogleVertex) {
+      result.headers = {
+        Authorization: null,
+        'x-goog-api-key': this.apiKey,
+      }
     }
     if (opts.toolChoice !== undefined) {
       ;(result as Record<string, unknown>).toolChoice = opts.toolChoice
@@ -766,6 +785,12 @@ export class PiRuntimeAdapter implements IModelRuntime {
   async listModels(
     capability: AIProviderCapability = 'text',
   ): Promise<ModelInfo[]> {
+    if (
+      this.providerType === AIProviderType.GoogleVertex &&
+      capability !== 'text'
+    ) {
+      return getVertexMediaModels(capability)
+    }
     const remoteUrl = this.modelListUrl ?? this.inferredModelListUrl
     if (remoteUrl) {
       try {
@@ -784,7 +809,13 @@ export class PiRuntimeAdapter implements IModelRuntime {
       const models = getBuiltinModels(
         this.piProviderId as never,
       ) as Model<Api>[]
-      return models.map((m) => ({ id: m.id, name: m.name }))
+      return models.map((m) => ({
+        id:
+          this.providerType === AIProviderType.GoogleVertex
+            ? `google/${m.id}`
+            : m.id,
+        name: m.name,
+      }))
     } catch (error) {
       this.logger.warn(
         `pi getBuiltinModels failed for provider ${this.piProviderId}: ${
@@ -801,7 +832,10 @@ export class PiRuntimeAdapter implements IModelRuntime {
   ): Promise<ModelInfo[]> {
     const requestUrl = this.resolveModelListUrl(url, capability)
     const response = await fetch(requestUrl, {
-      headers: { Authorization: `Bearer ${this.apiKey}` },
+      headers:
+        this.providerType === AIProviderType.GoogleVertex
+          ? { 'x-goog-api-key': this.apiKey }
+          : { Authorization: `Bearer ${this.apiKey}` },
     })
     if (!response.ok) {
       throw new Error(

--- a/apps/core/src/modules/ai/runtime/protocol-adapter.registry.ts
+++ b/apps/core/src/modules/ai/runtime/protocol-adapter.registry.ts
@@ -1,0 +1,48 @@
+export interface ProtocolAdapterRegistration<TContext, TAdapter> {
+  create: (context: TContext) => TAdapter
+  id: string
+  matches: (context: TContext) => boolean
+}
+
+export class ProtocolAdapterResolutionError extends Error {
+  constructor(
+    readonly kind: 'ambiguous' | 'not-found',
+    readonly adapterIds: string[],
+  ) {
+    super(
+      kind === 'not-found'
+        ? 'No protocol adapter supports the runtime configuration'
+        : `Multiple protocol adapters support the runtime configuration: ${adapterIds.join(', ')}`,
+    )
+    this.name = 'ProtocolAdapterResolutionError'
+  }
+}
+
+export class ProtocolAdapterRegistry<TContext, TAdapter> {
+  private readonly registrations: Array<
+    ProtocolAdapterRegistration<TContext, TAdapter>
+  > = []
+
+  register(
+    registration: ProtocolAdapterRegistration<TContext, TAdapter>,
+  ): this {
+    if (this.registrations.some(({ id }) => id === registration.id)) {
+      throw new Error(`Duplicate protocol adapter: ${registration.id}`)
+    }
+    this.registrations.push(registration)
+    return this
+  }
+
+  resolve(context: TContext): TAdapter {
+    const matches = this.registrations.filter((registration) =>
+      registration.matches(context),
+    )
+    if (matches.length !== 1) {
+      throw new ProtocolAdapterResolutionError(
+        matches.length === 0 ? 'not-found' : 'ambiguous',
+        matches.map(({ id }) => id),
+      )
+    }
+    return matches[0].create(context)
+  }
+}

--- a/apps/core/src/modules/ai/runtime/text-protocol.registry.ts
+++ b/apps/core/src/modules/ai/runtime/text-protocol.registry.ts
@@ -1,0 +1,41 @@
+import { AIProviderType } from '../ai.types'
+import type { IModelRuntime } from './model-runtime.interface'
+import { PiRuntimeAdapter } from './pi-runtime.adapter'
+import { ProtocolAdapterRegistry } from './protocol-adapter.registry'
+import type { ReasoningEffort, RuntimeConfig } from './types'
+
+export interface TextProtocolAdapterConfig extends RuntimeConfig {
+  contextWindow?: number | null
+  maxTokens?: number | null
+  reasoningEffort?: ReasoningEffort
+}
+
+export function createTextProtocolAdapterRegistry(): ProtocolAdapterRegistry<
+  TextProtocolAdapterConfig,
+  IModelRuntime
+> {
+  return new ProtocolAdapterRegistry<TextProtocolAdapterConfig, IModelRuntime>()
+    .register({
+      id: 'anthropic-messages',
+      matches: (config) => config.providerType === AIProviderType.Anthropic,
+      create: (config) =>
+        new PiRuntimeAdapter(config, { api: 'anthropic-messages' }),
+    })
+    .register({
+      id: 'google-vertex-openai-compatible',
+      matches: (config) => config.providerType === AIProviderType.GoogleVertex,
+      create: (config) =>
+        new PiRuntimeAdapter(config, { api: 'openai-completions' }),
+    })
+    .register({
+      id: 'openai-compatible-completions',
+      matches: (config) =>
+        config.providerType === AIProviderType.Generic ||
+        config.providerType === AIProviderType.OpenAICompatible,
+      create: (config) =>
+        new PiRuntimeAdapter(config, { api: 'openai-completions' }),
+    })
+}
+
+export const defaultTextProtocolAdapterRegistry =
+  createTextProtocolAdapterRegistry()

--- a/apps/core/src/modules/ai/runtime/types.ts
+++ b/apps/core/src/modules/ai/runtime/types.ts
@@ -1,8 +1,14 @@
-import type { Message as PiMessage, Tool, TSchema } from '@earendil-works/pi-ai'
+import type {
+  Api,
+  Message as PiMessage,
+  Tool,
+  TSchema,
+} from '@earendil-works/pi-ai'
 
 import type { AIProviderType } from '../ai.types'
 
 export interface RuntimeProviderInfo {
+  api?: Api
   id: string
   type: AIProviderType
   model: string

--- a/apps/core/src/modules/ai/vertex/vertex-api.ts
+++ b/apps/core/src/modules/ai/vertex/vertex-api.ts
@@ -1,0 +1,64 @@
+export const VERTEX_MEDIA_LOCATION = 'us-central1'
+
+export interface VertexConnectionConfig {
+  endpoint?: string
+  projectId?: string
+}
+
+export function resolveVertexProjectId(config: VertexConnectionConfig): string {
+  const explicit = config.projectId?.trim()
+  if (explicit) return explicit
+
+  const endpoint = config.endpoint?.trim()
+  if (endpoint) {
+    try {
+      const match = new URL(endpoint).pathname.match(/\/projects\/([^/]+)/)
+      if (match?.[1]) return decodeURIComponent(match[1])
+    } catch {
+      // The caller receives the provider-specific missing-project error below.
+    }
+  }
+
+  throw new Error('Google Vertex AI requires a Google Cloud project ID')
+}
+
+export function buildVertexPublisherModelUrl(input: {
+  config: VertexConnectionConfig
+  location?: string
+  method: 'generateContent' | 'predict'
+  model: string
+  version: 'v1' | 'v1beta1'
+}): string {
+  const projectId = encodeURIComponent(resolveVertexProjectId(input.config))
+  const location = encodeURIComponent(
+    input.location?.trim() || VERTEX_MEDIA_LOCATION,
+  )
+  const model = encodeURIComponent(input.model.replace(/^google\//, '').trim())
+  const host =
+    input.method === 'predict'
+      ? `https://${location}-aiplatform.googleapis.com`
+      : 'https://aiplatform.googleapis.com'
+
+  return `${host}/${input.version}/projects/${projectId}/locations/${location}/publishers/google/models/${model}:${input.method}`
+}
+
+export function getVertexHeaders(apiKey: string): Record<string, string> {
+  return {
+    'content-type': 'application/json',
+    'x-goog-api-key': apiKey,
+  }
+}
+
+export async function readVertexError(response: Response): Promise<string> {
+  try {
+    const payload = (await response.json()) as {
+      error?: { message?: unknown }
+    }
+    if (typeof payload.error?.message === 'string') {
+      return payload.error.message.slice(0, 300)
+    }
+  } catch {
+    // Preserve the HTTP status when the response is not JSON.
+  }
+  return `HTTP ${response.status}`
+}

--- a/apps/core/src/modules/ai/vertex/vertex-model-catalog.ts
+++ b/apps/core/src/modules/ai/vertex/vertex-model-catalog.ts
@@ -1,0 +1,51 @@
+import type { ModelInfo } from '../runtime'
+
+const VERTEX_TTS_VOICES = [
+  'Achernar',
+  'Achird',
+  'Algenib',
+  'Algieba',
+  'Alnilam',
+  'Aoede',
+  'Autonoe',
+  'Callirrhoe',
+  'Charon',
+  'Despina',
+  'Enceladus',
+  'Erinome',
+  'Fenrir',
+  'Gacrux',
+  'Iapetus',
+  'Kore',
+  'Laomedeia',
+  'Leda',
+  'Orus',
+  'Puck',
+  'Pulcherrima',
+  'Rasalgethi',
+  'Sadachbia',
+  'Sadaltager',
+  'Schedar',
+  'Sulafat',
+  'Umbriel',
+  'Vindemiatrix',
+  'Zephyr',
+  'Zubenelgenubi',
+]
+
+const VERTEX_IMAGE_MODELS: ModelInfo[] = [
+  { id: 'gemini-2.5-flash-image', name: 'Gemini 2.5 Flash Image' },
+]
+
+const VERTEX_SPEECH_MODELS: ModelInfo[] = [
+  'gemini-3.1-flash-tts-preview',
+  'gemini-2.5-flash-tts',
+  'gemini-2.5-flash-lite-preview-tts',
+  'gemini-2.5-pro-tts',
+].map((id) => ({ id, name: id, supportedVoices: VERTEX_TTS_VOICES }))
+
+export function getVertexMediaModels(
+  capability: 'image' | 'speech',
+): ModelInfo[] {
+  return capability === 'image' ? VERTEX_IMAGE_MODELS : VERTEX_SPEECH_MODELS
+}

--- a/apps/core/src/modules/configs/configs.schema.ts
+++ b/apps/core/src/modules/configs/configs.schema.ts
@@ -844,6 +844,9 @@ const AIProviderConfigSchema = withMeta(
       description:
         'Required for OpenAI-compatible services, e.g. https://api.deepseek.com',
     }),
+    projectId: field.plain(z.string().optional(), 'Google Cloud project ID', {
+      description: 'Required when the provider type is google-vertex',
+    }),
     modelListUrl: field.plain(z.string().optional(), 'Model list URL', {
       description:
         'Full URL to fetch the model list from (OpenAI format); leave empty to use the built-in registry',

--- a/apps/core/src/modules/configs/configs.service.ts
+++ b/apps/core/src/modules/configs/configs.service.ts
@@ -59,6 +59,27 @@ function normalizeS3StorageOptionNulls<T extends object>(value: T): T {
   return normalized as T
 }
 
+function isGoogleVertexEndpoint(endpoint: string): boolean {
+  try {
+    const url = new URL(endpoint)
+    return (
+      url.hostname === 'aiplatform.googleapis.com' &&
+      url.pathname.endsWith('/endpoints/openapi')
+    )
+  } catch {
+    return false
+  }
+}
+
+function extractGoogleVertexProjectId(endpoint: string): string | undefined {
+  try {
+    const match = new URL(endpoint).pathname.match(/\/projects\/([^/]+)/)
+    return match?.[1] ? decodeURIComponent(match[1]) : undefined
+  } catch {
+    return undefined
+  }
+}
+
 /*
  * NOTE:
  * 1. Configs live in Redis. `getConfig` is the single entry point; all reads
@@ -205,14 +226,29 @@ export class ConfigsService implements OnModuleInit {
     legacyImageConfig: IConfig['imageGenerationOptions'],
     legacyTtsConfig: IConfig['ttsOptions'],
   ): IConfig['ai'] {
-    const providers = (aiConfig.providers ?? []).map((provider) => ({
-      ...provider,
-      capabilities: {
-        text: provider.capabilities?.text ?? true,
-        image: provider.capabilities?.image ?? false,
-        speech: provider.capabilities?.speech ?? false,
-      },
-    }))
+    const providers = (aiConfig.providers ?? []).map((provider) => {
+      const endpoint = provider.endpoint?.trim() ?? ''
+      const isLegacyVertex =
+        provider.type === AIProviderType.OpenAICompatible &&
+        isGoogleVertexEndpoint(endpoint)
+      return {
+        ...provider,
+        ...(isLegacyVertex
+          ? {
+              type: AIProviderType.GoogleVertex,
+              modelListUrl: undefined,
+            }
+          : {}),
+        projectId: provider.projectId ?? extractGoogleVertexProjectId(endpoint),
+        capabilities: isLegacyVertex
+          ? { text: true, image: true, speech: true }
+          : {
+              text: provider.capabilities?.text ?? true,
+              image: provider.capabilities?.image ?? false,
+              speech: provider.capabilities?.speech ?? false,
+            },
+      }
+    })
 
     if (storedAiConfig?.version === 2) {
       return { ...aiConfig, version: 2, providers }
@@ -274,6 +310,7 @@ export class ConfigsService implements OnModuleInit {
         type: AIProviderType.OpenAICompatible,
         apiKey: input.apiKey,
         endpoint: normalizedEndpoint,
+        projectId: undefined,
         defaultModel: input.defaultModel ?? '',
         enabled: true,
         capabilities: {

--- a/apps/core/test/src/modules/ai/ai-agent.faux.e2e.spec.ts
+++ b/apps/core/test/src/modules/ai/ai-agent.faux.e2e.spec.ts
@@ -8,7 +8,10 @@ import { afterEach, describe, expect, it, vi } from 'vitest'
 
 import { withFauxAi } from '@/helper/faux-ai.helper'
 import { AIProviderType } from '~/modules/ai/ai.types'
-import { AiAgentChatService } from '~/modules/ai/ai-agent/ai-agent-chat.service'
+import {
+  AiAgentChatService,
+  toPiMessages,
+} from '~/modules/ai/ai-agent/ai-agent-chat.service'
 
 const PROVIDER = 'faux-agent'
 const MODEL_ID = 'faux-agent-model'
@@ -79,6 +82,41 @@ afterEach(() => {
 })
 
 describe('ai-agent faux e2e (streamChat)', () => {
+  it.each([
+    [AIProviderType.OpenAICompatible, 'openai-completions'],
+    [AIProviderType.Anthropic, 'anthropic-messages'],
+  ] as const)(
+    'replays assistant history using the selected %s protocol',
+    (type, api) => {
+      const { piMessages } = toPiMessages(
+        [
+          { role: 'assistant', content: 'previous answer' },
+          {
+            role: 'assistant_tool_call',
+            toolCalls: [
+              { id: 'call-1', name: 'lookup', arguments: '{"id":1}' },
+            ],
+          },
+        ],
+        { api, id: 'selected-provider', type, model: 'selected-model' },
+      )
+
+      expect(piMessages).toHaveLength(2)
+      expect(piMessages).toEqual([
+        expect.objectContaining({
+          api,
+          provider: 'selected-provider',
+          model: 'selected-model',
+        }),
+        expect.objectContaining({
+          api,
+          provider: 'selected-provider',
+          model: 'selected-model',
+        }),
+      ])
+    },
+  )
+
   it('text stream: emits text_delta + done', async () => {
     const ctx = setup({ responses: [fauxAssistantMessage('hello world')] })
     torn.push(ctx.teardown)

--- a/apps/core/test/src/modules/ai/ai-image/image-runtime.adapter.spec.ts
+++ b/apps/core/test/src/modules/ai/ai-image/image-runtime.adapter.spec.ts
@@ -1,7 +1,8 @@
 import type { AssistantImages } from '@earendil-works/pi-ai'
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { AppErrorCode } from '~/common/errors'
+import { AIProviderType } from '~/modules/ai/ai.types'
 import { ImageRuntimeAdapter } from '~/modules/ai/ai-image/image-runtime.adapter'
 
 const { generateOpenRouterImagesMock } = vi.hoisted(() => ({
@@ -31,9 +32,112 @@ function createAdapter() {
   })
 }
 
+afterEach(() => vi.unstubAllGlobals())
+
 describe('ImageRuntimeAdapter.generateImage', () => {
   beforeEach(() => {
     generateOpenRouterImagesMock.mockReset()
+  })
+
+  it('uses the recommended Vertex Gemini image API and x-goog-api-key authentication', async () => {
+    const png = Buffer.from('vertex-png')
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          candidates: [
+            {
+              content: {
+                parts: [
+                  { text: 'Generated image' },
+                  {
+                    inlineData: {
+                      data: png.toString('base64'),
+                      mimeType: 'image/png',
+                    },
+                  },
+                ],
+              },
+            },
+          ],
+        }),
+        { status: 200, headers: { 'content-type': 'application/json' } },
+      ),
+    )
+    vi.stubGlobal('fetch', fetchMock)
+    const adapter = new ImageRuntimeAdapter({
+      provider: 'vertex',
+      providerType: AIProviderType.GoogleVertex,
+      projectId: 'example-project',
+      apiKey: 'vertex-key',
+      model: 'gemini-2.5-flash-image',
+    })
+
+    const result = await adapter.generateImage({
+      prompt: 'a paper crane',
+      aspectRatio: '16:9',
+    })
+
+    expect(result.images[0]).toEqual({ buffer: png, mimeType: 'image/png' })
+    const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit]
+    expect(url).toBe(
+      'https://aiplatform.googleapis.com/v1/projects/example-project/locations/global/publishers/google/models/gemini-2.5-flash-image:generateContent',
+    )
+    expect(init.headers).toMatchObject({
+      'x-goog-api-key': 'vertex-key',
+    })
+    expect(JSON.parse(init.body as string)).toMatchObject({
+      contents: { role: 'user', parts: [{ text: 'a paper crane' }] },
+      generation_config: {
+        image_config: { aspect_ratio: '16:9' },
+        response_modalities: ['TEXT', 'IMAGE'],
+      },
+    })
+    expect(generateOpenRouterImagesMock).not.toHaveBeenCalled()
+  })
+
+  it('routes Vertex Imagen models to the predict protocol adapter', async () => {
+    const png = Buffer.from('imagen-png')
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          predictions: [
+            {
+              bytesBase64Encoded: png.toString('base64'),
+              mimeType: 'image/png',
+            },
+          ],
+        }),
+        { status: 200, headers: { 'content-type': 'application/json' } },
+      ),
+    )
+    vi.stubGlobal('fetch', fetchMock)
+    const adapter = new ImageRuntimeAdapter({
+      provider: 'vertex',
+      providerType: AIProviderType.GoogleVertex,
+      projectId: 'example-project',
+      apiKey: 'vertex-key',
+      model: 'imagen-4.0-generate-001',
+    })
+
+    const result = await adapter.generateImage({ prompt: 'a paper crane' })
+
+    expect(result.images).toEqual([{ buffer: png, mimeType: 'image/png' }])
+    expect(fetchMock.mock.calls[0]?.[0]).toBe(
+      'https://us-central1-aiplatform.googleapis.com/v1/projects/example-project/locations/us-central1/publishers/google/models/imagen-4.0-generate-001:predict',
+    )
+    expect(generateOpenRouterImagesMock).not.toHaveBeenCalled()
+  })
+
+  it('rejects unsupported provider protocols instead of falling back', () => {
+    expect(
+      () =>
+        new ImageRuntimeAdapter({
+          provider: 'anthropic',
+          providerType: AIProviderType.Anthropic,
+          apiKey: 'key',
+          model: 'image-model',
+        }),
+    ).toThrow('No protocol adapter supports the runtime configuration')
   })
 
   it('returns decoded buffers when the OpenRouter transport reports stopReason: stop', async () => {

--- a/apps/core/test/src/modules/ai/ai-provider.factory.spec.ts
+++ b/apps/core/test/src/modules/ai/ai-provider.factory.spec.ts
@@ -30,6 +30,7 @@ describe('createModelRuntime — enum coverage', () => {
     expect(runtime).toBeInstanceOf(PiRuntimeAdapter)
     expect(runtime.providerInfo.type).toBe(AIProviderType.OpenAICompatible)
     expect(runtime.providerInfo.model).toBe('deepseek-chat')
+    expect(runtime.providerInfo.api).toBe('openai-completions')
     expect(inspect(runtime).api).toBe('openai-completions')
   })
 
@@ -46,6 +47,7 @@ describe('createModelRuntime — enum coverage', () => {
     expect(runtime).toBeInstanceOf(PiRuntimeAdapter)
     expect(runtime.providerInfo.type).toBe(AIProviderType.Anthropic)
     expect(runtime.providerInfo.model).toBe('claude-sonnet-4-20250514')
+    expect(runtime.providerInfo.api).toBe('anthropic-messages')
     expect(inspect(runtime).api).toBe('anthropic-messages')
   })
 
@@ -78,6 +80,7 @@ describe('createModelRuntime — enum coverage', () => {
     })
     expect(runtime).toBeInstanceOf(PiRuntimeAdapter)
     expect(runtime.providerInfo.type).toBe(AIProviderType.GoogleVertex)
+    expect(runtime.providerInfo.api).toBe('openai-completions')
     expect(inspect(runtime).api).toBe('openai-completions')
     expect(inspect(runtime).piProviderId).toBe('google-vertex')
     expect(inspect(runtime).buildStreamOptions({}).headers).toEqual({
@@ -112,7 +115,7 @@ describe('createModelRuntime — enum coverage', () => {
         defaultModel: 'model',
         enabled: true,
       }),
-    ).toThrow('Unsupported provider type')
+    ).toThrow('No protocol adapter supports the runtime configuration')
   })
 })
 

--- a/apps/core/test/src/modules/ai/ai-provider.factory.spec.ts
+++ b/apps/core/test/src/modules/ai/ai-provider.factory.spec.ts
@@ -6,6 +6,9 @@ import { PiRuntimeAdapter } from '~/modules/ai/runtime/pi-runtime.adapter'
 
 interface AdapterInternals {
   api: 'openai-completions' | 'anthropic-messages'
+  buildStreamOptions: (options: object) => {
+    headers?: Record<string, string | null>
+  }
   piProviderId: string
 }
 
@@ -59,6 +62,28 @@ describe('createModelRuntime — enum coverage', () => {
     expect(runtime).toBeInstanceOf(PiRuntimeAdapter)
     expect(runtime.providerInfo.type).toBe(AIProviderType.Generic)
     expect(inspect(runtime).api).toBe('openai-completions')
+  })
+
+  it('constructs a Vertex text runtime over its OpenAI-compatible endpoint', () => {
+    const runtime = createModelRuntime({
+      id: 'vertex',
+      name: 'Vertex',
+      type: AIProviderType.GoogleVertex,
+      apiKey: 'vertex-key',
+      projectId: 'example-project',
+      endpoint:
+        'https://aiplatform.googleapis.com/v1/projects/example-project/locations/global/endpoints/openapi',
+      defaultModel: 'google/gemini-3.6-flash',
+      enabled: true,
+    })
+    expect(runtime).toBeInstanceOf(PiRuntimeAdapter)
+    expect(runtime.providerInfo.type).toBe(AIProviderType.GoogleVertex)
+    expect(inspect(runtime).api).toBe('openai-completions')
+    expect(inspect(runtime).piProviderId).toBe('google-vertex')
+    expect(inspect(runtime).buildStreamOptions({}).headers).toEqual({
+      Authorization: null,
+      'x-goog-api-key': 'vertex-key',
+    })
   })
 
   it('uses model override when provided', () => {

--- a/apps/core/test/src/modules/ai/ai-tts/tts-runtime.adapter.spec.ts
+++ b/apps/core/test/src/modules/ai/ai-tts/tts-runtime.adapter.spec.ts
@@ -1,5 +1,6 @@
 import { afterEach, describe, expect, it, vi } from 'vitest'
 
+import { AIProviderType } from '~/modules/ai/ai.types'
 import {
   resolveTtsBaseUrl,
   TtsRuntimeAdapter,
@@ -25,6 +26,95 @@ describe('resolveTtsBaseUrl', () => {
 })
 
 describe('TtsRuntimeAdapter', () => {
+  it('uses Vertex Gemini TTS and wraps returned PCM as WAV', async () => {
+    const pcm = Buffer.from([1, 0, 2, 0])
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          candidates: [
+            {
+              content: {
+                parts: [
+                  {
+                    inlineData: {
+                      data: pcm.toString('base64'),
+                      mimeType: 'audio/pcm;rate=24000;channels=1',
+                    },
+                  },
+                ],
+              },
+            },
+          ],
+        }),
+        { status: 200, headers: { 'content-type': 'application/json' } },
+      ),
+    )
+    vi.stubGlobal('fetch', fetchMock)
+    const adapter = new TtsRuntimeAdapter({
+      provider: 'vertex',
+      providerType: AIProviderType.GoogleVertex,
+      projectId: 'example-project',
+      apiKey: 'vertex-key',
+      endpoint:
+        'https://aiplatform.googleapis.com/v1/projects/example-project/locations/global/endpoints/openapi',
+      model: 'gemini-3.1-flash-tts-preview',
+    })
+
+    const result = await adapter.generateSpeech({
+      input: '今日',
+      language: 'ja',
+      voice: 'Kore',
+      speed: 1,
+    })
+
+    expect(result.mimeType).toBe('audio/wav')
+    expect(result.buffer.subarray(0, 4).toString()).toBe('RIFF')
+    expect(result.buffer.subarray(44)).toEqual(pcm)
+    const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit]
+    expect(url).toContain(
+      '/v1beta1/projects/example-project/locations/us-central1/publishers/google/models/gemini-3.1-flash-tts-preview:generateContent',
+    )
+    expect(init.headers).toMatchObject({
+      'x-goog-api-key': 'vertex-key',
+    })
+    expect(JSON.parse(init.body as string)).toMatchObject({
+      generation_config: {
+        response_modalities: ['AUDIO'],
+        speech_config: {
+          language_code: 'ja-JP',
+          voice_config: {
+            prebuilt_voice_config: { voice_name: 'Kore' },
+          },
+        },
+      },
+    })
+  })
+
+  it('rejects unsupported provider protocols instead of falling back', () => {
+    expect(
+      () =>
+        new TtsRuntimeAdapter({
+          provider: 'anthropic',
+          providerType: AIProviderType.Anthropic,
+          apiKey: 'key',
+          model: 'speech-model',
+        }),
+    ).toThrow('No protocol adapter supports the runtime configuration')
+  })
+
+  it('rejects a non-TTS Vertex model instead of choosing a transport by provider alone', () => {
+    expect(
+      () =>
+        new TtsRuntimeAdapter({
+          provider: 'vertex',
+          providerType: AIProviderType.GoogleVertex,
+          projectId: 'example-project',
+          apiKey: 'key',
+          model: 'gemini-2.5-flash',
+        }),
+    ).toThrow('No protocol adapter supports the runtime configuration')
+  })
+
   it('posts the OpenAI speech body and returns the audio buffer', async () => {
     const fetchMock = vi.fn(async () => audio())
     vi.stubGlobal('fetch', fetchMock)

--- a/apps/core/test/src/modules/ai/ai-tts/tts-voice-catalog.service.spec.ts
+++ b/apps/core/test/src/modules/ai/ai-tts/tts-voice-catalog.service.spec.ts
@@ -23,6 +23,24 @@ afterEach(() => {
 })
 
 describe('discoverTtsVoices', () => {
+  it('returns Vertex Gemini voices without a network request', async () => {
+    const fetchMock = vi.fn()
+    vi.stubGlobal('fetch', fetchMock)
+    const result = await discoverTtsVoices(
+      {
+        ...provider,
+        type: AIProviderType.GoogleVertex,
+        projectId: 'example-project',
+      },
+      'gemini-3.1-flash-tts-preview',
+    )
+
+    expect(result.source).toBe('builtin')
+    expect(result.voices.map((voice) => voice.id)).toEqual(
+      expect.arrayContaining(['Kore', 'Puck', 'Zephyr']),
+    )
+    expect(fetchMock).not.toHaveBeenCalled()
+  })
   it('returns the built-in OpenAI voice catalog without a network request', async () => {
     const fetchMock = vi.fn()
     vi.stubGlobal('fetch', fetchMock)

--- a/apps/core/test/src/modules/ai/runtime/protocol-adapter.registry.spec.ts
+++ b/apps/core/test/src/modules/ai/runtime/protocol-adapter.registry.spec.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it } from 'vitest'
+
+import type { ProtocolAdapterResolutionError } from '~/modules/ai/runtime/protocol-adapter.registry'
+import { ProtocolAdapterRegistry } from '~/modules/ai/runtime/protocol-adapter.registry'
+
+describe('ProtocolAdapterRegistry', () => {
+  it('returns the only adapter supporting the context', () => {
+    const registry = new ProtocolAdapterRegistry<{ protocol: string }, string>()
+      .register({
+        id: 'alpha',
+        matches: ({ protocol }) => protocol === 'alpha',
+        create: () => 'alpha-adapter',
+      })
+      .register({
+        id: 'beta',
+        matches: ({ protocol }) => protocol === 'beta',
+        create: () => 'beta-adapter',
+      })
+
+    expect(registry.resolve({ protocol: 'beta' })).toBe('beta-adapter')
+  })
+
+  it('rejects a configuration with no matching adapter', () => {
+    const registry = new ProtocolAdapterRegistry<string, string>().register({
+      id: 'known',
+      matches: (protocol) => protocol === 'known',
+      create: () => 'known-adapter',
+    })
+
+    expect(() => registry.resolve('unknown')).toThrowError(
+      expect.objectContaining<Partial<ProtocolAdapterResolutionError>>({
+        kind: 'not-found',
+        adapterIds: [],
+      }),
+    )
+  })
+
+  it('rejects ambiguous matches instead of selecting by registration order', () => {
+    const registry = new ProtocolAdapterRegistry<string, string>()
+      .register({
+        id: 'first',
+        matches: () => true,
+        create: () => 'first-adapter',
+      })
+      .register({
+        id: 'second',
+        matches: () => true,
+        create: () => 'second-adapter',
+      })
+
+    expect(() => registry.resolve('context')).toThrowError(
+      expect.objectContaining<Partial<ProtocolAdapterResolutionError>>({
+        kind: 'ambiguous',
+        adapterIds: ['first', 'second'],
+      }),
+    )
+  })
+
+  it('rejects duplicate adapter identifiers', () => {
+    const registry = new ProtocolAdapterRegistry<string, string>().register({
+      id: 'duplicate',
+      matches: () => true,
+      create: () => 'first-adapter',
+    })
+
+    expect(() =>
+      registry.register({
+        id: 'duplicate',
+        matches: () => false,
+        create: () => 'second-adapter',
+      }),
+    ).toThrow('Duplicate protocol adapter: duplicate')
+  })
+})


### PR DESCRIPTION
## Summary

- add Google Vertex AI provider presets with Project ID template interpolation and dedicated Admin configuration fields
- enable text, image, and speech capabilities through Vertex-specific transports
- introduce a strict protocol Adapter Registry for image and TTS runtimes
- separate OpenAI-compatible, Vertex Gemini, and Vertex Imagen protocol implementations
- preserve TTS language strategies, retry behavior, voice discovery, and legacy Vertex configuration normalization

## Why

Image and TTS protocol selection had begun accumulating provider-specific conditionals inside the runtime facades. Adding another provider with a proprietary wire protocol would require modifying shared runtime control flow and could silently fall back to an incompatible transport.

The new registry requires exactly one matching adapter. Unsupported or ambiguous configurations now fail explicitly.

## Impact

Administrators can configure Vertex with a Project ID through the provider preset modal. Vertex text, image, and speech capabilities use their appropriate endpoints, while existing OpenAI-compatible behavior remains unchanged.

## Validation

- Admin focused tests: 2 files, 30 tests passed
- Core focused tests: 5 files, 52 tests passed
- Admin and Core TypeScript checks passed
- scoped ESLint and commit hooks passed
- `git diff --check` passed
- credential and temporary-fixture scans found no repository residue
- acceptance: https://app.lobehub.com/acceptance/0cb931d1-299c-4e20-9217-99ca19f8e6b0
- verification round: https://app.lobehub.com/verify/76b536b6-7bad-4a13-9801-1af5304dfa41
