### PR TITLE
fix(category): prevent unpublished post metadata disclosure

### DIFF
--- a/apps/core/src/modules/category/category.controller.ts
+++ b/apps/core/src/modules/category/category.controller.ts
@@ -15,6 +15,7 @@ import { ApiController } from '~/common/decorators/api-controller.decorator'
 import { Auth } from '~/common/decorators/auth.decorator'
 import { HTTPDecorators } from '~/common/decorators/http.decorator'
 import { Lang } from '~/common/decorators/lang.decorator'
+import { HasAdminAccess } from '~/common/decorators/role.decorator'
 import { AppErrorCode, createAppException } from '~/common/errors'
 import { withMeta } from '~/common/response/envelope.types'
 import { MetaObjectBuilder } from '~/common/response/meta-builder'
@@ -57,6 +58,7 @@ export class CategoryController {
   @Get('/')
   async getCategories(
     @Query() query: MultiCategoriesQueryDto,
+    @HasAdminAccess() isAuthenticated: boolean,
     @Lang() lang?: string,
   ) {
     const { ids, joint, type = CategoryType.Category } = query
@@ -77,11 +79,14 @@ export class CategoryController {
 
       const categoriesPromise = joint
         ? null
-        : this.categoryService.repository.findByIds(ids)
+        : this.categoryService.repository.findByIds(ids, {
+            publishedOnly: !isAuthenticated,
+          })
 
       const postsByCategory = await this.postService.listByCategoryIds(ids, {
         includeCategory: false,
         metaOnly: true,
+        publishedOnly: !isAuthenticated,
       })
       for (const id of ids) {
         const rawPosts = postsByCategory.get(id) ?? []
@@ -181,8 +186,12 @@ export class CategoryController {
 
     const result =
       type === CategoryType.Category
-        ? await this.categoryService.findAllCategory()
-        : await this.categoryService.getPostTagsSum()
+        ? await this.categoryService.findAllCategory({
+            publishedOnly: !isAuthenticated,
+          })
+        : await this.categoryService.getPostTagsSum({
+            publishedOnly: !isAuthenticated,
+          })
 
     if (lang && Array.isArray(result) && result.length) {
       const entryMaps = await this.translationEntryService.getTranslationsBatch(
@@ -208,6 +217,7 @@ export class CategoryController {
   async getCategoryById(
     @Param() { query }: SlugOrIdDto,
     @Query() { tag }: MultiQueryTagAndCategoryDto,
+    @HasAdminAccess() isAuthenticated: boolean,
     @Lang() lang?: string,
   ) {
     if (!query) {
@@ -216,7 +226,9 @@ export class CategoryController {
       })
     }
     if (tag === true) {
-      const data = await this.categoryService.findArticleWithTag(query)
+      const data = await this.categoryService.findArticleWithTag(query, {
+        isPublished: isAuthenticated ? undefined : true,
+      })
       const tagMetaBuilder = new MetaObjectBuilder()
       if (lang && data?.length) {
         const articles = data.map((post: any) => ({
@@ -256,10 +268,15 @@ export class CategoryController {
 
     const [postsResult, tagsSum, count] = await Promise.all([
       this.categoryService.findCategoryPost(res.id, {
+        isPublished: isAuthenticated ? undefined : true,
         tags: typeof tag === 'string' ? tag : undefined,
       }),
-      this.categoryService.getCategoryTagsSum(res.id),
-      this.postService.countByCategoryId(res.id),
+      this.categoryService.getCategoryTagsSum(res.id, {
+        publishedOnly: !isAuthenticated,
+      }),
+      this.postService.countByCategoryId(res.id, {
+        publishedOnly: !isAuthenticated,
+      }),
     ])
 
     const children: any[] = postsResult ?? []

--- a/apps/core/src/modules/category/category.repository.ts
+++ b/apps/core/src/modules/category/category.repository.ts
@@ -38,7 +38,11 @@ export class CategoryRepository extends BaseRepository {
 
   async findAll(
     type: CategoryType = CategoryType.Category,
+    options: { publishedOnly?: boolean } = {},
   ): Promise<CategoryWithCount[]> {
+    const postJoinCondition = options.publishedOnly
+      ? and(eq(posts.categoryId, categories.id), eq(posts.isPublished, true))
+      : eq(posts.categoryId, categories.id)
     const rows = await this.db
       .select({
         id: categories.id,
@@ -49,7 +53,7 @@ export class CategoryRepository extends BaseRepository {
         count: sql<number>`coalesce(count(${posts.id}), 0)::int`,
       })
       .from(categories)
-      .leftJoin(posts, eq(posts.categoryId, categories.id))
+      .leftJoin(posts, postJoinCondition)
       .where(eq(categories.type, type))
       .groupBy(categories.id)
       .orderBy(categories.createdAt)
@@ -69,9 +73,15 @@ export class CategoryRepository extends BaseRepository {
     return row ?? null
   }
 
-  async findByIds(ids: Array<EntityId | string>): Promise<CategoryWithCount[]> {
+  async findByIds(
+    ids: Array<EntityId | string>,
+    options: { publishedOnly?: boolean } = {},
+  ): Promise<CategoryWithCount[]> {
     if (ids.length === 0) return []
     const idBigs = ids.map((id) => parseEntityId(id))
+    const postJoinCondition = options.publishedOnly
+      ? and(eq(posts.categoryId, categories.id), eq(posts.isPublished, true))
+      : eq(posts.categoryId, categories.id)
     const rows = await this.db
       .select({
         id: categories.id,
@@ -79,14 +89,12 @@ export class CategoryRepository extends BaseRepository {
         slug: categories.slug,
         type: categories.type,
         createdAt: categories.createdAt,
-        count: sql<number>`(
-          select coalesce(count(*), 0)::int
-          from ${posts}
-          where ${posts.categoryId} = ${categories.id}
-        )`,
+        count: sql<number>`coalesce(count(${posts.id}), 0)::int`,
       })
       .from(categories)
+      .leftJoin(posts, postJoinCondition)
       .where(inArray(categories.id, idBigs))
+      .groupBy(categories.id)
 
     return rows.map((row) => ({
       id: toEntityId(row.id) as EntityId,

--- a/apps/core/src/modules/category/category.service.ts
+++ b/apps/core/src/modules/category/category.service.ts
@@ -63,16 +63,19 @@ export class CategoryService implements OnApplicationBootstrap {
     return this.categoryRepository.findBySlug(slug)
   }
 
-  async findAllCategory() {
-    return this.categoryRepository.findAll(CategoryType.Category)
+  async findAllCategory(options: { publishedOnly?: boolean } = {}) {
+    return this.categoryRepository.findAll(CategoryType.Category, options)
   }
 
-  async getPostTagsSum() {
-    return this.postService.aggregateAllTagCounts()
+  async getPostTagsSum(options: { publishedOnly?: boolean } = {}) {
+    return this.postService.aggregateAllTagCounts(options)
   }
 
-  async getCategoryTagsSum(categoryId: string) {
-    return this.postService.aggregateTagCountsByCategory(categoryId)
+  async getCategoryTagsSum(
+    categoryId: string,
+    options: { publishedOnly?: boolean } = {},
+  ) {
+    return this.postService.aggregateTagCountsByCategory(categoryId, options)
   }
 
   async findArticleWithTag(
@@ -82,6 +85,7 @@ export class CategoryService implements OnApplicationBootstrap {
     const posts = await this.postService.findByTag(tag, {
       includeCategory: true,
       metaOnly: true,
+      publishedOnly: condition.isPublished === true,
     })
     const filtered =
       condition.isPublished === undefined

--- a/apps/core/src/modules/post/post.repository.ts
+++ b/apps/core/src/modules/post/post.repository.ts
@@ -271,11 +271,16 @@ export class PostRepository extends BaseRepository {
       .where(eq(posts.id, idBig))
   }
 
-  async countByCategoryId(categoryId: EntityId | string): Promise<number> {
+  async countByCategoryId(
+    categoryId: EntityId | string,
+    options: { publishedOnly?: boolean } = {},
+  ): Promise<number> {
+    const filters: SQL[] = [eq(posts.categoryId, parseEntityId(categoryId))]
+    if (options.publishedOnly) filters.push(eq(posts.isPublished, true))
     const [row] = await this.db
       .select({ count: sql<number>`count(*)::int` })
       .from(posts)
-      .where(eq(posts.categoryId, parseEntityId(categoryId)))
+      .where(and(...filters))
     return Number(row?.count ?? 0)
   }
 
@@ -321,14 +326,20 @@ export class PostRepository extends BaseRepository {
     return rows.map((row) => toEntityId(row.id) as EntityId)
   }
 
-  async aggregateAllTagCounts(): Promise<PostTagCount[]> {
-    const result = await this.db.execute<PostTagCount>(sql`
-      select unnest(tags) as name, count(*)::int
-      from posts
-      group by name
-      order by count desc, name asc
-    `)
-    return result.rows.map((row) => ({
+  async aggregateAllTagCounts(
+    options: { publishedOnly?: boolean } = {},
+  ): Promise<PostTagCount[]> {
+    const tagAlias = sql<string>`tag`
+    const rows = await this.db
+      .select({
+        name: sql<string>`unnest(${posts.tags})`.as('tag'),
+        count: sql<number>`count(*)::int`,
+      })
+      .from(posts)
+      .where(options.publishedOnly ? eq(posts.isPublished, true) : undefined)
+      .groupBy(tagAlias)
+      .orderBy(sql`count(*) desc`, sql`tag asc`)
+    return rows.map((row) => ({
       name: row.name,
       count: Number(row.count ?? 0),
     }))
@@ -336,15 +347,21 @@ export class PostRepository extends BaseRepository {
 
   async aggregateTagCountsByCategory(
     categoryId: EntityId | string,
+    options: { publishedOnly?: boolean } = {},
   ): Promise<PostTagCount[]> {
-    const result = await this.db.execute<PostTagCount>(sql`
-      select unnest(tags) as name, count(*)::int
-      from posts
-      where category_id = ${parseEntityId(categoryId)}
-      group by name
-      order by count desc, name asc
-    `)
-    return result.rows.map((row) => ({
+    const filters: SQL[] = [eq(posts.categoryId, parseEntityId(categoryId))]
+    if (options.publishedOnly) filters.push(eq(posts.isPublished, true))
+    const tagAlias = sql<string>`tag`
+    const rows = await this.db
+      .select({
+        name: sql<string>`unnest(${posts.tags})`.as('tag'),
+        count: sql<number>`count(*)::int`,
+      })
+      .from(posts)
+      .where(and(...filters))
+      .groupBy(tagAlias)
+      .orderBy(sql`count(*) desc`, sql`tag asc`)
+    return rows.map((row) => ({
       name: row.name,
       count: Number(row.count ?? 0),
     }))
@@ -352,12 +369,18 @@ export class PostRepository extends BaseRepository {
 
   async findByTag(
     tag: string,
-    options: { includeCategory?: boolean; metaOnly?: boolean } = {},
+    options: {
+      includeCategory?: boolean
+      metaOnly?: boolean
+      publishedOnly?: boolean
+    } = {},
   ): Promise<PostRow[]> {
+    const filters: SQL[] = [sql`${posts.tags} @> array[${tag}]::text[]`]
+    if (options.publishedOnly) filters.push(eq(posts.isPublished, true))
     const rows = await this.db
       .select(options.metaOnly ? postMetaColumns : postColumns)
       .from(posts)
-      .where(sql`${posts.tags} @> array[${tag}]::text[]`)
+      .where(and(...filters))
       .orderBy(pinAtDescNullsLast, desc(posts.createdAt))
 
     const mapped = rows.map(mapBase)

--- a/apps/core/src/modules/post/post.service.ts
+++ b/apps/core/src/modules/post/post.service.ts
@@ -120,8 +120,11 @@ export class PostService implements OnApplicationBootstrap {
     return this.postRepository.count()
   }
 
-  async countByCategoryId(categoryId: string) {
-    return this.postRepository.countByCategoryId(categoryId)
+  async countByCategoryId(
+    categoryId: string,
+    options: { publishedOnly?: boolean } = {},
+  ) {
+    return this.postRepository.countByCategoryId(categoryId, options)
   }
 
   async listByCategory(
@@ -153,17 +156,24 @@ export class PostService implements OnApplicationBootstrap {
 
   async findByTag(
     tag: string,
-    options: { includeCategory?: boolean; metaOnly?: boolean } = {},
+    options: {
+      includeCategory?: boolean
+      metaOnly?: boolean
+      publishedOnly?: boolean
+    } = {},
   ) {
     return this.postRepository.findByTag(tag, options)
   }
 
-  async aggregateAllTagCounts() {
-    return this.postRepository.aggregateAllTagCounts()
+  async aggregateAllTagCounts(options: { publishedOnly?: boolean } = {}) {
+    return this.postRepository.aggregateAllTagCounts(options)
   }
 
-  async aggregateTagCountsByCategory(categoryId: string) {
-    return this.postRepository.aggregateTagCountsByCategory(categoryId)
+  async aggregateTagCountsByCategory(
+    categoryId: string,
+    options: { publishedOnly?: boolean } = {},
+  ) {
+    return this.postRepository.aggregateTagCountsByCategory(categoryId, options)
   }
 
   async findAdjacent(

--- a/apps/core/test/src/contracts/category-public-visibility.contract.spec.ts
+++ b/apps/core/test/src/contracts/category-public-visibility.contract.spec.ts
@@ -1,0 +1,234 @@
+import { describe, expect, test } from 'vitest'
+
+import { apiRoutePrefix } from '~/common/decorators/api-controller.decorator'
+import { POST_SERVICE_TOKEN } from '~/constants/injection.constant'
+import { CategoryController } from '~/modules/category/category.controller'
+import { CategoryService } from '~/modules/category/category.service'
+
+import { createE2EApp } from '../../helper/create-e2e-app'
+import {
+  translationEntryProvider,
+  translationProvider,
+} from '../../mock/processors/translation.mock'
+
+const CATEGORY_ID = '7000000000000000900'
+
+const fixtureCategory = {
+  id: CATEGORY_ID,
+  name: 'Tech',
+  slug: 'tech',
+  type: 0,
+  createdAt: new Date('2023-12-01T00:00:00.000Z'),
+  modifiedAt: null,
+}
+
+const publicPost = {
+  id: '7000000000000000910',
+  title: 'Public post',
+  slug: 'public-post',
+  summary: 'Public summary',
+  images: ['https://example.com/public.png'],
+  tags: ['shared-tag', 'public-tag'],
+  isPublished: true,
+  copyright: true,
+  pinAt: null,
+  readCount: 1,
+  likeCount: 0,
+  category: fixtureCategory,
+  categoryId: CATEGORY_ID,
+  createdAt: new Date('2024-01-15T00:00:00.000Z'),
+  modifiedAt: null,
+}
+
+const privateMetadata = {
+  id: '7000000000000000999',
+  title: 'PRIVATE_TITLE_SENTINEL',
+  slug: 'private-slug-sentinel',
+  summary: 'PRIVATE_SUMMARY_SENTINEL',
+  image: 'https://example.com/private-image-sentinel.png',
+  tag: 'private-tag-sentinel',
+} as const
+
+const privatePost = {
+  id: privateMetadata.id,
+  title: privateMetadata.title,
+  slug: privateMetadata.slug,
+  summary: privateMetadata.summary,
+  images: [privateMetadata.image],
+  tags: ['shared-tag', privateMetadata.tag],
+  isPublished: false,
+  copyright: true,
+  pinAt: null,
+  readCount: 0,
+  likeCount: 0,
+  category: fixtureCategory,
+  categoryId: CATEGORY_ID,
+  createdAt: new Date('2024-01-16T00:00:00.000Z'),
+  modifiedAt: null,
+}
+
+const allPosts = [publicPost, privatePost]
+
+const filterPublished = (publishedOnly?: boolean) =>
+  publishedOnly ? allPosts.filter((post) => post.isPublished) : allPosts
+
+const filterPublicationState = (isPublished?: boolean) =>
+  isPublished === undefined
+    ? allPosts
+    : allPosts.filter((post) => post.isPublished === isPublished)
+
+const aggregateTags = (posts: typeof allPosts) => {
+  const counts = new Map<string, number>()
+  for (const post of posts) {
+    for (const tag of post.tags) counts.set(tag, (counts.get(tag) ?? 0) + 1)
+  }
+  return [...counts].map(([name, count]) => ({ name, count }))
+}
+
+const categoryServiceProvider = {
+  provide: CategoryService,
+  useValue: {
+    repository: {
+      async findByIds(_ids: string[], options: { publishedOnly?: boolean }) {
+        return [
+          {
+            ...fixtureCategory,
+            count: filterPublished(options?.publishedOnly).length,
+          },
+        ]
+      },
+    },
+    async findAllCategory(options: { publishedOnly?: boolean }) {
+      return [
+        {
+          ...fixtureCategory,
+          count: filterPublished(options?.publishedOnly).length,
+        },
+      ]
+    },
+    async findById(id: string) {
+      return { ...fixtureCategory, id }
+    },
+    async findBySlug(slug: string) {
+      return { ...fixtureCategory, slug }
+    },
+    async findCategoryPost(
+      _categoryId: string,
+      condition: { isPublished?: boolean },
+    ) {
+      return filterPublicationState(condition?.isPublished)
+    },
+    async getCategoryTagsSum(
+      _categoryId: string,
+      options: { publishedOnly?: boolean },
+    ) {
+      return aggregateTags(filterPublished(options?.publishedOnly))
+    },
+    async getPostTagsSum(options: { publishedOnly?: boolean }) {
+      return aggregateTags(filterPublished(options?.publishedOnly))
+    },
+    async findArticleWithTag(
+      tag: string,
+      condition: { isPublished?: boolean },
+    ) {
+      return filterPublicationState(condition?.isPublished).filter((post) =>
+        post.tags.includes(tag),
+      )
+    },
+  },
+}
+
+const postServiceProvider = {
+  provide: POST_SERVICE_TOKEN,
+  useValue: {
+    async countByCategoryId(
+      _categoryId: string,
+      options: { publishedOnly?: boolean },
+    ) {
+      return filterPublished(options?.publishedOnly).length
+    },
+    async listByCategoryIds(
+      ids: string[],
+      options: { publishedOnly?: boolean },
+    ) {
+      return new Map(
+        ids.map((id) => [id, filterPublished(options?.publishedOnly)]),
+      )
+    },
+  },
+}
+
+const assertPrivateMetadataAbsent = (body: unknown) => {
+  const serialized = JSON.stringify(body)
+  for (const value of Object.values(privateMetadata)) {
+    expect(serialized).not.toContain(value)
+  }
+}
+
+describe('CategoryController public visibility contract (e2e)', () => {
+  const proxy = createE2EApp({
+    controllers: [CategoryController],
+    providers: [
+      categoryServiceProvider,
+      postServiceProvider,
+      translationProvider,
+      translationEntryProvider,
+    ],
+  })
+
+  test.each([
+    '/categories',
+    `/categories/${fixtureCategory.slug}`,
+    `/categories?ids=${CATEGORY_ID}`,
+    `/categories?ids=${CATEGORY_ID}&joint=true`,
+    '/categories/shared-tag?tag=true',
+    '/categories?type=1',
+  ])('anonymous GET %s never exposes private post metadata', async (path) => {
+    const response = await proxy.app.inject({
+      method: 'GET',
+      url: `${apiRoutePrefix}${path}`,
+    })
+
+    expect(response.statusCode).toBe(200)
+    assertPrivateMetadataAbsent(response.json())
+  })
+
+  test('anonymous detail count, children and tags share one public scope', async () => {
+    const response = await proxy.app.inject({
+      method: 'GET',
+      url: `${apiRoutePrefix}/categories/${fixtureCategory.slug}`,
+    })
+    const body = response.json()
+
+    expect(body.data.count).toBe(1)
+    expect(body.data.children).toHaveLength(1)
+    expect(body.data.children[0].id).toBe(publicPost.id)
+    expect(body.data.tags_sum).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ name: 'public-tag', count: 1 }),
+      ]),
+    )
+    expect(body.data.tags_sum).not.toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ name: privateMetadata.tag }),
+      ]),
+    )
+  })
+
+  test('authenticated owner retains full category management visibility', async () => {
+    const response = await proxy.app.inject({
+      method: 'GET',
+      url: `${apiRoutePrefix}/categories/${fixtureCategory.slug}`,
+      headers: { 'test-token': '1' },
+    })
+    const body = response.json()
+    const serialized = JSON.stringify(body)
+
+    expect(response.statusCode).toBe(200)
+    expect(body.data.count).toBe(2)
+    expect(body.data.children).toHaveLength(2)
+    for (const value of Object.values(privateMetadata)) {
+      expect(serialized).toContain(value)
+    }
+  })
+})

--- a/apps/core/test/src/modules/category/category.controller.spec.ts
+++ b/apps/core/test/src/modules/category/category.controller.spec.ts
@@ -130,6 +130,7 @@ describe('CategoryController', () => {
 
       const result = await controller.getCategories(
         { type: undefined } as any,
+        false,
         'en',
       )
 
@@ -150,6 +151,7 @@ describe('CategoryController', () => {
 
       const result = await controller.getCategories(
         { type: undefined } as any,
+        false,
         'en',
       )
 
@@ -167,6 +169,7 @@ describe('CategoryController', () => {
 
       const result = await controller.getCategories(
         { type: undefined } as any,
+        false,
         'en',
       )
 
@@ -178,7 +181,11 @@ describe('CategoryController', () => {
         categories: [{ id: 'cat-1', name: 'X' }],
       })
 
-      await controller.getCategories({ type: undefined } as any, undefined)
+      await controller.getCategories(
+        { type: undefined } as any,
+        false,
+        undefined,
+      )
 
       expect(
         translationEntryService.getTranslationsBatch,
@@ -212,6 +219,7 @@ describe('CategoryController', () => {
       const result = await controller.getCategoryById(
         { query: 'cat-1' } as any,
         {} as any,
+        false,
         'en',
       )
 
@@ -241,6 +249,7 @@ describe('CategoryController', () => {
       const result = await controller.getCategoryById(
         { query: 'cat-1' } as any,
         {} as any,
+        false,
         'en',
       )
 
@@ -262,6 +271,7 @@ describe('CategoryController', () => {
       const result = await controller.getCategoryById(
         { query: 'cat-1' } as any,
         {} as any,
+        false,
         'en',
       )
 
@@ -280,6 +290,7 @@ describe('CategoryController', () => {
       const result = await controller.getCategoryById(
         { query: 'cat-1' } as any,
         {} as any,
+        false,
         'en',
       )
 
@@ -308,6 +319,7 @@ describe('CategoryController', () => {
       const result = await controller.getCategoryById(
         { query: 'mytag' } as any,
         { tag: true } as any,
+        false,
         'en',
       )
 
@@ -333,6 +345,7 @@ describe('CategoryController', () => {
       const result = await controller.getCategoryById(
         { query: 'mytag' } as any,
         { tag: true } as any,
+        false,
         'en',
       )
 
@@ -355,6 +368,7 @@ describe('CategoryController', () => {
       const result = await controller.getCategoryById(
         { query: 'mytag' } as any,
         { tag: true } as any,
+        false,
         'en',
       )
 
@@ -373,6 +387,7 @@ describe('CategoryController', () => {
       await controller.getCategoryById(
         { query: 'mytag' } as any,
         { tag: true } as any,
+        false,
         undefined,
       )
 
@@ -411,6 +426,7 @@ describe('CategoryController', () => {
 
       const result = await controller.getCategories(
         { ids: ['cat-a', 'cat-b'], joint: false } as any,
+        false,
         'en',
       )
 
@@ -438,6 +454,7 @@ describe('CategoryController', () => {
 
       const result = await controller.getCategories(
         { ids: ['cat-a'], joint: false } as any,
+        false,
         'en',
       )
 
@@ -471,6 +488,7 @@ describe('CategoryController', () => {
 
       const result = await controller.getCategories(
         { ids: ['cat-a', 'cat-b'], joint: false } as any,
+        false,
         'en',
       )
 
@@ -493,7 +511,11 @@ describe('CategoryController', () => {
           posts,
         })
 
-      await controller.getCategories({ ids: ['cat-a'] } as any, undefined)
+      await controller.getCategories(
+        { ids: ['cat-a'] } as any,
+        false,
+        undefined,
+      )
 
       expect(
         translationService.collectArticleTranslations,

--- a/apps/core/test/src/modules/category/category.repository.spec.ts
+++ b/apps/core/test/src/modules/category/category.repository.spec.ts
@@ -73,6 +73,40 @@ describe('CategoryRepository', () => {
     expect(bOut?.count).toBe(0)
   })
 
+  it('can restrict category counts to published posts', async () => {
+    const category = await repository.create({ name: 'a', slug: 'a' })
+
+    await db.insert(posts).values([
+      {
+        id: snowflake.nextId(),
+        title: 'public',
+        slug: 'public',
+        contentFormat: 'markdown',
+        categoryId: category.id,
+        isPublished: true,
+      },
+      {
+        id: snowflake.nextId(),
+        title: 'private',
+        slug: 'private',
+        contentFormat: 'markdown',
+        categoryId: category.id,
+        isPublished: false,
+      },
+    ])
+
+    const [publicListRow] = await repository.findAll(CategoryType.Category, {
+      publishedOnly: true,
+    })
+    const [publicDetailRow] = await repository.findByIds([category.id], {
+      publishedOnly: true,
+    })
+
+    expect(publicListRow.count).toBe(1)
+    expect(publicDetailRow.count).toBe(1)
+    expect((await repository.findAll(CategoryType.Category))[0].count).toBe(2)
+  })
+
   it('findBySlug looks up by slug and returns null on miss', async () => {
     await repository.create({ name: 'foo', slug: 'foo' })
     const hit = await repository.findBySlug('foo')

--- a/apps/core/test/src/modules/post/post-public-visibility.repository.spec.ts
+++ b/apps/core/test/src/modules/post/post-public-visibility.repository.spec.ts
@@ -1,0 +1,99 @@
+import type { Pool } from 'pg'
+import {
+  createPgTestDatabase,
+  type PgTestDatabase,
+} from 'test/helper/pg-verify-url'
+
+import { posts } from '~/database/schema'
+import { CategoryRepository } from '~/modules/category/category.repository'
+import { PostRepository } from '~/modules/post/post.repository'
+import { SnowflakeService } from '~/shared/id/snowflake.service'
+
+describe('PostRepository public visibility filters', () => {
+  let context: PgTestDatabase
+  let pool: Pool
+  let db: PgTestDatabase['db']
+  let categoryRepository: CategoryRepository
+  let postRepository: PostRepository
+  let snowflake: SnowflakeService
+
+  beforeAll(async () => {
+    context = await createPgTestDatabase('mx_post_public_visibility')
+    pool = context.pool
+    db = context.db
+    snowflake = new SnowflakeService()
+    categoryRepository = new CategoryRepository(db as any, snowflake)
+    postRepository = new PostRepository(db as any, snowflake)
+  }, 60_000)
+
+  beforeEach(async () => {
+    await pool.query('truncate table posts cascade')
+    await pool.query('truncate table categories cascade')
+  })
+
+  afterAll(async () => {
+    if (context) await context.close()
+  })
+
+  test('count and tag queries can exclude unpublished posts at the database boundary', async () => {
+    const category = await categoryRepository.create({
+      name: 'tech',
+      slug: 'tech',
+    })
+    await db.insert(posts).values([
+      {
+        id: snowflake.nextId(),
+        title: 'public',
+        slug: 'public',
+        contentFormat: 'markdown',
+        categoryId: category.id,
+        isPublished: true,
+        tags: ['shared', 'public-only'],
+      },
+      {
+        id: snowflake.nextId(),
+        title: 'private',
+        slug: 'private',
+        contentFormat: 'markdown',
+        categoryId: category.id,
+        isPublished: false,
+        tags: ['shared', 'private-only'],
+      },
+    ])
+
+    expect(
+      await postRepository.countByCategoryId(category.id, {
+        publishedOnly: true,
+      }),
+    ).toBe(1)
+
+    const allTags = await postRepository.aggregateAllTagCounts({
+      publishedOnly: true,
+    })
+    const categoryTags = await postRepository.aggregateTagCountsByCategory(
+      category.id,
+      { publishedOnly: true },
+    )
+    for (const tags of [allTags, categoryTags]) {
+      expect(tags).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({ name: 'shared', count: 1 }),
+          expect.objectContaining({ name: 'public-only', count: 1 }),
+        ]),
+      )
+      expect(tags).not.toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({ name: 'private-only' }),
+        ]),
+      )
+    }
+
+    const sharedPosts = await postRepository.findByTag('shared', {
+      includeCategory: false,
+      metaOnly: true,
+      publishedOnly: true,
+    })
+    expect(sharedPosts).toHaveLength(1)
+    expect(sharedPosts[0].slug).toBe('public')
+  })
+})


### PR DESCRIPTION
## Summary

- scope anonymous category and tag reads to published posts at the repository boundary
- align category counts, tag counts, multi-category children, and tag detail with the same visibility rule
- preserve full results for authenticated owner requests

## Security impact

Previously, unauthenticated category and tag endpoints could include metadata from unpublished posts. The controller now follows the existing HasAdminAccess pattern and passes published-only constraints through the service into PostgreSQL queries before translation or serialization.

The regression contract asserts that private IDs, titles, slugs, summaries, images, and tags never appear in anonymous responses for category lists/details, multi-category queries, tag details, or tag summaries. It also verifies that an authenticated owner retains full management visibility.

## Verification

- pnpm typecheck
- pnpm build
- 8 new anonymous/authenticated visibility contract tests passed
- 22 existing category controller and consumer contract tests passed
- changed files passed ESLint and Prettier
- PostgreSQL repository integration coverage added for published-only category counts, post counts, tag aggregates, and tag lookup

No database migration is required. Existing service and repository callers keep the previous full-result default unless they explicitly request publishedOnly.