### PR TITLE
fix(admin): keep JSON snippets readable after save

### DIFF
--- a/apps/admin/src/features/snippets/utils/snippets.normalize.test.ts
+++ b/apps/admin/src/features/snippets/utils/snippets.normalize.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from 'vitest'
+
+import { SnippetType } from '~/models/snippet'
+
+import { normalizeSnippetRawForSave } from './snippets'
+
+describe('normalizeSnippetRawForSave', () => {
+  it('keeps JSON snippets readable after saving', () => {
+    const raw = '{"name":"Mix Space","nested":{"enabled":true}}'
+
+    expect(normalizeSnippetRawForSave(SnippetType.JSON, raw, (key) => key))
+      .toBe(`{
+  "name": "Mix Space",
+  "nested": {
+    "enabled": true
+  }
+}`)
+  })
+
+  it('reports invalid JSON without changing the validation behavior', () => {
+    expect(() =>
+      normalizeSnippetRawForSave(SnippetType.JSON, '{', (key) => key),
+    ).toThrow('snippets.error.jsonInvalid')
+  })
+})

--- a/apps/admin/src/features/snippets/utils/snippets.ts
+++ b/apps/admin/src/features/snippets/utils/snippets.ts
@@ -60,7 +60,7 @@ export function normalizeSnippetRawForSave(
   switch (type) {
     case SnippetType.JSON: {
       try {
-        return JSON.stringify(JSON.parse(raw))
+        return JSON.stringify(JSON.parse(raw), null, 2)
       } catch {
         throw new Error(t('snippets.error.jsonInvalid'))
       }


### PR DESCRIPTION
## Summary

- format JSON snippets with two-space indentation when they are saved
- add regression coverage for readable output and invalid JSON handling

## Root cause

The snippet editor used `JSON.stringify(JSON.parse(raw))` during save. That validation step also collapsed valid JSON into a single line, so reopening the snippet lost the readable structure shown in the editor. The structured snippet conversion path already uses two-space indentation, making the two save paths inconsistent.

## Scope

This addresses the JSON snippet formatting regression reported in #2749. The current Admin writing flow has since been substantially revised, so this PR does not claim to close the separate preview and draft-state reports from that issue.

## Verification

- `pnpm -C apps/admin exec vitest run src/features/snippets/utils/snippets.normalize.test.ts` (2 tests passed)
- `pnpm -C apps/admin run typecheck`
- `pnpm -C apps/admin run build`
- ESLint on the changed TypeScript files
- `git diff --check`

Related to #2749
