### PR TITLE
fix(activity): prevent private note data leakage

### DIFF
--- a/apps/core/src/modules/activity/activity.service.ts
+++ b/apps/core/src/modules/activity/activity.service.ts
@@ -525,7 +525,7 @@ export class ActivityService implements OnModuleInit, OnModuleDestroy {
     const $gte = new Date(Date.now() - 365 * 24 * 60 * 60 * 1000)
     const [allPosts, allNotes] = await Promise.all([
       this.postService.findRecent(50, { publishedOnly: true }),
-      this.noteService.findRecent(50),
+      this.noteService.findRecent(50, { metaOnly: true, visibleOnly: true }),
     ])
     const posts = allPosts
       .filter((row) => row.createdAt >= $gte)
@@ -534,14 +534,26 @@ export class ActivityService implements OnModuleInit, OnModuleDestroy {
         text: getPublicText(post),
         content: getPublicContent(post),
       }))
+    const now = new Date()
     const notes = allNotes
-      .filter((row) => row.createdAt >= $gte)
-      .map((note) => {
-        if (note.hasPassword || !note.isPublished) {
-          note.title = 'Private note'
-        }
-        return omit(note, 'isPublished')
-      })
+      .filter(
+        (row) =>
+          row.createdAt >= $gte &&
+          row.isPublished &&
+          !row.hasPassword &&
+          (row.publicAt === null || row.publicAt <= now),
+      )
+      .map((note) =>
+        pick(note, [
+          'id',
+          'nid',
+          'title',
+          'mood',
+          'weather',
+          'bookmark',
+          'createdAt',
+        ]),
+      )
     return { posts, notes }
   }
 }

--- a/apps/core/test/src/modules/activity/activity.service.spec.ts
+++ b/apps/core/test/src/modules/activity/activity.service.spec.ts
@@ -48,8 +48,11 @@ const premiumPost = {
   createdAt: new Date(),
 }
 
-const createService = (postFindRecent: ReturnType<typeof vi.fn>) => {
-  const noteService = { findRecent: vi.fn(async () => []) }
+const createService = (
+  postFindRecent: ReturnType<typeof vi.fn>,
+  noteFindRecent: ReturnType<typeof vi.fn> = vi.fn(async () => []),
+) => {
+  const noteService = { findRecent: noteFindRecent }
   return new ActivityService(
     {} as any,
     {} as any,
@@ -97,5 +100,70 @@ describe('ActivityService.getLastYearPublication', () => {
     await service.getLastYearPublication()
 
     expect(findRecent).toHaveBeenCalledWith(50, { publishedOnly: true })
+  })
+
+  it('returns only public note metadata and never private note bodies', async () => {
+    const findRecent = vi.fn(async () => [])
+    const noteFindRecent = vi.fn(async () => [
+      {
+        id: 'private-note',
+        nid: 38,
+        title: 'Private note',
+        text: 'private body',
+        content: 'private content',
+        images: [{ src: 'private-image' }],
+        isPublished: false,
+        hasPassword: false,
+        createdAt: new Date(),
+      },
+      {
+        id: 'password-note',
+        nid: 39,
+        title: 'Password note',
+        text: 'password body',
+        content: 'password content',
+        isPublished: true,
+        hasPassword: true,
+        createdAt: new Date(),
+      },
+      {
+        id: 'public-note',
+        nid: 41,
+        title: 'Public note',
+        mood: null,
+        weather: null,
+        bookmark: false,
+        text: 'public body',
+        content: 'public content',
+        images: [],
+        isPublished: true,
+        hasPassword: false,
+        publicAt: null,
+        createdAt: new Date(),
+      },
+    ])
+    const service = createService(findRecent, noteFindRecent)
+
+    const result = await service.getLastYearPublication()
+
+    expect(noteFindRecent).toHaveBeenCalledWith(50, {
+      metaOnly: true,
+      visibleOnly: true,
+    })
+    expect(result.notes).toEqual([
+      {
+        id: 'public-note',
+        nid: 41,
+        title: 'Public note',
+        mood: null,
+        weather: null,
+        bookmark: false,
+        createdAt: expect.any(Date),
+      },
+    ])
+    expect(JSON.stringify(result)).not.toContain('private body')
+    expect(JSON.stringify(result)).not.toContain('private content')
+    expect(JSON.stringify(result)).not.toContain('private-image')
+    expect(JSON.stringify(result)).not.toContain('password body')
   })
 })


### PR DESCRIPTION
## Summary

- limit activity publication to visible notes and metadata-only rows
- require published, non-password-protected notes whose `publicAt` has passed
- serialize an explicit public metadata allowlist and add regression coverage for private payload leakage

## Security impact

The activity publication endpoint previously called `noteService.findRecent(50)` without visibility or projection options. Replacing only some titles with `Private note` still returned the original note object, so anonymous activity responses could include private text, content, and images.

## Implementation

- query notes with `{ metaOnly: true, visibleOnly: true }`
- apply a defense-in-depth filter for the one-year window, publication state, password protection, and scheduled `publicAt`
- return only `id`, `nid`, `title`, `mood`, `weather`, `bookmark`, and `createdAt` for each published note

## Verification

- GitHub Actions run `31367661319`: all 9 checks passed, including lint/typecheck, Core build, Docker build, CLI/Core E2E, three test shards, GitGuardian, and the Open Source Software Supply Chain Security Scanner
- `git diff --check` passed

No database migration or production deployment is included. Anonymous endpoint verification remains a post-merge deployment check.
