### PR TITLE
fix(note): allow clearing mood and weather

### DIFF
--- a/apps/core/src/modules/note/note.schema.ts
+++ b/apps/core/src/modules/note/note.schema.ts
@@ -51,8 +51,8 @@ const NoteBaseSchema = WriteBaseSchema.extend({
       z.date().nullable(),
     )
     .optional(),
-  mood: z.string().optional(),
-  weather: z.string().optional(),
+  mood: z.string().nullable().optional(),
+  weather: z.string().nullable().optional(),
   bookmark: z.boolean().default(false).optional(),
   coordinates: CoordinateSchema.optional().nullable(),
   location: z.string().optional().nullable(),

--- a/apps/core/test/src/schemas/partial-schema-defaults.spec.ts
+++ b/apps/core/test/src/schemas/partial-schema-defaults.spec.ts
@@ -57,4 +57,15 @@ describe('Partial schemas should not apply defaults for missing fields', () => {
     const result = PartialNoteSchema.parse({ title: '' })
     expect(result.title).toBe('Untitled')
   })
+
+  it('PartialNoteSchema - nullable metadata can be explicitly cleared', () => {
+    const result = PartialNoteSchema.parse({ mood: null, weather: null })
+    expect(result).toMatchObject({ mood: null, weather: null })
+  })
+
+  it('PartialNoteSchema - omitted nullable metadata stays omitted', () => {
+    const result = PartialNoteSchema.parse({ title: 'without metadata' })
+    expect(result).not.toHaveProperty('mood')
+    expect(result).not.toHaveProperty('weather')
+  })
 })


### PR DESCRIPTION
## Summary

- accept explicit JSON `null` for note `mood` and `weather`
- preserve omission semantics for partial note updates
- add regression coverage for explicit clears and omitted fields

## Why

The database columns, note read models, repository patch input, and API client types already support `string | null`, but `NoteBaseSchema` only accepted strings. As a result, PATCH requests could set metadata but could not clear it.

## Verification

- focused schema tests: 7 passed
- repository typecheck passed
- migration lint passed (31 files)
- full core bundle passed
- targeted ESLint passed

The default local test lifecycle requires a container runtime, which is unavailable on this workstation; the focused schema suite was run with only the database lifecycle disabled.