### PR TITLE
fix(core): invalidate RSS caches after content changes

### DIFF
--- a/apps/core/src/modules/aggregate/aggregate.service.ts
+++ b/apps/core/src/modules/aggregate/aggregate.service.ts
@@ -539,6 +539,9 @@ export class AggregateService {
 
   @OnEvent(EventBusEvents.CleanAggregateCache)
   async cleanCache() {
-    await this.redisService.getClient().del(CacheKeys.Aggregate)
+    await Promise.all([
+      this.redisService.getClient().del(CacheKeys.RSS, CacheKeys.RSSXml),
+      this.redisService.deleteKeysByPattern(`${CacheKeys.Aggregate}*`),
+    ])
   }
 }

--- a/apps/core/src/modules/post/post.service.ts
+++ b/apps/core/src/modules/post/post.service.ts
@@ -544,14 +544,19 @@ export class PostService implements OnApplicationBootstrap {
         FileReferenceType.Post,
       ),
     ])
-    await this.eventManager.emit(
-      BusinessEvents.POST_DELETE,
-      { id },
-      {
-        scope: EventScope.TO_SYSTEM_VISITOR,
-        nextTick: true,
-      },
-    )
+    await Promise.all([
+      this.eventManager.emit(EventBusEvents.CleanAggregateCache, null, {
+        scope: EventScope.TO_SYSTEM,
+      }),
+      this.eventManager.emit(
+        BusinessEvents.POST_DELETE,
+        { id },
+        {
+          scope: EventScope.TO_SYSTEM_VISITOR,
+          nextTick: true,
+        },
+      ),
+    ])
   }
 
   async getCategoryBySlug(slug: string) {

--- a/apps/core/test/src/modules/aggregate/aggregate.service.spec.ts
+++ b/apps/core/test/src/modules/aggregate/aggregate.service.spec.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it, vi } from 'vitest'
 
+import { API_CACHE_PREFIX, CacheKeys } from '~/constants/cache.constant'
 import { AggregateService } from '~/modules/aggregate/aggregate.service'
 
 const noteRow = {
@@ -252,5 +253,56 @@ describe('AggregateService.buildRssStructure', () => {
     expect(data).toHaveLength(1)
     expect(data[0].text).not.toContain('full premium body')
     expect(JSON.parse(data[0].content!).root.children).toHaveLength(2)
+  })
+})
+
+describe('AggregateService.cleanCache', () => {
+  it('invalidates RSS and aggregate-derived caches without flushing unrelated API caches', async () => {
+    const del = vi.fn(async () => 2)
+    const deleteKeysByPattern = vi.fn(async () => 5)
+    const redisService = {
+      getClient: vi.fn(() => ({ del })),
+      deleteKeysByPattern,
+    }
+
+    const service = new AggregateService(
+      {} as any,
+      {} as any,
+      {} as any,
+      {} as any,
+      {} as any,
+      {} as any,
+      {} as any,
+      {} as any,
+      {} as any,
+      {} as any,
+      redisService as any,
+      {} as any,
+      {} as any,
+      {} as any,
+    )
+
+    await service.cleanCache()
+
+    expect(del).toHaveBeenCalledOnce()
+    expect(del).toHaveBeenCalledWith(CacheKeys.RSS, CacheKeys.RSSXml)
+    expect(deleteKeysByPattern).toHaveBeenCalledOnce()
+    expect(deleteKeysByPattern).toHaveBeenCalledWith(`${CacheKeys.Aggregate}*`)
+    expect(`${CacheKeys.Aggregate}*`).not.toBe(`${API_CACHE_PREFIX}*`)
+  })
+
+  it('keeps every aggregate-derived cache under the invalidated prefix', () => {
+    const aggregateKeys = [
+      CacheKeys.Aggregate,
+      CacheKeys.AggregateSite,
+      CacheKeys.SiteMap,
+      CacheKeys.SiteMapXml,
+    ]
+
+    for (const key of aggregateKeys) {
+      expect(key.startsWith(CacheKeys.Aggregate)).toBe(true)
+    }
+    expect(CacheKeys.RSS.startsWith(CacheKeys.Aggregate)).toBe(false)
+    expect(CacheKeys.RSSXml.startsWith(CacheKeys.Aggregate)).toBe(false)
   })
 })

--- a/apps/core/test/src/modules/post/post.service.spec.ts
+++ b/apps/core/test/src/modules/post/post.service.spec.ts
@@ -4,6 +4,8 @@ import { describe, expect, it, vi } from 'vitest'
 import { createPgRepositoryMock, now } from '@/helper/pg-repository-mock'
 import { AppException } from '~/common/errors/exception.types'
 import { ArticleTypeEnum } from '~/constants/article.constant'
+import { BusinessEvents, EventScope } from '~/constants/business-event.constant'
+import { EventBusEvents } from '~/constants/event-bus.constant'
 import {
   CATEGORY_SERVICE_TOKEN,
   DRAFT_SERVICE_TOKEN,
@@ -103,6 +105,7 @@ const createService = () => {
     commentService,
     contentMigrationCommitService,
     draftService,
+    eventManager,
     fileReferenceService,
     repository,
     service,
@@ -268,6 +271,7 @@ describe('PostService', () => {
     const {
       commentService,
       draftService,
+      eventManager,
       fileReferenceService,
       repository,
       service,
@@ -285,6 +289,29 @@ describe('PostService', () => {
     expect(
       fileReferenceService.removeReferencesForDocument,
     ).toHaveBeenCalledWith('post-1', FileReferenceType.Post)
+    expect(eventManager.emit).toHaveBeenCalledWith(
+      EventBusEvents.CleanAggregateCache,
+      null,
+      { scope: EventScope.TO_SYSTEM },
+    )
+    expect(eventManager.emit).toHaveBeenCalledWith(
+      BusinessEvents.POST_DELETE,
+      { id: 'post-1' },
+      {
+        scope: EventScope.TO_SYSTEM_VISITOR,
+        nextTick: true,
+      },
+    )
+  })
+
+  it('does not invalidate aggregate caches when post deletion fails', async () => {
+    const { eventManager, repository, service } = createService()
+    repository.findById.mockResolvedValue(createPost())
+    repository.deleteById.mockRejectedValue(new Error('delete failed'))
+
+    await expect(service.deletePost('post-1')).rejects.toThrow('delete failed')
+
+    expect(eventManager.emit).not.toHaveBeenCalled()
   })
 
   it('rejects missing related post ids', async () => {


### PR DESCRIPTION
## Summary

- invalidate the cached aggregate RSS payload and rendered RSS XML when aggregate content changes
- clear aggregate, aggregate-site, sitemap, and key variants through the existing non-blocking prefix helper
- emit aggregate-cache invalidation after a post deletion finishes successfully
- keep unrelated `mx-api-cache:*` entries outside the invalidation scope
- add unit coverage for exact keys, aggregate-prefix boundaries, and post-delete success/failure behavior

## Problem

`CleanAggregateCache` is emitted after most post, note, category, owner, aggregate-config, and theme-snippet changes. Two adjacent regressions left stale feeds possible:

1. After the PostgreSQL migration, `AggregateService.cleanCache()` only deleted the exact aggregate key, leaving `CacheKeys.RSS`, `CacheKeys.RSSXml`, sitemap/site caches, and aggregate variants stale until their TTL expired.
2. `PostService.deletePost()` emitted `POST_DELETE` after cleanup but never emitted `CleanAggregateCache`. Existing `POST_DELETE` listeners only handle WebSocket/search/AI-derived cleanup; none forwards to aggregate-cache invalidation.

## Implementation

The aggregate handler now deletes both RSS keys exactly and calls the existing ``deleteKeysByPattern(`${CacheKeys.Aggregate}*`)`` helper. That helper uses Redis `SCAN` plus batched `UNLINK`; this change does not use blocking `KEYS` or flush the broader API cache namespace.

After all post deletion and related-record cleanup operations resolve, `deletePost()` now emits `CleanAggregateCache` alongside the existing `POST_DELETE` event. If deletion cleanup rejects, neither event is emitted.

## Verification

- focused aggregate + post service tests: 2 files, 21 tests passed
- targeted ESLint and Prettier on all changed files
- `pnpm typecheck`
- `pnpm build`
- all 9 GitHub CI, test, build, E2E, and security checks passed after the second commit