### PR TITLE
fix(s3): add sanitized transport diagnostics

### DIFF
--- a/apps/core/src/utils/s3.util.ts
+++ b/apps/core/src/utils/s3.util.ts
@@ -139,17 +139,88 @@ const readCauseField = (
   }
 }
 
-const getErrorCause = (error: unknown): Record<string, unknown> | undefined => {
-  if (typeof error !== 'object' || error === null) return undefined
-
+const readNestedCauseField = (
+  cause: Record<string, unknown>,
+  field: 'cause' | 'errors',
+): unknown => {
   try {
-    const cause = (error as { cause?: unknown }).cause
-    return typeof cause === 'object' && cause !== null
-      ? (cause as Record<string, unknown>)
-      : undefined
+    return cause[field]
   } catch {
     return undefined
   }
+}
+
+const getS3TransportCause = (
+  error: unknown,
+): Record<string, unknown> | undefined => {
+  const queue: Array<{ depth: number; value: unknown }> = [
+    { depth: 0, value: error },
+  ]
+  const seen = new WeakSet<object>()
+  const maxDepth = 4
+  const maxNodes = 16
+  let visited = 0
+
+  while (queue.length > 0 && visited < maxNodes) {
+    const current = queue.shift()
+    if (
+      !current ||
+      typeof current.value !== 'object' ||
+      current.value === null ||
+      seen.has(current.value)
+    ) {
+      continue
+    }
+
+    seen.add(current.value)
+    visited++
+    const cause = current.value as Record<string, unknown>
+    const name = toAllowedTransportValue<S3TransportName>(
+      readCauseField(cause, 'name'),
+      S3_TRANSPORT_NAME_ALLOWLIST,
+      'UnknownError',
+    )
+    const code = toAllowedTransportValue<S3TransportCode>(
+      readCauseField(cause, 'code'),
+      S3_TRANSPORT_CODE_ALLOWLIST,
+      'UNKNOWN',
+    )
+    const syscall = toAllowedTransportValue<S3TransportSyscall>(
+      readCauseField(cause, 'syscall'),
+      S3_TRANSPORT_SYSCALL_ALLOWLIST,
+      'unknown',
+    )
+
+    if (
+      name !== 'UnknownError' ||
+      code !== 'UNKNOWN' ||
+      syscall !== 'unknown'
+    ) {
+      return cause
+    }
+
+    if (current.depth >= maxDepth) continue
+
+    queue.push({
+      depth: current.depth + 1,
+      value: readNestedCauseField(cause, 'cause'),
+    })
+
+    const errors = readNestedCauseField(cause, 'errors')
+    if (Array.isArray(errors)) {
+      for (let index = 0; index < errors.length && index < maxNodes; index++) {
+        let nestedError: unknown
+        try {
+          nestedError = errors[index]
+        } catch {
+          continue
+        }
+        queue.push({ depth: current.depth + 1, value: nestedError })
+      }
+    }
+  }
+
+  return undefined
 }
 
 const classifyS3TransportError = (
@@ -169,7 +240,7 @@ const getS3TransportDiagnosticNonce = (): string => {
 }
 
 const createS3TransportError = (error: unknown): Error => {
-  const cause = getErrorCause(error)
+  const cause = getS3TransportCause(error)
   const name = toAllowedTransportValue<S3TransportName>(
     readCauseField(cause, 'name'),
     S3_TRANSPORT_NAME_ALLOWLIST,
@@ -783,12 +854,9 @@ export class S3Uploader {
     const resolved = this.resolveEndpoint(host, encodedObjectKey, url.protocol)
     const { requestHost, canonicalUri } = resolved
 
-    const contentLength = fileData.length.toString()
-
     const headers: Record<string, string> = {
       Host: requestHost,
       'Content-Type': contentType,
-      'Content-Length': contentLength,
       'x-amz-date': xAmzDate,
       'x-amz-content-sha256': hashedPayload,
     }

--- a/apps/core/src/utils/s3.util.ts
+++ b/apps/core/src/utils/s3.util.ts
@@ -11,6 +11,188 @@ export interface S3UploaderOptions {
   endpoint?: string
 }
 
+const S3_TRANSPORT_DIAGNOSTIC_BEGIN = 'begin=S3_TRANSPORT_DIAGNOSTIC'
+const S3_TRANSPORT_DIAGNOSTIC_END = 'end=S3_TRANSPORT_DIAGNOSTIC'
+// Keep the deployment contract's lowercase hexadecimal grammar literal.
+// eslint-disable-next-line unicorn/better-regex
+const S3_TRANSPORT_DIAGNOSTIC_NONCE_PATTERN = /^[0-9a-f]{32}$/
+
+const S3_TRANSPORT_NAMES = [
+  'AbortError',
+  'BodyTimeoutError',
+  'ConnectTimeoutError',
+  'HeadersTimeoutError',
+  'RequestContentLengthMismatchError',
+  'SocketError',
+  'TimeoutError',
+  'UnknownError',
+] as const
+
+const S3_TRANSPORT_CODES = [
+  'ABORT_ERR',
+  'CERT_HAS_EXPIRED',
+  'DEPTH_ZERO_SELF_SIGNED_CERT',
+  'EAI_AGAIN',
+  'ECONNREFUSED',
+  'ECONNRESET',
+  'EHOSTUNREACH',
+  'ENETUNREACH',
+  'ENOTFOUND',
+  'EPIPE',
+  'ERR_SSL_WRONG_VERSION_NUMBER',
+  'ERR_TLS_CERT_ALTNAME_INVALID',
+  'ETIMEDOUT',
+  'SELF_SIGNED_CERT_IN_CHAIN',
+  'UNABLE_TO_VERIFY_LEAF_SIGNATURE',
+  'UND_ERR_ABORTED',
+  'UND_ERR_BODY_TIMEOUT',
+  'UND_ERR_CLOSED',
+  'UND_ERR_CONNECT_TIMEOUT',
+  'UND_ERR_DESTROYED',
+  'UND_ERR_HEADERS_TIMEOUT',
+  'UND_ERR_REQ_CONTENT_LENGTH_MISMATCH',
+  'UND_ERR_SOCKET',
+  'UNKNOWN',
+] as const
+
+const S3_TRANSPORT_SYSCALLS = [
+  'connect',
+  'getaddrinfo',
+  'lookup',
+  'read',
+  'recv',
+  'send',
+  'socket',
+  'tls',
+  'unknown',
+  'write',
+] as const
+
+type S3TransportName = (typeof S3_TRANSPORT_NAMES)[number]
+type S3TransportCode = (typeof S3_TRANSPORT_CODES)[number]
+type S3TransportSyscall = (typeof S3_TRANSPORT_SYSCALLS)[number]
+type S3TransportCategory =
+  | 'aborted'
+  | 'connection_refused'
+  | 'connection_timeout'
+  | 'dns_failure'
+  | 'request_content_length_mismatch'
+  | 'socket_failure'
+  | 'tls_failure'
+  | 'unknown'
+
+const S3_TRANSPORT_NAME_ALLOWLIST = new Set<string>(S3_TRANSPORT_NAMES)
+const S3_TRANSPORT_CODE_ALLOWLIST = new Set<string>(S3_TRANSPORT_CODES)
+const S3_TRANSPORT_SYSCALL_ALLOWLIST = new Set<string>(S3_TRANSPORT_SYSCALLS)
+
+const S3_TRANSPORT_CODE_CATEGORY = {
+  ABORT_ERR: 'aborted',
+  CERT_HAS_EXPIRED: 'tls_failure',
+  DEPTH_ZERO_SELF_SIGNED_CERT: 'tls_failure',
+  EAI_AGAIN: 'dns_failure',
+  ECONNREFUSED: 'connection_refused',
+  ECONNRESET: 'socket_failure',
+  EHOSTUNREACH: 'socket_failure',
+  ENETUNREACH: 'socket_failure',
+  ENOTFOUND: 'dns_failure',
+  EPIPE: 'socket_failure',
+  ERR_SSL_WRONG_VERSION_NUMBER: 'tls_failure',
+  ERR_TLS_CERT_ALTNAME_INVALID: 'tls_failure',
+  ETIMEDOUT: 'connection_timeout',
+  SELF_SIGNED_CERT_IN_CHAIN: 'tls_failure',
+  UNABLE_TO_VERIFY_LEAF_SIGNATURE: 'tls_failure',
+  UND_ERR_ABORTED: 'aborted',
+  UND_ERR_BODY_TIMEOUT: 'connection_timeout',
+  UND_ERR_CLOSED: 'socket_failure',
+  UND_ERR_CONNECT_TIMEOUT: 'connection_timeout',
+  UND_ERR_DESTROYED: 'socket_failure',
+  UND_ERR_HEADERS_TIMEOUT: 'connection_timeout',
+  UND_ERR_REQ_CONTENT_LENGTH_MISMATCH: 'request_content_length_mismatch',
+  UND_ERR_SOCKET: 'socket_failure',
+} satisfies Partial<Record<S3TransportCode, S3TransportCategory>>
+
+const S3_TRANSPORT_NAME_CATEGORY = {
+  AbortError: 'aborted',
+  BodyTimeoutError: 'connection_timeout',
+  ConnectTimeoutError: 'connection_timeout',
+  HeadersTimeoutError: 'connection_timeout',
+  RequestContentLengthMismatchError: 'request_content_length_mismatch',
+  SocketError: 'socket_failure',
+  TimeoutError: 'connection_timeout',
+} satisfies Partial<Record<S3TransportName, S3TransportCategory>>
+
+const toAllowedTransportValue = <T extends string>(
+  value: unknown,
+  allowlist: ReadonlySet<string>,
+  fallback: T,
+): T =>
+  typeof value === 'string' && allowlist.has(value) ? (value as T) : fallback
+
+const readCauseField = (
+  cause: Record<string, unknown> | undefined,
+  field: 'name' | 'code' | 'syscall',
+): unknown => {
+  try {
+    return cause?.[field]
+  } catch {
+    return undefined
+  }
+}
+
+const getErrorCause = (error: unknown): Record<string, unknown> | undefined => {
+  if (typeof error !== 'object' || error === null) return undefined
+
+  try {
+    const cause = (error as { cause?: unknown }).cause
+    return typeof cause === 'object' && cause !== null
+      ? (cause as Record<string, unknown>)
+      : undefined
+  } catch {
+    return undefined
+  }
+}
+
+const classifyS3TransportError = (
+  name: S3TransportName,
+  code: S3TransportCode,
+): S3TransportCategory =>
+  S3_TRANSPORT_CODE_CATEGORY[code as keyof typeof S3_TRANSPORT_CODE_CATEGORY] ??
+  S3_TRANSPORT_NAME_CATEGORY[name as keyof typeof S3_TRANSPORT_NAME_CATEGORY] ??
+  'unknown'
+
+const getS3TransportDiagnosticNonce = (): string => {
+  const nonce = process.env.MX_SPACE_S3_DIAGNOSTIC_NONCE
+  return typeof nonce === 'string' &&
+    S3_TRANSPORT_DIAGNOSTIC_NONCE_PATTERN.test(nonce)
+    ? nonce
+    : 'unbound'
+}
+
+const createS3TransportError = (error: unknown): Error => {
+  const cause = getErrorCause(error)
+  const name = toAllowedTransportValue<S3TransportName>(
+    readCauseField(cause, 'name'),
+    S3_TRANSPORT_NAME_ALLOWLIST,
+    'UnknownError',
+  )
+  const code = toAllowedTransportValue<S3TransportCode>(
+    readCauseField(cause, 'code'),
+    S3_TRANSPORT_CODE_ALLOWLIST,
+    'UNKNOWN',
+  )
+  const syscall = toAllowedTransportValue<S3TransportSyscall>(
+    readCauseField(cause, 'syscall'),
+    S3_TRANSPORT_SYSCALL_ALLOWLIST,
+    'unknown',
+  )
+  const category = classifyS3TransportError(name, code)
+  const nonce = getS3TransportDiagnosticNonce()
+
+  return new Error(
+    `S3 transport failed: ${S3_TRANSPORT_DIAGNOSTIC_BEGIN} nonce=${nonce} name=${name} code=${code} syscall=${syscall} category=${category} ${S3_TRANSPORT_DIAGNOSTIC_END}`,
+  )
+}
+
 /**
  * Resolved endpoint information used for signing and sending S3 requests.
  */
@@ -674,10 +856,20 @@ export class S3Uploader {
     }
 
     try {
-      const response = await fetch(requestUrl, fetchOptions as RequestInit)
+      let response: Response
+      try {
+        response = await fetch(requestUrl, fetchOptions as RequestInit)
+      } catch (error) {
+        throw createS3TransportError(error)
+      }
 
       if (!response.ok) {
-        const responseText = await response.text()
+        let responseText: string
+        try {
+          responseText = await response.text()
+        } catch (error) {
+          throw createS3TransportError(error)
+        }
         throw new Error(
           `Upload failed with status code: ${response.status} - ${responseText}`,
         )

--- a/apps/core/test/src/utils/s3.util.spec.ts
+++ b/apps/core/test/src/utils/s3.util.spec.ts
@@ -1,10 +1,17 @@
+import { once } from 'node:events'
+import { createServer } from 'node:http'
+import type { AddressInfo } from 'node:net'
 import { Readable } from 'node:stream'
 
-import { describe, expect, it, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { S3Uploader } from '~/utils/s3.util'
 
 const PART_SIZE = 8 * 1024 * 1024
+const nativeFetch = globalThis.fetch
+const TRANSPORT_DIAGNOSTIC_NONCE_ENV = 'MX_SPACE_S3_DIAGNOSTIC_NONCE'
+const TRANSPORT_DIAGNOSTIC_BEGIN = 'begin=S3_TRANSPORT_DIAGNOSTIC'
+const TRANSPORT_DIAGNOSTIC_END = 'end=S3_TRANSPORT_DIAGNOSTIC'
 
 const createUploader = () =>
   new S3Uploader({
@@ -14,6 +21,482 @@ const createUploader = () =>
     secretKey: 'sk',
     endpoint: 'https://example.r2.cloudflarestorage.com',
   })
+
+const createLocalUploader = async (
+  handler: Parameters<typeof createServer>[0],
+) => {
+  const server = createServer(handler)
+  const sockets = new Set<import('node:net').Socket>()
+  server.on('connection', (socket) => {
+    sockets.add(socket)
+    socket.once('close', () => sockets.delete(socket))
+  })
+  server.on('clientError', (_error, socket) => socket.destroy())
+  server.listen(0, 'localhost')
+  await once(server, 'listening')
+
+  const { port } = server.address() as AddressInfo
+  const uploader = new S3Uploader({
+    bucket: 'localhost-test-bucket',
+    region: 'local',
+    accessKey: 'localhost-access-key',
+    secretKey: 'localhost-secret-key',
+    endpoint: `http://localhost:${port}`,
+  })
+
+  return {
+    port,
+    uploader,
+    close: async () => {
+      for (const socket of sockets) socket.destroy()
+      server.close()
+      await once(server, 'close')
+    },
+  }
+}
+
+const rejectUpload = async (rejection: unknown) => {
+  vi.stubGlobal('fetch', vi.fn().mockRejectedValueOnce(rejection))
+
+  return createUploader()
+    .uploadToS3('private/object.txt', Buffer.from('data'), 'text/plain')
+    .then(
+      () => undefined,
+      (error: unknown) => error as Error & { cause?: unknown },
+    )
+}
+
+interface ExpectedTransportDiagnostic {
+  category: string
+  code: string
+  name: string
+  nonce?: string
+  syscall: string
+}
+
+const expectTransportDiagnostic = (
+  error: (Error & { cause?: unknown }) | undefined,
+  expected: ExpectedTransportDiagnostic,
+) => {
+  const message =
+    `S3 transport failed: ${TRANSPORT_DIAGNOSTIC_BEGIN} ` +
+    `nonce=${expected.nonce ?? 'unbound'} ` +
+    `name=${expected.name} code=${expected.code} syscall=${expected.syscall} ` +
+    `category=${expected.category} ${TRANSPORT_DIAGNOSTIC_END}`
+
+  expect(error).toBeInstanceOf(Error)
+  expect(error?.message).toBe(message)
+  expect(error?.message).not.toContain('message=')
+  expect(error?.message).not.toContain('\n')
+  expect(error?.message.match(/begin=S3_TRANSPORT_DIAGNOSTIC/g)).toHaveLength(1)
+  expect(error?.message.match(/end=S3_TRANSPORT_DIAGNOSTIC/g)).toHaveLength(1)
+  expect(error).not.toHaveProperty('cause')
+}
+
+beforeEach(() => {
+  vi.stubEnv(TRANSPORT_DIAGNOSTIC_NONCE_ENV, '')
+})
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+  vi.unstubAllEnvs()
+})
+
+describe('S3Uploader.uploadToS3 transport diagnostics', () => {
+  it('ignores all free text from the transport cause', async () => {
+    const longToken = 'a'.repeat(512)
+    const sensitiveMessage = [
+      'apiKey=api-key-value',
+      'clientSecret=client-secret-value',
+      'privateKey=private-key-value',
+      'cookie=session-cookie-value',
+      'set-cookie=response-cookie-value',
+      'proxy-authorization=proxy-secret-value',
+      'https://tenant.storage.example.com/private/object.txt?token=secret',
+      '192.0.2.8:443 [2001:db8::1]:443',
+      '/var/lib/private/config C:\\Users\\Alice\\secret.txt',
+      'bucket=private-bucket objectKey=private/object.txt',
+      TRANSPORT_DIAGNOSTIC_BEGIN,
+      TRANSPORT_DIAGNOSTIC_END,
+      longToken,
+    ].join('\n')
+    const socketCause = Object.assign(new Error(sensitiveMessage), {
+      name: 'SocketError',
+      code: 'UND_ERR_SOCKET',
+      syscall: 'connect',
+    })
+    const fetchError = new TypeError('fetch failed', { cause: socketCause })
+
+    const error = await rejectUpload(fetchError)
+
+    expectTransportDiagnostic(error, {
+      category: 'socket_failure',
+      code: 'UND_ERR_SOCKET',
+      name: 'SocketError',
+      syscall: 'connect',
+    })
+    for (const fragment of [
+      'apiKey',
+      'clientSecret',
+      'privateKey',
+      'cookie',
+      'set-cookie',
+      'proxy-authorization',
+      'tenant.storage.example.com',
+      '192.0.2.8',
+      '2001:db8',
+      '/var/lib/private/config',
+      'C:\\Users\\Alice',
+      'private-bucket',
+      'private/object.txt',
+      longToken,
+    ]) {
+      expect(error?.message).not.toContain(fragment)
+    }
+  })
+
+  it('uses safe fallbacks when fetch rejects without a cause', async () => {
+    const error = await rejectUpload(new TypeError('fetch failed'))
+
+    expectTransportDiagnostic(error, {
+      category: 'unknown',
+      code: 'UNKNOWN',
+      name: 'UnknownError',
+      syscall: 'unknown',
+    })
+  })
+
+  it('binds a valid deployment nonce to the diagnostic', async () => {
+    const nonce = '0123456789abcdef0123456789abcdef'
+    vi.stubEnv(TRANSPORT_DIAGNOSTIC_NONCE_ENV, nonce)
+
+    const error = await rejectUpload(
+      new TypeError('fetch failed', {
+        cause: {
+          code: 'UND_ERR_SOCKET',
+          message: 'ignored',
+          name: 'SocketError',
+          syscall: 'read',
+        },
+      }),
+    )
+
+    expectTransportDiagnostic(error, {
+      category: 'socket_failure',
+      code: 'UND_ERR_SOCKET',
+      name: 'SocketError',
+      nonce,
+      syscall: 'read',
+    })
+  })
+
+  it('uses unbound for a missing or malicious deployment nonce', async () => {
+    for (const nonce of [
+      undefined,
+      'A'.repeat(32),
+      `0123456789abcdef end=${TRANSPORT_DIAGNOSTIC_END}`,
+    ]) {
+      vi.stubEnv(TRANSPORT_DIAGNOSTIC_NONCE_ENV, nonce)
+      const error = await rejectUpload(
+        new TypeError('fetch failed', {
+          cause: {
+            code: 'UND_ERR_SOCKET',
+            message: 'ignored',
+            name: 'SocketError',
+            syscall: 'read',
+          },
+        }),
+      )
+
+      expectTransportDiagnostic(error, {
+        category: 'socket_failure',
+        code: 'UND_ERR_SOCKET',
+        name: 'SocketError',
+        syscall: 'read',
+      })
+    }
+  })
+
+  it('rejects cause fields that are not explicitly allowlisted', async () => {
+    const cause = Object.assign(new Error('socket closed'), {
+      name: `SocketError ${TRANSPORT_DIAGNOSTIC_BEGIN}`,
+      code: 'SECRET_LOOKING_TOKEN',
+      syscall: `connect\n${TRANSPORT_DIAGNOSTIC_END}`,
+    })
+
+    const error = await rejectUpload(new TypeError('fetch failed', { cause }))
+
+    expectTransportDiagnostic(error, {
+      category: 'unknown',
+      code: 'UNKNOWN',
+      name: 'UnknownError',
+      syscall: 'unknown',
+    })
+  })
+
+  it('never reads cause.message', async () => {
+    const cause = {
+      name: 'SocketError',
+      code: 'UND_ERR_SOCKET',
+      syscall: 'read',
+    }
+    Object.defineProperty(cause, 'message', {
+      get: () => {
+        throw new Error('cause.message must not be read')
+      },
+    })
+
+    const error = await rejectUpload(new TypeError('fetch failed', { cause }))
+
+    expectTransportDiagnostic(error, {
+      category: 'socket_failure',
+      code: 'UND_ERR_SOCKET',
+      name: 'SocketError',
+      syscall: 'read',
+    })
+  })
+
+  it.each([
+    {
+      category: 'socket_failure',
+      code: 'UND_ERR_SOCKET',
+      name: 'SocketError',
+      syscall: 'read',
+    },
+    {
+      category: 'request_content_length_mismatch',
+      code: 'UND_ERR_REQ_CONTENT_LENGTH_MISMATCH',
+      name: 'RequestContentLengthMismatchError',
+      syscall: 'write',
+    },
+    {
+      category: 'dns_failure',
+      code: 'ENOTFOUND',
+      name: 'UnknownError',
+      syscall: 'getaddrinfo',
+    },
+    {
+      category: 'connection_refused',
+      code: 'ECONNREFUSED',
+      name: 'SocketError',
+      syscall: 'connect',
+    },
+    {
+      category: 'connection_timeout',
+      code: 'UNKNOWN',
+      name: 'ConnectTimeoutError',
+      syscall: 'connect',
+    },
+    {
+      category: 'tls_failure',
+      code: 'ERR_TLS_CERT_ALTNAME_INVALID',
+      name: 'UnknownError',
+      syscall: 'tls',
+    },
+    {
+      category: 'aborted',
+      code: 'UNKNOWN',
+      name: 'AbortError',
+      syscall: 'unknown',
+    },
+    {
+      category: 'unknown',
+      code: 'UNKNOWN',
+      name: 'UnknownError',
+      syscall: 'unknown',
+    },
+  ])(
+    'classifies $category using fixed allowlists',
+    async ({ category, code, name, syscall }) => {
+      const cause = { code, message: 'ignored free text', name, syscall }
+      const error = await rejectUpload(new TypeError('fetch failed', { cause }))
+
+      expectTransportDiagnostic(error, { category, code, name, syscall })
+    },
+  )
+
+  it('preserves the existing HTTP error behavior after a response', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi
+        .fn()
+        .mockResolvedValueOnce(new Response('AccessDenied', { status: 403 })),
+    )
+
+    await expect(
+      createUploader().uploadToS3(
+        'private/object.txt',
+        Buffer.from('data'),
+        'text/plain',
+      ),
+    ).rejects.toThrow('Upload failed with status code: 403 - AccessDenied')
+  })
+})
+
+describe('S3Uploader.uploadToS3 with local Undici transport', () => {
+  it('sends a real PUT request successfully', async () => {
+    let receivedMethod = ''
+    let receivedUrl = ''
+    let receivedBody = Buffer.alloc(0)
+    const local = await createLocalUploader((request, response) => {
+      const chunks: Buffer[] = []
+      request.on('data', (chunk) => chunks.push(Buffer.from(chunk)))
+      request.on('end', () => {
+        receivedMethod = request.method ?? ''
+        receivedUrl = request.url ?? ''
+        receivedBody = Buffer.concat(chunks)
+        response.writeHead(200)
+        response.end()
+      })
+    })
+
+    try {
+      await local.uploader.uploadToS3(
+        'folder/hello.txt',
+        Buffer.from('hello localhost'),
+        'text/plain',
+      )
+
+      expect(receivedMethod).toBe('PUT')
+      expect(receivedUrl).toBe('/localhost-test-bucket/folder/hello.txt')
+      expect(receivedBody.toString()).toBe('hello localhost')
+    } finally {
+      await local.close()
+    }
+  })
+
+  it('reports a structured cause when the server closes the socket', async () => {
+    const local = await createLocalUploader((request) => {
+      request.socket.destroy()
+    })
+
+    try {
+      const error = await local.uploader
+        .uploadToS3(
+          'private/disconnect.txt',
+          Buffer.from('disconnect'),
+          'text/plain',
+        )
+        .then(
+          () => undefined,
+          (reason: unknown) => reason as Error,
+        )
+
+      expectTransportDiagnostic(error, {
+        category: 'socket_failure',
+        code: 'UND_ERR_SOCKET',
+        name: 'SocketError',
+        syscall: 'unknown',
+      })
+      expect(error?.message).not.toContain(String(local.port))
+      expect(error?.message).not.toContain('private/disconnect')
+    } finally {
+      await local.close()
+    }
+  })
+
+  it('reports Undici content-length mismatch without network details', async () => {
+    const local = await createLocalUploader((request, response) => {
+      request.resume()
+      request.on('end', () => {
+        response.writeHead(200)
+        response.end()
+      })
+    })
+    vi.stubGlobal(
+      'fetch',
+      vi.fn((input: RequestInfo | URL, init?: RequestInit) => {
+        const headers = new Headers(init?.headers)
+        const contentLength = Number(headers.get('Content-Length'))
+        headers.set('Content-Length', String(contentLength + 1))
+        return nativeFetch(input, { ...init, headers })
+      }),
+    )
+
+    try {
+      const error = await local.uploader
+        .uploadToS3(
+          'private/mismatch.txt',
+          Buffer.from('mismatch'),
+          'text/plain',
+        )
+        .then(
+          () => undefined,
+          (reason: unknown) => reason as Error,
+        )
+
+      expectTransportDiagnostic(error, {
+        category: 'request_content_length_mismatch',
+        code: 'UND_ERR_REQ_CONTENT_LENGTH_MISMATCH',
+        name: 'RequestContentLengthMismatchError',
+        syscall: 'unknown',
+      })
+      expect(error?.message).not.toContain(String(local.port))
+      expect(error?.message).not.toContain('private/mismatch')
+    } finally {
+      await local.close()
+    }
+  })
+
+  it('preserves the real HTTP 403 response behavior', async () => {
+    const local = await createLocalUploader((_request, response) => {
+      response.writeHead(403, { 'Content-Type': 'text/plain' })
+      response.end('AccessDenied')
+    })
+
+    try {
+      await expect(
+        local.uploader.uploadToS3(
+          'private/forbidden.txt',
+          Buffer.from('forbidden'),
+          'text/plain',
+        ),
+      ).rejects.toThrow('Upload failed with status code: 403 - AccessDenied')
+    } finally {
+      await local.close()
+    }
+  })
+
+  it('wraps a transport failure while reading an HTTP error body', async () => {
+    const nonce = 'fedcba9876543210fedcba9876543210'
+    vi.stubEnv(TRANSPORT_DIAGNOSTIC_NONCE_ENV, nonce)
+    const local = await createLocalUploader((_request, response) => {
+      response.writeHead(403, {
+        'Content-Length': '64',
+        'Content-Type': 'text/plain',
+      })
+      response.flushHeaders()
+      response.write('partial AccessDenied')
+      setImmediate(() => response.destroy())
+    })
+
+    try {
+      const error = await local.uploader
+        .uploadToS3(
+          'private/truncated-error.txt',
+          Buffer.from('forbidden'),
+          'text/plain',
+        )
+        .then(
+          () => undefined,
+          (reason: unknown) => reason as Error,
+        )
+
+      expectTransportDiagnostic(error, {
+        category: 'socket_failure',
+        code: 'UND_ERR_SOCKET',
+        name: 'SocketError',
+        nonce,
+        syscall: 'unknown',
+      })
+      expect(error?.message).not.toContain(String(local.port))
+      expect(error?.message).not.toContain('partial AccessDenied')
+      expect(error?.message).not.toContain('private/truncated-error')
+    } finally {
+      await local.close()
+    }
+  })
+})
 
 describe('S3Uploader.uploadStream', () => {
   it('uploads equal-length non-trailing parts regardless of chunk boundaries', async () => {

--- a/apps/core/test/src/utils/s3.util.spec.ts
+++ b/apps/core/test/src/utils/s3.util.spec.ts
@@ -32,7 +32,7 @@ const createLocalUploader = async (
     socket.once('close', () => sockets.delete(socket))
   })
   server.on('clientError', (_error, socket) => socket.destroy())
-  server.listen(0, 'localhost')
+  server.listen(0, '127.0.0.1')
   await once(server, 'listening')
 
   const { port } = server.address() as AddressInfo
@@ -41,7 +41,7 @@ const createLocalUploader = async (
     region: 'local',
     accessKey: 'localhost-access-key',
     secretKey: 'localhost-secret-key',
-    endpoint: `http://localhost:${port}`,
+    endpoint: `http://127.0.0.1:${port}`,
   })
 
   return {

--- a/apps/core/test/src/utils/s3.util.spec.ts
+++ b/apps/core/test/src/utils/s3.util.spec.ts
@@ -8,7 +8,6 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { S3Uploader } from '~/utils/s3.util'
 
 const PART_SIZE = 8 * 1024 * 1024
-const nativeFetch = globalThis.fetch
 const TRANSPORT_DIAGNOSTIC_NONCE_ENV = 'MX_SPACE_S3_DIAGNOSTIC_NONCE'
 const TRANSPORT_DIAGNOSTIC_BEGIN = 'begin=S3_TRANSPORT_DIAGNOSTIC'
 const TRANSPORT_DIAGNOSTIC_END = 'end=S3_TRANSPORT_DIAGNOSTIC'
@@ -157,6 +156,74 @@ describe('S3Uploader.uploadToS3 transport diagnostics', () => {
 
   it('uses safe fallbacks when fetch rejects without a cause', async () => {
     const error = await rejectUpload(new TypeError('fetch failed'))
+
+    expectTransportDiagnostic(error, {
+      category: 'unknown',
+      code: 'UNKNOWN',
+      name: 'UnknownError',
+      syscall: 'unknown',
+    })
+  })
+
+  it('reads allowlisted fields when fetch rejects with a transport error directly', async () => {
+    const directError = Object.assign(new Error('ignored'), {
+      code: 'UND_ERR_SOCKET',
+      name: 'SocketError',
+      syscall: 'read',
+    })
+
+    const error = await rejectUpload(directError)
+
+    expectTransportDiagnostic(error, {
+      category: 'socket_failure',
+      code: 'UND_ERR_SOCKET',
+      name: 'SocketError',
+      syscall: 'read',
+    })
+  })
+
+  it('finds an allowlisted transport error inside nested aggregate causes', async () => {
+    const nestedError = Object.assign(new Error('nested secret'), {
+      code: 'ECONNRESET',
+      name: 'SocketError',
+      syscall: 'read',
+    })
+    const aggregate = new AggregateError(
+      [new Error('unrelated secret'), nestedError],
+      'aggregate secret',
+    )
+    const middle = new Error('middle secret', { cause: aggregate })
+    const outer = new TypeError('fetch failed', { cause: middle })
+
+    const error = await rejectUpload(outer)
+
+    expectTransportDiagnostic(error, {
+      category: 'socket_failure',
+      code: 'ECONNRESET',
+      name: 'SocketError',
+      syscall: 'read',
+    })
+    for (const fragment of [
+      'nested secret',
+      'unrelated secret',
+      'aggregate secret',
+      'middle secret',
+      'fetch failed',
+    ]) {
+      expect(error?.message).not.toContain(fragment)
+    }
+  })
+
+  it('bounds cyclic cause traversal and ignores unsafe nested getters', async () => {
+    const cyclic: Record<string, unknown> = {}
+    cyclic.cause = cyclic
+    Object.defineProperty(cyclic, 'errors', {
+      get: () => {
+        throw new Error('errors must remain unreadable')
+      },
+    })
+
+    const error = await rejectUpload(cyclic)
 
     expectTransportDiagnostic(error, {
       category: 'unknown',
@@ -331,12 +398,36 @@ describe('S3Uploader.uploadToS3 transport diagnostics', () => {
       ),
     ).rejects.toThrow('Upload failed with status code: 403 - AccessDenied')
   })
+
+  it('leaves content length generation to fetch and out of the signature', async () => {
+    let requestInit: RequestInit | undefined
+    vi.stubGlobal(
+      'fetch',
+      vi.fn((_input: RequestInfo | URL, init?: RequestInit) => {
+        requestInit = init
+        return Promise.resolve(new Response(null, { status: 200 }))
+      }),
+    )
+
+    await createUploader().uploadToS3(
+      'private/object.txt',
+      Buffer.from('data'),
+      'text/plain',
+    )
+
+    const requestHeaders = new Headers(requestInit?.headers)
+    expect(requestHeaders.has('Content-Length')).toBe(false)
+    expect(requestHeaders.get('Authorization')).not.toContain('content-length')
+    expect(requestInit?.body).toBeInstanceOf(Uint8Array)
+  })
 })
 
 describe('S3Uploader.uploadToS3 with local Undici transport', () => {
   it('sends a real PUT request successfully', async () => {
     let receivedMethod = ''
     let receivedUrl = ''
+    let receivedContentLength = ''
+    let receivedAuthorization = ''
     let receivedBody = Buffer.alloc(0)
     const local = await createLocalUploader((request, response) => {
       const chunks: Buffer[] = []
@@ -344,6 +435,8 @@ describe('S3Uploader.uploadToS3 with local Undici transport', () => {
       request.on('end', () => {
         receivedMethod = request.method ?? ''
         receivedUrl = request.url ?? ''
+        receivedContentLength = request.headers['content-length'] ?? ''
+        receivedAuthorization = request.headers.authorization ?? ''
         receivedBody = Buffer.concat(chunks)
         response.writeHead(200)
         response.end()
@@ -359,6 +452,10 @@ describe('S3Uploader.uploadToS3 with local Undici transport', () => {
 
       expect(receivedMethod).toBe('PUT')
       expect(receivedUrl).toBe('/localhost-test-bucket/folder/hello.txt')
+      expect(receivedContentLength).toBe(
+        String(Buffer.byteLength('hello localhost')),
+      )
+      expect(receivedAuthorization).not.toContain('content-length')
       expect(receivedBody.toString()).toBe('hello localhost')
     } finally {
       await local.close()
@@ -390,49 +487,6 @@ describe('S3Uploader.uploadToS3 with local Undici transport', () => {
       })
       expect(error?.message).not.toContain(String(local.port))
       expect(error?.message).not.toContain('private/disconnect')
-    } finally {
-      await local.close()
-    }
-  })
-
-  it('reports Undici content-length mismatch without network details', async () => {
-    const local = await createLocalUploader((request, response) => {
-      request.resume()
-      request.on('end', () => {
-        response.writeHead(200)
-        response.end()
-      })
-    })
-    vi.stubGlobal(
-      'fetch',
-      vi.fn((input: RequestInfo | URL, init?: RequestInit) => {
-        const headers = new Headers(init?.headers)
-        const contentLength = Number(headers.get('Content-Length'))
-        headers.set('Content-Length', String(contentLength + 1))
-        return nativeFetch(input, { ...init, headers })
-      }),
-    )
-
-    try {
-      const error = await local.uploader
-        .uploadToS3(
-          'private/mismatch.txt',
-          Buffer.from('mismatch'),
-          'text/plain',
-        )
-        .then(
-          () => undefined,
-          (reason: unknown) => reason as Error,
-        )
-
-      expectTransportDiagnostic(error, {
-        category: 'request_content_length_mismatch',
-        code: 'UND_ERR_REQ_CONTENT_LENGTH_MISMATCH',
-        name: 'RequestContentLengthMismatchError',
-        syscall: 'unknown',
-      })
-      expect(error?.message).not.toContain(String(local.port))
-      expect(error?.message).not.toContain('private/mismatch')
     } finally {
       await local.close()
     }


### PR DESCRIPTION
## Summary

- add bounded S3 transport diagnostics with explicit allowlists for error name, code, syscall, and category
- prevent provider, endpoint, object-key, response-body, stack, and arbitrary cause text from entering the diagnostic message
- avoid signing an explicit `Content-Length` for `Uint8Array` uploads and add focused transport coverage

## Problem

An S3-compatible upload can fail before an HTTP response exists, but the uploader did not expose a stable, privacy-safe way to distinguish DNS, connection, socket, timeout, TLS, abort, and request-length failures. Logging the original nested error would expose uncontrolled provider or network details.

The full CI test setup also loads an Undici dispatcher that rejects the uploader's explicit `Content-Length` before a request reaches the local fixture. Letting `fetch()` derive the length removes that dispatcher-specific coupling while preserving the actual body length on the wire.

## Implementation

- inspect direct errors, nested `cause` values, and `AggregateError.errors` with a bounded traversal of 4 levels and 16 nodes
- emit only allowlisted values, with `UnknownError`, `UNKNOWN`, `unknown`, and `unknown` category fallbacks
- bind an optional deployment nonce only when it matches exactly 32 lowercase hexadecimal characters; otherwise emit `unbound`
- wrap both `fetch()` transport failures and response-body read failures without changing existing HTTP error responses
- remove `Content-Length` from the direct `uploadToS3()` signed-header set; multipart and other signed request paths remain unchanged

## Verification

- focused S3 Vitest coverage: 25/25 tests passed, including nested/cyclic causes, allowlist fallbacks, nonce handling, real local Undici transport, and HTTP error behavior
- ESLint, Core TypeScript checking, and `git diff --check` passed
- GitHub Actions run `31297381567`: all 9 checks passed, including lint/typecheck, Core build, Docker build, CLI/Core E2E, three test shards, GitGuardian, and the Open Source Software Supply Chain Security Scanner

This is transport diagnostic and compatibility hardening only. It does not establish the root cause of a production S3 failure, change production configuration, or deploy anything.
