### PR TITLE
feat(space): add TMDB search composer

### DIFF
--- a/apps/core/openapi.json
+++ b/apps/core/openapi.json
@@ -1923,6 +1923,99 @@
           }
         }
       }
+    },
+    "/enrichment/search/{provider}": {
+      "get": {
+        "operationId": "searchEnrichment",
+        "summary": "Search a configured enrichment provider by text",
+        "tags": [
+          "recently"
+        ],
+        "parameters": [
+          {
+            "name": "provider",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "minLength": 1,
+              "maxLength": 64
+            }
+          },
+          {
+            "name": "query",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "minLength": 1,
+              "maxLength": 100
+            }
+          },
+          {
+            "name": "size",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "default": 8,
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 20
+            }
+          }
+        ],
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "data"
+                  ],
+                  "properties": {
+                    "data": {
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/components/schemas/EnrichmentResult"
+                      }
+                    },
+                    "meta": {
+                      "$ref": "#/components/schemas/ResponseMeta"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "4XX": {
+            "description": "Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            }
+          },
+          "5XX": {
+            "description": "Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            }
+          }
+        }
+      }
     }
   },
   "components": {

--- a/apps/core/src/common/openapi/route-manifest.ts
+++ b/apps/core/src/common/openapi/route-manifest.ts
@@ -15,7 +15,11 @@ import {
   ReaderReplyCommentSchema,
 } from '~/modules/comment/comment.schema'
 import { CommentViews } from '~/modules/comment/comment.views'
-import { ResolveQuerySchema } from '~/modules/enrichment/enrichment.schema'
+import {
+  EnrichmentSearchParamsSchema,
+  EnrichmentSearchQuerySchema,
+  ResolveQuerySchema,
+} from '~/modules/enrichment/enrichment.schema'
 import { EnrichmentViews } from '~/modules/enrichment/enrichment.views'
 import { NoteSchema } from '~/modules/note/note.schema'
 import { NoteViews } from '~/modules/note/note.views'
@@ -397,5 +401,17 @@ export const routeManifest: readonly OpenApiRoute[] = [
     auth: false,
     query: ResolveQuerySchema,
     response: { name: 'EnrichmentResult', schema: EnrichmentViews.result },
+  },
+  {
+    operationId: 'searchEnrichment',
+    method: 'get',
+    path: '/enrichment/search/:provider',
+    tag: 'recently',
+    summary: 'Search a configured enrichment provider by text',
+    auth: true,
+    params: EnrichmentSearchParamsSchema,
+    query: EnrichmentSearchQuerySchema,
+    response: { name: 'EnrichmentResult', schema: EnrichmentViews.result },
+    responseIsArray: true,
   },
 ] as const

--- a/apps/core/src/modules/enrichment/enrichment.controller.ts
+++ b/apps/core/src/modules/enrichment/enrichment.controller.ts
@@ -26,6 +26,7 @@ import {
   AdminCaptureListQueryDto,
   AdminListQueryDto,
   AdminProbeBodyDto,
+  EnrichmentSearchQueryDto,
   ResolveQueryDto,
 } from './enrichment.schema'
 import { EnrichmentService } from './enrichment.service'
@@ -36,6 +37,7 @@ import { EnrichmentOriginGuard } from './enrichment-origin.guard'
 import { CaptureStorageService } from './providers/open-graph/capture-storage.service'
 
 const PUBLIC_RESOLVE_THROTTLE = { default: { limit: 30, ttl: 60_000 } }
+const SEARCH_THROTTLE = { default: { limit: 60, ttl: 60_000 } }
 const ADMIN_PROBE_THROTTLE = { default: { limit: 30, ttl: 60_000 } }
 
 const DEFAULT_CAPTURE_MAX_ITEMS = 500
@@ -69,6 +71,34 @@ export class EnrichmentController {
       }
       this.bumpCaptureAccess(result)
       return result as EnrichmentResult
+    } catch (error) {
+      if (
+        error instanceof ProviderDisabledError ||
+        error instanceof TokenMissingError
+      ) {
+        res.status(204)
+        return
+      }
+      throw error
+    }
+  }
+
+  @Get('search/:provider')
+  @Auth()
+  @Throttle(SEARCH_THROTTLE)
+  async search(
+    @Param('provider') provider: string,
+    @Query() query: EnrichmentSearchQueryDto,
+    @Lang() lang: string | undefined,
+    @Res({ passthrough: true }) res: any,
+  ): Promise<EnrichmentResult[] | undefined> {
+    try {
+      return await this.enrichmentService.search(
+        provider,
+        query.query,
+        lang,
+        query.size,
+      )
     } catch (error) {
       if (
         error instanceof ProviderDisabledError ||

--- a/apps/core/src/modules/enrichment/enrichment.schema.ts
+++ b/apps/core/src/modules/enrichment/enrichment.schema.ts
@@ -6,6 +6,17 @@ export const ResolveQuerySchema = z.object({
 })
 export class ResolveQueryDto extends createZodDto(ResolveQuerySchema) {}
 
+export const EnrichmentSearchParamsSchema = z.object({
+  provider: z.string().trim().min(1).max(64),
+})
+export const EnrichmentSearchQuerySchema = z.object({
+  query: z.string().trim().min(1).max(100),
+  size: z.coerce.number().int().min(1).max(20).default(8),
+})
+export class EnrichmentSearchQueryDto extends createZodDto(
+  EnrichmentSearchQuerySchema,
+) {}
+
 export const AdminListQuerySchema = z.object({
   page: z.coerce.number().int().min(1).default(1),
   size: z.coerce.number().int().min(1).max(100).default(20),

--- a/apps/core/src/modules/enrichment/enrichment.service.ts
+++ b/apps/core/src/modules/enrichment/enrichment.service.ts
@@ -261,6 +261,28 @@ export class EnrichmentService implements OnModuleInit {
     return this.fetchAndPersist(provider, id, { locale: cacheLocale })
   }
 
+  async search(
+    providerName: string,
+    query: string,
+    lang?: string,
+    limit = 8,
+  ): Promise<EnrichmentResult[]> {
+    const provider = this.providerRegistry.getByName(providerName)
+    if (!provider?.search) throw new ProviderDisabledError(providerName)
+
+    const config = await this.configsService.get('thirdPartyServiceIntegration')
+    if (!this.isProviderEnabled(provider, config)) {
+      throw new ProviderDisabledError(provider.name)
+    }
+    if (!this.hasRequiredConfig(provider, config)) {
+      throw new TokenMissingError(provider.name)
+    }
+
+    const reqLocale = resolveRequestedLanguage(lang)
+    const locale = this.resolveCacheLocale(provider, reqLocale)
+    return provider.search(query, locale || undefined, limit)
+  }
+
   async refresh(
     providerName: string,
     id: string,

--- a/apps/core/src/modules/enrichment/providers/api-response.types.ts
+++ b/apps/core/src/modules/enrichment/providers/api-response.types.ts
@@ -7,15 +7,26 @@
 
 export interface TMDBMovieApiResponse {
   id: number
-  title: string
+  title?: string
   name?: string
   overview: string | null
   poster_path: string | null
   vote_average: number | null
   vote_count: number | null
-  genres: Array<{ name: string }> | null
+  genres?: Array<{ name: string }> | null
   release_date?: string
   first_air_date?: string
+}
+
+export interface TMDBSearchResultApiResponse extends TMDBMovieApiResponse {
+  media_type: 'movie' | 'person' | 'tv'
+}
+
+export interface TMDBSearchApiResponse {
+  page: number
+  results: TMDBSearchResultApiResponse[]
+  total_pages: number
+  total_results: number
 }
 
 // TMDB uses a single type — movies have `title`+`release_date`, TV has `name`+`first_air_date`

--- a/apps/core/src/modules/enrichment/providers/provider.interface.ts
+++ b/apps/core/src/modules/enrichment/providers/provider.interface.ts
@@ -40,6 +40,17 @@ export interface EnrichmentProvider<TRaw = unknown> {
     ctx?: EnrichmentFetchContext,
   ) => Promise<EnrichmentResult<TRaw>>
 
+  /**
+   * Optional text search for providers that expose a discovery API. Results
+   * use the same normalized shape as URL resolution so clients can preview a
+   * choice and then persist its canonical URL through the existing pipeline.
+   */
+  search?: (
+    query: string,
+    locale?: string,
+    limit?: number,
+  ) => Promise<EnrichmentResult<TRaw>[]>
+
   readonly requiredConfigKeys?: string[]
   readonly featureGateConfigKey?: string
   /**

--- a/apps/core/src/modules/enrichment/providers/tmdb/tmdb.client.ts
+++ b/apps/core/src/modules/enrichment/providers/tmdb/tmdb.client.ts
@@ -11,13 +11,22 @@ export class TmdbClient {
     return config?.tmdb?.apiKey || undefined
   }
 
-  async fetch<T = any>(path: string, opts?: { language?: string }): Promise<T> {
+  async fetch<T = any>(
+    path: string,
+    opts?: {
+      language?: string
+      query?: Record<string, boolean | number | string | undefined>
+    },
+  ): Promise<T> {
     const apiKey = await this.getApiKey()
     if (!apiKey) throw new Error('TMDB API key not configured')
 
     const url = new URL(path, 'https://api.themoviedb.org')
     if (opts?.language) {
       url.searchParams.set('language', opts.language)
+    }
+    for (const [key, value] of Object.entries(opts?.query ?? {})) {
+      if (value !== undefined) url.searchParams.set(key, String(value))
     }
     const res = await fetch(url.toString(), {
       headers: {

--- a/apps/core/src/modules/enrichment/providers/tmdb/tmdb.provider.ts
+++ b/apps/core/src/modules/enrichment/providers/tmdb/tmdb.provider.ts
@@ -1,7 +1,11 @@
 import { Injectable, Logger } from '@nestjs/common'
 
 import type { EnrichmentResult, UrlMatchResult } from '../../enrichment.types'
-import type { TMDBMovieApiResponse } from '../api-response.types'
+import type {
+  TMDBMovieApiResponse,
+  TMDBSearchApiResponse,
+  TMDBSearchResultApiResponse,
+} from '../api-response.types'
 import { ENRICHMENT_CATEGORIES } from '../provider.constants'
 import type { EnrichmentProvider } from '../provider.interface'
 import { TmdbClient } from './tmdb.client'
@@ -87,8 +91,50 @@ export class TmdbProvider implements EnrichmentProvider {
       }
     }
 
+    return this.normalize(data, subtype, backfill)
+  }
+
+  async search(
+    query: string,
+    locale?: string,
+    limit = 8,
+  ): Promise<EnrichmentResult[]> {
+    const normalizedQuery = query.trim()
+    if (!normalizedQuery) return []
+
+    const language = locale ? TMDB_LANG_MAP[locale] : undefined
+    const data = await this.client.fetch<TMDBSearchApiResponse>(
+      '/3/search/multi',
+      {
+        language,
+        query: {
+          include_adult: false,
+          page: 1,
+          query: normalizedQuery,
+        },
+      },
+    )
+
+    return data.results
+      .filter(
+        (
+          item,
+        ): item is TMDBSearchResultApiResponse & {
+          media_type: 'movie' | 'tv'
+        } => item.media_type === 'movie' || item.media_type === 'tv',
+      )
+      .slice(0, Math.min(20, Math.max(1, limit)))
+      .map((item) => this.normalize(item, item.media_type))
+  }
+
+  private normalize(
+    data: TMDBMovieApiResponse,
+    subtype: 'movie' | 'tv',
+    backfill?: TMDBMovieApiResponse,
+  ): EnrichmentResult {
     const title =
-      pickNonBlank(data.title, data.name, backfill?.title, backfill?.name) || id
+      pickNonBlank(data.title, data.name, backfill?.title, backfill?.name) ||
+      `${subtype}/${data.id}`
     const description = pickNonBlank(data.overview, backfill?.overview)
 
     const attrs: NonNullable<EnrichmentResult['attributes']> = []

--- a/apps/core/test/src/modules/enrichment/enrichment-admin.controller.e2e-spec.ts
+++ b/apps/core/test/src/modules/enrichment/enrichment-admin.controller.e2e-spec.ts
@@ -74,6 +74,7 @@ const captureStorageMock = {
 
 const enrichmentServiceMock = {
   resolve: vi.fn(),
+  search: vi.fn(),
   refresh: vi.fn(async () => baseRow.normalized),
   probe: vi.fn(),
   matchUrlToRef: vi.fn(),
@@ -108,8 +109,7 @@ const providers = [
   }),
   defineProvider({
     provide: EnrichmentCaptureRepository,
-    useValue:
-      captureRepositoryMock as unknown as EnrichmentCaptureRepository,
+    useValue: captureRepositoryMock as unknown as EnrichmentCaptureRepository,
   }),
   defineProvider({
     provide: CaptureStorageService,
@@ -133,9 +133,7 @@ describe('EnrichmentController admin endpoints (e2e)', () => {
     configState.captureEnabled = false
     enrichmentRepositoryMock.findById.mockResolvedValue(baseRow)
     enrichmentRepositoryMock.clearCapture.mockResolvedValue(undefined)
-    captureRepositoryMock.findByEnrichmentId.mockResolvedValue(
-      baseCaptureRow,
-    )
+    captureRepositoryMock.findByEnrichmentId.mockResolvedValue(baseCaptureRow)
     captureRepositoryMock.getQuotaUsage.mockResolvedValue({
       count: 3,
       totalBytes: 4096,
@@ -172,6 +170,7 @@ describe('EnrichmentController admin endpoints (e2e)', () => {
       async (objectKey: string) => `https://cdn.example.test/${objectKey}`,
     )
     enrichmentServiceMock.refresh.mockResolvedValue(baseRow.normalized as any)
+    enrichmentServiceMock.search.mockResolvedValue([baseRow.normalized] as any)
   })
 
   describe('auth gating', () => {
@@ -183,6 +182,7 @@ describe('EnrichmentController admin endpoints (e2e)', () => {
       { method: 'GET', url: 'enrichment/admin/by-id/row-1' },
       { method: 'GET', url: 'enrichment/admin/captures' },
       { method: 'GET', url: 'enrichment/admin/captures/quota' },
+      { method: 'GET', url: 'enrichment/search/tmdb?query=Dune' },
       { method: 'DELETE', url: 'enrichment/admin/captures/row-1' },
       {
         method: 'POST',
@@ -208,6 +208,25 @@ describe('EnrichmentController admin endpoints (e2e)', () => {
     )
   })
 
+  test('GET search/:provider returns normalized media results', async () => {
+    const res = await proxy.app.inject({
+      method: 'GET',
+      url: `${apiRoutePrefix}/enrichment/search/tmdb?query=Dune&size=6`,
+      headers: authPassHeader,
+    })
+
+    expect(res.statusCode).toBe(200)
+    expect(res.json().data).toEqual([
+      expect.objectContaining({ title: 'Hello', category: 'web' }),
+    ])
+    expect(enrichmentServiceMock.search).toHaveBeenCalledWith(
+      'tmdb',
+      'Dune',
+      undefined,
+      6,
+    )
+  })
+
   test('GET admin/by-id/:id returns row with capture', async () => {
     const res = await proxy.app.inject({
       method: 'GET',
@@ -218,9 +237,7 @@ describe('EnrichmentController admin endpoints (e2e)', () => {
     const body = res.json()
     expect(body.data.id).toBe('row-1')
     expect(body.data.capture).toBeTruthy()
-    expect(body.data.capture.object_key).toBe(
-      'enrichment-captures/row-1.webp',
-    )
+    expect(body.data.capture.object_key).toBe('enrichment-captures/row-1.webp')
   })
 
   test('GET admin/by-id/:id 404 when missing', async () => {
@@ -286,9 +303,7 @@ describe('EnrichmentController admin endpoints (e2e)', () => {
     })
     expect(res.statusCode).toBe(204)
     expect(captureStorageMock.delete).toHaveBeenCalledWith('row-1')
-    expect(enrichmentRepositoryMock.clearCapture).toHaveBeenCalledWith(
-      'row-1',
-    )
+    expect(enrichmentRepositoryMock.clearCapture).toHaveBeenCalledWith('row-1')
   })
 
   test('POST admin/captures/:id/recapture 409 when fetchMode != browser', async () => {

--- a/apps/core/test/src/modules/enrichment/enrichment.service.spec.ts
+++ b/apps/core/test/src/modules/enrichment/enrichment.service.spec.ts
@@ -155,6 +155,7 @@ function makeService(stubs: ServiceStubs = {}) {
     imageService,
     taskQueueService,
     taskQueueProcessor,
+    configsService,
   }
 }
 
@@ -274,6 +275,46 @@ describe('EnrichmentService.resolveCacheLocale', () => {
       supportedLocales: ['zh'],
     } as any
     expect(service.resolveCacheLocale(provider, undefined)).toBe('')
+  })
+})
+
+describe('EnrichmentService.search', () => {
+  it('checks provider readiness and delegates with the normalized locale', async () => {
+    const { service, provider, configsService } = makeService()
+    const searchResults = [makeResult({ title: 'Dune' })]
+    Object.assign(provider, {
+      featureGateConfigKey: 'tmdb',
+      requiredConfigKeys: ['apiKey'],
+      localeAware: true,
+      supportedLocales: ['zh', 'en'],
+      search: vi.fn(async () => searchResults),
+    })
+    configsService.get.mockResolvedValue({
+      tmdb: { enabled: true, apiKey: 'configured' },
+    })
+
+    await expect(service.search('tmdb', 'Dune', 'zh-CN', 6)).resolves.toBe(
+      searchResults,
+    )
+    expect((provider as any).search).toHaveBeenCalledWith('Dune', 'zh', 6)
+  })
+
+  it('rejects search when the provider credential is missing', async () => {
+    const { service, provider, configsService } = makeService()
+    Object.assign(provider, {
+      featureGateConfigKey: 'tmdb',
+      requiredConfigKeys: ['apiKey'],
+      search: vi.fn(),
+    })
+    configsService.get.mockResolvedValue({
+      tmdb: { enabled: true, apiKey: '' },
+    })
+
+    await expect(service.search('tmdb', 'Dune')).rejects.toMatchObject({
+      name: 'TokenMissingError',
+      providerName: 'tmdb',
+    })
+    expect((provider as any).search).not.toHaveBeenCalled()
   })
 })
 

--- a/apps/core/test/src/modules/enrichment/providers/tmdb.provider.spec.ts
+++ b/apps/core/test/src/modules/enrichment/providers/tmdb.provider.spec.ts
@@ -181,4 +181,80 @@ describe('TmdbProvider', () => {
       expect(result.description).toBeUndefined() // empty, no backfill
     })
   })
+
+  describe('search', () => {
+    it('searches localized movie and TV results while excluding people', async () => {
+      const client = createClient()
+      vi.mocked(client.fetch).mockResolvedValue({
+        page: 1,
+        total_pages: 1,
+        total_results: 3,
+        results: [
+          {
+            id: 438_631,
+            media_type: 'movie',
+            title: '沙丘',
+            overview: '保罗踏上旅程。',
+            poster_path: '/dune.jpg',
+            vote_average: 7.8,
+            vote_count: 14_000,
+            release_date: '2021-09-15',
+          },
+          {
+            id: 99,
+            media_type: 'person',
+            name: 'A person',
+            overview: null,
+            poster_path: null,
+            vote_average: null,
+            vote_count: null,
+          },
+          {
+            id: 94_953,
+            media_type: 'tv',
+            name: '沙丘：预言',
+            overview: '姐妹会的起源。',
+            poster_path: '/prophecy.jpg',
+            vote_average: 7.2,
+            vote_count: 400,
+            first_air_date: '2024-11-17',
+          },
+        ],
+      })
+      const p = new TmdbProvider(client)
+
+      const results = await p.search('  Dune  ', 'zh', 8)
+
+      expect(client.fetch).toHaveBeenCalledWith('/3/search/multi', {
+        language: 'zh-CN',
+        query: {
+          include_adult: false,
+          page: 1,
+          query: 'Dune',
+        },
+      })
+      expect(
+        results.map(({ title, subtype, url }) => ({ title, subtype, url })),
+      ).toEqual([
+        {
+          title: '沙丘',
+          subtype: 'movie',
+          url: 'https://www.themoviedb.org/movie/438631',
+        },
+        {
+          title: '沙丘：预言',
+          subtype: 'tv',
+          url: 'https://www.themoviedb.org/tv/94953',
+        },
+      ])
+    })
+
+    it('does not call TMDB for an empty query', async () => {
+      const client = createClient()
+      const p = new TmdbProvider(client)
+
+      await expect(p.search('   ')).resolves.toEqual([])
+      expect(client.fetch).not.toHaveBeenCalled()
+    })
+  })
 })

--- a/apps/ios/Packages/SpaceCore/Sources/SpaceCore/RecentlyService.swift
+++ b/apps/ios/Packages/SpaceCore/Sources/SpaceCore/RecentlyService.swift
@@ -130,6 +130,27 @@ public struct RecentlyService: Sendable {
         }
     }
 
+    /// Searches the server-configured TMDB provider without exposing its API
+    /// key to the app. The results share the normal enrichment shape, so a
+    /// selected title can enter the existing canonical-URL publishing path.
+    public func searchTMDB(query: String, size: Int = 8) async throws -> [EnrichmentResult] {
+        let input = Operations.SearchEnrichment.Input(
+            path: .init(provider: "tmdb"),
+            query: .init(query: query, size: size)
+        )
+        switch try await client.searchEnrichment(input) {
+        case let .ok(response):
+            return try response.body.json.data
+        case let .clientError(status, response):
+            throw SpaceError(envelope: try response.body.json, status: status)
+        case let .serverError(status, response):
+            throw SpaceError(envelope: try response.body.json, status: status)
+        case let .undocumented(statusCode, _):
+            guard statusCode == 204 else { throw SpaceError.undocumented(statusCode) }
+            return []
+        }
+    }
+
     /// URLs the server will turn into media cards.
     ///
     /// `UrlExtractorService.extractFromMarkdown` runs the content through
@@ -187,7 +208,12 @@ public struct RecentlyService: Sendable {
         selectedEnrichmentURLs: [String]
     ) -> String {
         selectedEnrichmentURLs.reduce(content) { partial, url in
-            isolatingLink(url, in: partial)
+            if detectedURLs(in: partial).contains(url) {
+                return isolatingLink(url, in: partial)
+            }
+            return [partial.trimmingCharacters(in: .whitespacesAndNewlines), url]
+                .filter { !$0.isEmpty }
+                .joined(separator: "\n\n")
         }
     }
 

--- a/apps/ios/Packages/SpaceCore/Sources/SpaceCore/openapi.json
+++ b/apps/ios/Packages/SpaceCore/Sources/SpaceCore/openapi.json
@@ -1923,6 +1923,99 @@
           }
         }
       }
+    },
+    "/enrichment/search/{provider}": {
+      "get": {
+        "operationId": "searchEnrichment",
+        "summary": "Search a configured enrichment provider by text",
+        "tags": [
+          "recently"
+        ],
+        "parameters": [
+          {
+            "name": "provider",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "minLength": 1,
+              "maxLength": 64
+            }
+          },
+          {
+            "name": "query",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "minLength": 1,
+              "maxLength": 100
+            }
+          },
+          {
+            "name": "size",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "default": 8,
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 20
+            }
+          }
+        ],
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "data"
+                  ],
+                  "properties": {
+                    "data": {
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/components/schemas/EnrichmentResult"
+                      }
+                    },
+                    "meta": {
+                      "$ref": "#/components/schemas/ResponseMeta"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "4XX": {
+            "description": "Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            }
+          },
+          "5XX": {
+            "description": "Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            }
+          }
+        }
+      }
     }
   },
   "components": {

--- a/apps/ios/Packages/SpaceCore/Tests/SpaceCoreTests/RecentlyServiceTests.swift
+++ b/apps/ios/Packages/SpaceCore/Tests/SpaceCoreTests/RecentlyServiceTests.swift
@@ -94,6 +94,25 @@ import Testing
         #expect(try await service.resolve(url: "https://a.example") == nil)
     }
 
+    @Test func searchesTMDBThroughTheAuthenticatedEnrichmentEndpoint() async throws {
+        let (service, transport) = makeService([
+            .init(
+                operationID: "searchEnrichment",
+                status: .ok,
+                json: #"{"data":[{"title":"Dune","description":"A desert epic","url":"https://www.themoviedb.org/movie/438631","category":"media","subtype":"movie","published_at":"2021-09-15","fetched_at":"","thumbnail_image":{"url":"https://image.tmdb.org/t/p/w500/dune.jpg"}}]}"#
+            ),
+        ])
+
+        let result = try #require(try await service.searchTMDB(query: "Dune", size: 6).first)
+
+        #expect(result.title == "Dune")
+        #expect(result.url == "https://www.themoviedb.org/movie/438631")
+        #expect(transport.operationIDs == ["searchEnrichment"])
+        #expect(transport.requestPaths.first?.contains("query=Dune") == true)
+        #expect(transport.requestPaths.first?.contains("size=6") == true)
+        #expect(transport.requestPaths.first?.contains("/enrichment/search/tmdb") == true)
+    }
+
     /// Mirrors `UrlExtractorService.extractFromMarkdown`: only a link that owns
     /// its whole *paragraph* becomes a card. A single newline is not a
     /// paragraph break in markdown — verified against a live instance.
@@ -135,6 +154,17 @@ import Testing
         let rewritten = RecentlyService.isolatingLink(url, in: text)
         #expect(rewritten == expected)
         #expect(RecentlyService.firstCardableURL(in: rewritten) == url)
+    }
+
+    @Test func preparingAppendsASelectedSearchResultAsACardifiableLink() {
+        let url = "https://www.themoviedb.org/movie/438631"
+        let prepared = RecentlyService.preparing(
+            content: "Watched Dune tonight.",
+            selectedEnrichmentURLs: [url]
+        )
+
+        #expect(prepared == "Watched Dune tonight.\n\n\(url)")
+        #expect(RecentlyService.cardableURLs(in: prepared) == [url])
     }
 
     @Test func deleteRollsBackNothingOnSuccess() async throws {

--- a/apps/ios/Packages/SpaceUI/Sources/SpaceUI/ComposerFieldSurface.swift
+++ b/apps/ios/Packages/SpaceUI/Sources/SpaceUI/ComposerFieldSurface.swift
@@ -11,6 +11,18 @@ public struct ComposerFieldSurface: ViewModifier {
             .padding(.horizontal, Spacing.regular)
             .padding(.vertical, 10)
             .frame(minHeight: 44, alignment: .leading)
+            .composerContainerSurface()
+    }
+}
+
+/// Shared shell for compound composers where text and the primary action live
+/// in one continuous field, matching the visual hierarchy of system messaging
+/// interfaces without forcing identical internal padding on every consumer.
+public struct ComposerContainerSurface: ViewModifier {
+    public init() {}
+
+    public func body(content: Content) -> some View {
+        content
             .background(
                 Color(SpacePalette.inset),
                 in: .rect(cornerRadius: Radius.composer, style: .continuous)
@@ -25,5 +37,9 @@ public struct ComposerFieldSurface: ViewModifier {
 public extension View {
     func composerFieldSurface() -> some View {
         modifier(ComposerFieldSurface())
+    }
+
+    func composerContainerSurface() -> some View {
+        modifier(ComposerContainerSurface())
     }
 }

--- a/apps/ios/Space/Recently/RecentlyCommandSearchView.swift
+++ b/apps/ios/Space/Recently/RecentlyCommandSearchView.swift
@@ -1,0 +1,295 @@
+import SpaceCore
+import SpaceUI
+import SwiftUI
+
+struct RecentlyCommandSearchView: View {
+    @Bindable var store: RecentlyComposerStore
+
+    @Environment(\.accessibilityReduceTransparency) private var reduceTransparency
+    private let contextRowHeight: CGFloat = 46
+    private let mediaRowHeight: CGFloat = 58
+
+    var body: some View {
+        VStack(spacing: 0) {
+            header
+            Divider()
+            results
+        }
+        .background {
+            let shape = RoundedRectangle(cornerRadius: Radius.sheet, style: .continuous)
+            if reduceTransparency {
+                shape.fill(Color(SpacePalette.surface))
+            } else {
+                shape
+                    .fill(.clear)
+                    .glassEffect(.regular, in: shape)
+            }
+        }
+        .clipShape(.rect(cornerRadius: Radius.sheet, style: .continuous))
+    }
+
+    private var header: some View {
+        HStack(spacing: Spacing.xSmall) {
+            if store.activeCommand != nil {
+                Button("Back to commands", systemImage: "chevron.left") {
+                    store.returnToSlashMenu()
+                }
+                .labelStyle(.iconOnly)
+                .buttonStyle(.plain)
+                .foregroundStyle(Color(SpacePalette.primary))
+                .frame(width: 36, height: 40)
+                .contentShape(.rect)
+                .accessibilityIdentifier("recently.composer.command.back")
+            } else {
+                Image(systemName: "paperclip")
+                    .font(.subheadline.weight(.semibold))
+                    .foregroundStyle(Color(SpacePalette.accent))
+                    .frame(width: 36, height: 40)
+            }
+
+            Text(store.activeCommand?.detailTitle ?? "Add context or media")
+                .font(.subheadline.weight(.semibold))
+                .foregroundStyle(Color(SpacePalette.primary))
+                .lineLimit(1)
+                .accessibilityIdentifier("recently.composer.command.detail")
+
+            Spacer(minLength: Spacing.small)
+
+            Button("Close search", systemImage: "xmark") {
+                store.dismissAttachmentSearch()
+            }
+            .labelStyle(.iconOnly)
+            .buttonStyle(.plain)
+            .foregroundStyle(Color(SpacePalette.subtle))
+            .frame(width: 36, height: 40)
+            .contentShape(.rect)
+            .accessibilityIdentifier("recently.composer.command.close")
+        }
+        .padding(.horizontal, Spacing.small)
+        .frame(height: 42)
+    }
+
+    private var results: some View {
+        ScrollView {
+            LazyVStack(spacing: 0) {
+                if store.showsContextSearchResults {
+                    contextResults
+                }
+
+                if store.showsTMDBSearchResults, !trimmedQuery.isEmpty {
+                    tmdbResults
+                }
+
+                if showsEmptyState {
+                    emptyState
+                }
+            }
+        }
+        .scrollIndicators(.hidden)
+        .frame(height: resultsHeight)
+        .accessibilityLabel("Search results")
+    }
+
+    @ViewBuilder
+    private var contextResults: some View {
+        if showsBothResultKinds, !store.contextCandidates.isEmpty {
+            sectionHeader("Space")
+        }
+
+        if store.isLoadingContexts, store.contextCandidates.isEmpty {
+            loadingRow("Searching Space…")
+        } else {
+            ForEach(store.contextCandidates) { candidate in
+                contextRow(candidate)
+            }
+        }
+    }
+
+    @ViewBuilder
+    private var tmdbResults: some View {
+        if showsBothResultKinds,
+           store.isLoadingTMDB || !store.tmdbCandidates.isEmpty
+        {
+            sectionHeader("TMDB")
+        }
+
+        if store.isLoadingTMDB, store.tmdbCandidates.isEmpty {
+            loadingRow("Searching TMDB…")
+        } else {
+            ForEach(store.tmdbCandidates) { candidate in
+                tmdbRow(candidate)
+            }
+        }
+    }
+
+    private func sectionHeader(_ title: String) -> some View {
+        Text(title.uppercased())
+            .font(.system(size: 10, weight: .semibold))
+            .tracking(0.7)
+            .foregroundStyle(Color(SpacePalette.subtle))
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .padding(.horizontal, Spacing.medium)
+            .frame(height: 26)
+    }
+
+    private func loadingRow(_ title: String) -> some View {
+        HStack(spacing: Spacing.small) {
+            ProgressView()
+                .controlSize(.small)
+            Text(title)
+                .font(.caption)
+                .foregroundStyle(Color(SpacePalette.muted))
+        }
+        .frame(maxWidth: .infinity)
+        .frame(height: 64)
+    }
+
+    private func contextRow(_ candidate: RecentlyContext) -> some View {
+        Button {
+            store.selectContext(candidate)
+        } label: {
+            HStack(spacing: Spacing.small) {
+                Image(systemName: candidate.kind.systemImage)
+                    .font(.system(size: 17, weight: .medium))
+                    .foregroundStyle(Color(SpacePalette.accent))
+                    .frame(width: 24)
+
+                VStack(alignment: .leading, spacing: 1) {
+                    Text(candidate.title)
+                        .font(.subheadline.weight(.medium))
+                        .foregroundStyle(Color(SpacePalette.primary))
+                        .lineLimit(1)
+                    Text(candidate.kind.title)
+                        .font(.caption2)
+                        .foregroundStyle(Color(SpacePalette.subtle))
+                }
+                .frame(maxWidth: .infinity, alignment: .leading)
+
+                Image(systemName: "plus.circle")
+                    .font(.subheadline)
+                    .foregroundStyle(Color(SpacePalette.subtle))
+            }
+            .padding(.horizontal, Spacing.medium)
+            .frame(height: contextRowHeight)
+            .contentShape(.rect)
+            .overlay(alignment: .bottom) {
+                Divider().padding(.leading, 44)
+            }
+        }
+        .buttonStyle(.plain)
+        .accessibilityIdentifier(
+            "recently.composer.context.candidate.\(candidate.kind.rawValue).\(candidate.id)"
+        )
+        .accessibilityLabel("Attach \(candidate.kind.title), \(candidate.title)")
+    }
+
+    private func tmdbRow(_ card: MediaCard) -> some View {
+        Button {
+            store.selectTMDB(card)
+        } label: {
+            HStack(spacing: Spacing.small) {
+                ComposerArtwork(url: card.artworkURL, accent: card.accent)
+                    .frame(width: 32, height: 48)
+                    .clipShape(.rect(cornerRadius: 6))
+
+                VStack(alignment: .leading, spacing: 2) {
+                    Text(card.title)
+                        .font(.subheadline.weight(.medium))
+                        .foregroundStyle(Color(SpacePalette.primary))
+                        .lineLimit(1)
+                    Text(card.topCaps ?? (card.metaLine.isEmpty ? "TMDB" : card.metaLine))
+                        .font(.caption2)
+                        .foregroundStyle(Color(SpacePalette.subtle))
+                        .lineLimit(1)
+                }
+                .frame(maxWidth: .infinity, alignment: .leading)
+
+                Image(systemName: "plus.circle")
+                    .font(.subheadline)
+                    .foregroundStyle(Color(SpacePalette.subtle))
+            }
+            .padding(.horizontal, Spacing.medium)
+            .frame(height: mediaRowHeight)
+            .contentShape(.rect)
+            .overlay(alignment: .bottom) {
+                Divider().padding(.leading, 52)
+            }
+        }
+        .buttonStyle(.plain)
+        .accessibilityIdentifier("recently.composer.tmdb.candidate.\(card.id)")
+        .accessibilityLabel("Attach \(card.title) from TMDB")
+    }
+
+    private var emptyState: some View {
+        HStack(spacing: Spacing.xSmall) {
+            Image(systemName: emptyStateIcon)
+                .font(.subheadline)
+                .foregroundStyle(Color(SpacePalette.subtle))
+            Text(emptyStateTitle)
+                .font(.caption)
+                .foregroundStyle(Color(SpacePalette.muted))
+                .lineLimit(2)
+        }
+        .frame(maxWidth: .infinity)
+        .frame(height: 52)
+        .padding(.horizontal, Spacing.regular)
+    }
+
+    private var trimmedQuery: String {
+        store.contextSearch.trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
+    private var showsBothResultKinds: Bool {
+        store.showsContextSearchResults && store.showsTMDBSearchResults
+    }
+
+    private var showsEmptyState: Bool {
+        let hasContext = !store.contextCandidates.isEmpty
+        let hasTMDB = !store.tmdbCandidates.isEmpty
+        let isLoading = store.isLoadingContexts || store.isLoadingTMDB
+        if store.showsTMDBSearchResults, !store.showsContextSearchResults, trimmedQuery.isEmpty {
+            return true
+        }
+        return !hasContext && !hasTMDB && !isLoading
+    }
+
+    private var emptyStateIcon: String {
+        store.errorMessage == nil ? "magnifyingglass" : "exclamationmark.triangle"
+    }
+
+    private var emptyStateTitle: String {
+        if store.errorMessage != nil {
+            return "Search is unavailable. Check the Space server connection."
+        }
+        if store.showsTMDBSearchResults, !store.showsContextSearchResults, trimmedQuery.isEmpty {
+            return "Type a movie or TV title below"
+        }
+        if store.showsContextSearchResults, trimmedQuery.isEmpty {
+            return "Type below to search Space"
+        }
+        return "No matching content"
+    }
+
+    private var resultsHeight: CGFloat {
+        if showsEmptyState { return 52 }
+
+        var height: CGFloat = 0
+        if store.showsContextSearchResults {
+            if store.isLoadingContexts, store.contextCandidates.isEmpty {
+                height += 64
+            } else {
+                height += CGFloat(store.contextCandidates.count) * contextRowHeight
+                if showsBothResultKinds, !store.contextCandidates.isEmpty { height += 26 }
+            }
+        }
+        if store.showsTMDBSearchResults, !trimmedQuery.isEmpty {
+            if store.isLoadingTMDB, store.tmdbCandidates.isEmpty {
+                height += 64
+            } else {
+                height += CGFloat(store.tmdbCandidates.count) * mediaRowHeight
+                if showsBothResultKinds, !store.tmdbCandidates.isEmpty { height += 26 }
+            }
+        }
+        return min(max(height, 64), 212)
+    }
+}

--- a/apps/ios/Space/Recently/RecentlyComposerPanelView.swift
+++ b/apps/ios/Space/Recently/RecentlyComposerPanelView.swift
@@ -1,0 +1,44 @@
+import SpaceUI
+import SwiftUI
+
+struct RecentlyComposerPanelView: View {
+    @Bindable var store: RecentlyComposerStore
+
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
+
+    var body: some View {
+        VStack(spacing: 0) {
+            if store.isChoosingContext {
+                RecentlyCommandSearchView(store: store)
+                    .transition(panelTransition)
+            } else if store.isShowingSlashMenu {
+                RecentlySlashMenuView(commands: store.slashCommands) { command in
+                    store.executeSlashCommand(command)
+                }
+                .transition(panelTransition)
+            }
+        }
+        .padding(.leading, 56)
+        .padding(.trailing, Spacing.small)
+        .padding(.bottom, store.isShowingComposerPanel ? Spacing.xSmall : 0)
+        .animation(panelAnimation, value: store.isChoosingContext)
+        .animation(panelAnimation, value: store.isShowingSlashMenu)
+    }
+
+    private var panelAnimation: Animation {
+        reduceMotion
+            ? .easeOut(duration: 0.12)
+            : .snappy(duration: 0.24, extraBounce: 0)
+    }
+
+    private var panelTransition: AnyTransition {
+        guard !reduceMotion else { return .opacity }
+        return .asymmetric(
+            insertion: .opacity
+                .combined(with: .scale(scale: 0.985, anchor: .bottom))
+                .combined(with: .offset(x: 0, y: 6)),
+            removal: .opacity
+                .combined(with: .scale(scale: 0.99, anchor: .bottom))
+        )
+    }
+}

--- a/apps/ios/Space/Recently/RecentlyComposerSelectionTray.swift
+++ b/apps/ios/Space/Recently/RecentlyComposerSelectionTray.swift
@@ -1,0 +1,133 @@
+import SpaceCore
+import SpaceUI
+import SwiftUI
+
+struct RecentlyComposerSelectionTray: View {
+    @Bindable var store: RecentlyComposerStore
+
+    var body: some View {
+        ScrollView(.horizontal) {
+            LazyHStack(spacing: Spacing.small) {
+                if let context = store.context {
+                    contextReceipt(context)
+                }
+
+                ForEach(store.selectedLinks) { preview in
+                    linkReceipt(preview)
+                }
+            }
+        }
+        .scrollIndicators(.hidden)
+        .frame(height: 52)
+        .accessibilityLabel("Selected attachments")
+    }
+
+    private func contextReceipt(_ context: RecentlyContext) -> some View {
+        HStack(spacing: Spacing.small) {
+            Image(systemName: context.kind.systemImage)
+                .font(.system(size: 17, weight: .medium))
+                .foregroundStyle(Color(SpacePalette.accent))
+                .frame(width: 24)
+
+            VStack(alignment: .leading, spacing: 1) {
+                Text(context.title)
+                    .font(.caption.weight(.semibold))
+                    .foregroundStyle(Color(SpacePalette.primary))
+                    .lineLimit(1)
+                Text(context.kind.title)
+                    .font(.caption2)
+                    .foregroundStyle(Color(SpacePalette.subtle))
+            }
+            .frame(maxWidth: .infinity, alignment: .leading)
+
+            removeButton(label: "Remove \(context.title)") {
+                store.removeContext()
+            }
+        }
+        .padding(.leading, Spacing.medium)
+        .frame(width: 220, height: 52)
+        .selectionReceiptSurface()
+        .accessibilityIdentifier("recently.composer.selection.context")
+    }
+
+    private func linkReceipt(_ preview: ComposerLinkPreview) -> some View {
+        HStack(spacing: Spacing.small) {
+            if let card = preview.card {
+                ComposerArtwork(url: card.artworkURL, accent: card.accent)
+                    .frame(width: 34, height: 48)
+                    .clipShape(.rect(cornerRadius: 6))
+            } else {
+                Image(systemName: "link")
+                    .font(.system(size: 17, weight: .medium))
+                    .foregroundStyle(Color(SpacePalette.accent))
+                    .frame(width: 34)
+            }
+
+            VStack(alignment: .leading, spacing: 1) {
+                Text(preview.card?.title ?? URL(string: preview.url)?.host() ?? "Link")
+                    .font(.caption.weight(.semibold))
+                    .foregroundStyle(Color(SpacePalette.primary))
+                    .lineLimit(1)
+                Text(linkDetail(preview))
+                    .font(.caption2)
+                    .foregroundStyle(Color(SpacePalette.subtle))
+                    .lineLimit(1)
+            }
+            .frame(maxWidth: .infinity, alignment: .leading)
+
+            if preview.isResolving {
+                ProgressView()
+                    .controlSize(.small)
+                    .frame(width: 32, height: 44)
+            } else {
+                removeButton(label: "Remove \(preview.card?.title ?? "link")") {
+                    store.toggleLink(preview.url)
+                }
+            }
+        }
+        .padding(.leading, Spacing.small)
+        .frame(width: 230, height: 52)
+        .selectionReceiptSurface()
+        .accessibilityIdentifier("recently.composer.enrichment")
+    }
+
+    private func removeButton(label: String, action: @escaping () -> Void) -> some View {
+        Button(label, systemImage: "xmark.circle.fill", action: action)
+            .labelStyle(.iconOnly)
+            .buttonStyle(.plain)
+            .foregroundStyle(Color(SpacePalette.subtle))
+            .frame(width: 40, height: 44)
+            .contentShape(.rect)
+    }
+
+    private func linkDetail(_ preview: ComposerLinkPreview) -> String {
+        guard let card = preview.card else {
+            return preview.isResolving ? "Resolving…" : "Link attachment"
+        }
+        return card.topCaps ?? (card.metaLine.isEmpty ? card.category.capitalized : card.metaLine)
+    }
+}
+
+struct ComposerArtwork: View {
+    let url: URL?
+    let accent: Color
+
+    var body: some View {
+        AsyncImage(url: url) { image in
+            image.resizable().scaledToFill()
+        } placeholder: {
+            Rectangle().fill(accent.opacity(0.18))
+        }
+        .clipped()
+    }
+}
+
+private extension View {
+    func selectionReceiptSurface() -> some View {
+        background(Color(SpacePalette.inset), in: .rect(cornerRadius: Radius.control))
+            .overlay {
+                RoundedRectangle(cornerRadius: Radius.control, style: .continuous)
+                    .stroke(Color(.separator).opacity(0.28), lineWidth: 0.5)
+            }
+    }
+}

--- a/apps/ios/Space/Recently/RecentlyComposerStore.swift
+++ b/apps/ios/Space/Recently/RecentlyComposerStore.swift
@@ -14,10 +14,17 @@ struct ComposerLinkPreview: Identifiable, Equatable {
 @MainActor
 @Observable
 final class RecentlyComposerStore {
+    private enum AttachmentSearchScope {
+        case all
+        case context
+        case tmdb
+    }
+
     private struct DraftState {
         let text: String
         let context: RecentlyContext?
         let links: [ComposerLinkPreview]
+        let attachedURLs: [String]
         let selectionOverrides: [String: Bool]
     }
 
@@ -26,18 +33,46 @@ final class RecentlyComposerStore {
 
     private(set) var context: RecentlyContext?
     private(set) var contextCandidates: [RecentlyContext] = []
+    private(set) var tmdbCandidates: [MediaCard] = []
     private(set) var links: [ComposerLinkPreview] = []
     private(set) var isChoosingContext = false
     private(set) var isLoadingContexts = false
+    private(set) var isLoadingTMDB = false
     private(set) var isSaving = false
     private(set) var editingID: String?
+    private(set) var activeCommand: RecentlySlashCommand?
     private(set) var errorMessage: String?
     private(set) var focusRequestID = 0
     private(set) var dismissRequestID = 0
 
     var isEditing: Bool { editingID != nil }
+    var slashCommands: [RecentlySlashCommand] {
+        guard !isChoosingContext, !isSaving else { return [] }
+        return RecentlySlashCommand.suggestions(for: text)
+    }
+
+    var isShowingSlashMenu: Bool { !slashCommands.isEmpty }
+    var isShowingComposerPanel: Bool { isShowingSlashMenu || isChoosingContext }
+    var selectedLinks: [ComposerLinkPreview] { links.filter(\.isSelected) }
+    var showsContextSearchResults: Bool { attachmentSearchScope != .tmdb }
+    var showsTMDBSearchResults: Bool { attachmentSearchScope != .context }
+    var attachmentSearchPlaceholder: String {
+        guard attachmentSearchScope == .context else {
+            return attachmentSearchScope == .tmdb ? "Search TMDB" : "TMDB or context"
+        }
+        return switch contextKindFilter {
+        case .post: "Search posts"
+        case .note: "Search notes"
+        case .page: "Search pages"
+        case .recently: "Search Recently"
+        case nil: "Search Space"
+        }
+    }
+
     var canSubmit: Bool {
-        !text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty && !isSaving
+        let hasText = !text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+        let hasSelectedEnrichment = links.contains(where: \.isSelected)
+        return (hasText || hasSelectedEnrichment) && !isSaving
     }
 
     private let service: RecentlyService
@@ -45,11 +80,16 @@ final class RecentlyComposerStore {
     private let onSaved: () -> Void
 
     private var suspendedDraft: DraftState?
+    private var attachedURLs: [String] = []
     private var selectionOverrides: [String: Bool] = [:]
     private var linkGeneration = 0
     private var contextGeneration = 0
+    private var tmdbGeneration = 0
+    private var attachmentSearchScope: AttachmentSearchScope = .all
+    private var contextKindFilter: RecentlyContext.Kind?
     private var linkResolutionTask: Task<Void, Never>?
     private var contextSearchTask: Task<Void, Never>?
+    private var tmdbSearchTask: Task<Void, Never>?
 
     init(
         service: RecentlyService,
@@ -65,7 +105,8 @@ final class RecentlyComposerStore {
         errorMessage = nil
         linkGeneration &+= 1
         let generation = linkGeneration
-        let urls = Self.uniqueURLs(in: text)
+        let detectedURLs = Self.uniqueURLs(in: text)
+        let urls = detectedURLs + attachedURLs.filter { !detectedURLs.contains($0) }
         let existing = Dictionary(uniqueKeysWithValues: links.map { ($0.url, $0) })
 
         links = urls.map { url in
@@ -95,6 +136,13 @@ final class RecentlyComposerStore {
 
     func toggleLink(_ url: String) {
         guard let index = links.firstIndex(where: { $0.url == url }) else { return }
+        if attachedURLs.contains(url), !Self.uniqueURLs(in: text).contains(url) {
+            attachedURLs.removeAll { $0 == url }
+            links.remove(at: index)
+            selectionOverrides.removeValue(forKey: url)
+            errorMessage = nil
+            return
+        }
         links[index].isSelected.toggle()
         selectionOverrides[url] = links[index].isSelected
         errorMessage = nil
@@ -105,22 +153,90 @@ final class RecentlyComposerStore {
     }
 
     func toggleContextPicker() {
-        isChoosingContext.toggle()
-        guard isChoosingContext else { return }
-        if contextCandidates.isEmpty {
-            scheduleContextSearch(immediate: true)
+        errorMessage = nil
+        if isChoosingContext {
+            dismissAttachmentSearch()
+            return
         }
+        openAttachmentSearch(scope: .all)
     }
 
     func contextSearchDidChange() {
+        guard isChoosingContext else { return }
+        errorMessage = nil
         scheduleContextSearch(immediate: false)
+        scheduleTMDBSearch(immediate: false)
     }
 
     func selectContext(_ candidate: RecentlyContext) {
         context = candidate
         isChoosingContext = false
-        contextSearch = ""
+        clearAttachmentSearch()
         errorMessage = nil
+        focusInput()
+    }
+
+    func selectTMDB(_ candidate: MediaCard) {
+        guard let url = candidate.url?.absoluteString else { return }
+
+        if !attachedURLs.contains(url) {
+            attachedURLs.append(url)
+        }
+        selectionOverrides[url] = true
+        if let index = links.firstIndex(where: { $0.url == url }) {
+            links[index].card = candidate
+            links[index].isSelected = true
+            links[index].isResolving = false
+        } else {
+            links.append(
+                ComposerLinkPreview(
+                    url: url,
+                    card: candidate,
+                    isSelected: true,
+                    isResolving: false
+                )
+            )
+        }
+
+        isChoosingContext = false
+        clearAttachmentSearch()
+        errorMessage = nil
+        focusInput()
+    }
+
+    func executeSlashCommand(_ command: RecentlySlashCommand) {
+        guard let invocation = RecentlySlashCommand.invocation(in: text) else { return }
+
+        text.removeSubrange(invocation.range)
+        switch command.searchScope {
+        case .context:
+            openAttachmentSearch(
+                scope: .context,
+                contextKind: command.contextKind,
+                command: command
+            )
+        case .tmdb:
+            openAttachmentSearch(scope: .tmdb, command: command)
+        }
+        errorMessage = nil
+    }
+
+    func dismissAttachmentSearch() {
+        isChoosingContext = false
+        clearAttachmentSearch()
+        errorMessage = nil
+        focusInput()
+    }
+
+    func returnToSlashMenu() {
+        isChoosingContext = false
+        clearAttachmentSearch()
+        errorMessage = nil
+        if let last = text.last, !last.isWhitespace {
+            text.append(" ")
+        }
+        text.append("/")
+        focusInput()
     }
 
     func removeContext() {
@@ -134,6 +250,7 @@ final class RecentlyComposerStore {
                 text: text,
                 context: context,
                 links: links,
+                attachedURLs: attachedURLs,
                 selectionOverrides: selectionOverrides
             )
         }
@@ -143,7 +260,8 @@ final class RecentlyComposerStore {
         context = entry.context
         errorMessage = nil
         isChoosingContext = false
-        contextSearch = ""
+        clearAttachmentSearch()
+        attachedURLs = []
 
         let selected = entry.selectedEnrichmentURLs
         let enrichmentMap = entry.enrichments?.additionalProperties ?? [:]
@@ -225,6 +343,11 @@ final class RecentlyComposerStore {
     }
 
     private func scheduleContextSearch(immediate: Bool) {
+        guard attachmentSearchScope != .tmdb else {
+            contextCandidates = []
+            isLoadingContexts = false
+            return
+        }
         contextGeneration &+= 1
         let generation = contextGeneration
         contextSearchTask?.cancel()
@@ -237,6 +360,32 @@ final class RecentlyComposerStore {
         }
     }
 
+    private func scheduleTMDBSearch(immediate: Bool) {
+        guard attachmentSearchScope != .context else {
+            tmdbCandidates = []
+            isLoadingTMDB = false
+            return
+        }
+        tmdbGeneration &+= 1
+        let generation = tmdbGeneration
+        let query = contextSearch.trimmingCharacters(in: .whitespacesAndNewlines)
+        tmdbSearchTask?.cancel()
+
+        guard !query.isEmpty else {
+            tmdbCandidates = []
+            isLoadingTMDB = false
+            return
+        }
+
+        tmdbSearchTask = Task { [weak self] in
+            if !immediate {
+                try? await Task.sleep(for: .milliseconds(350))
+            }
+            guard !Task.isCancelled, let self else { return }
+            await loadTMDBCandidates(query: query, generation: generation)
+        }
+    }
+
     private func loadContextCandidates(generation: Int) async {
         isLoadingContexts = true
         defer {
@@ -245,7 +394,9 @@ final class RecentlyComposerStore {
         do {
             let candidates = try await service.refCandidates(search: contextSearch)
             if generation == contextGeneration {
-                contextCandidates = candidates
+                contextCandidates = candidates.filter { candidate in
+                    contextKindFilter == nil || candidate.kind == contextKindFilter
+                }
             }
         } catch {
             if generation == contextGeneration {
@@ -255,12 +406,61 @@ final class RecentlyComposerStore {
         }
     }
 
+    private func loadTMDBCandidates(query: String, generation: Int) async {
+        isLoadingTMDB = true
+        defer {
+            if generation == tmdbGeneration { isLoadingTMDB = false }
+        }
+        do {
+            let results = try await service.searchTMDB(query: query)
+            if generation == tmdbGeneration {
+                tmdbCandidates = results.map(MediaCard.init)
+            }
+        } catch {
+            if generation == tmdbGeneration {
+                tmdbCandidates = []
+                errorMessage = error.localizedDescription
+            }
+        }
+    }
+
+    private func clearAttachmentSearch() {
+        contextGeneration &+= 1
+        tmdbGeneration &+= 1
+        contextSearchTask?.cancel()
+        tmdbSearchTask?.cancel()
+        contextSearch = ""
+        contextCandidates = []
+        tmdbCandidates = []
+        isLoadingContexts = false
+        isLoadingTMDB = false
+        attachmentSearchScope = .all
+        contextKindFilter = nil
+        activeCommand = nil
+    }
+
+    private func openAttachmentSearch(
+        scope: AttachmentSearchScope,
+        contextKind: RecentlyContext.Kind? = nil,
+        command: RecentlySlashCommand? = nil
+    ) {
+        clearAttachmentSearch()
+        attachmentSearchScope = scope
+        contextKindFilter = contextKind
+        activeCommand = command
+        isChoosingContext = true
+        scheduleContextSearch(immediate: true)
+        scheduleTMDBSearch(immediate: true)
+        focusInput()
+    }
+
     private func restoreSuspendedDraft() {
         editingID = nil
         if let suspendedDraft {
             text = suspendedDraft.text
             context = suspendedDraft.context
             links = suspendedDraft.links
+            attachedURLs = suspendedDraft.attachedURLs
             selectionOverrides = suspendedDraft.selectionOverrides
         } else {
             resetDraft()
@@ -268,7 +468,7 @@ final class RecentlyComposerStore {
         self.suspendedDraft = nil
         errorMessage = nil
         isChoosingContext = false
-        contextSearch = ""
+        clearAttachmentSearch()
         textDidChange()
     }
 
@@ -277,11 +477,12 @@ final class RecentlyComposerStore {
         text = ""
         context = nil
         links = []
+        attachedURLs = []
         selectionOverrides = [:]
         suspendedDraft = nil
         errorMessage = nil
         isChoosingContext = false
-        contextSearch = ""
+        clearAttachmentSearch()
         linkResolutionTask?.cancel()
     }
 

--- a/apps/ios/Space/Recently/RecentlyComposerView.swift
+++ b/apps/ios/Space/Recently/RecentlyComposerView.swift
@@ -4,6 +4,7 @@ import SwiftUI
 
 struct RecentlyInlineComposerView: View {
     @Bindable var store: RecentlyComposerStore
+    @Environment(\.accessibilityReduceTransparency) private var reduceTransparency
     @FocusState private var inputFocused: Bool
 
     var body: some View {
@@ -12,21 +13,23 @@ struct RecentlyInlineComposerView: View {
                 editingBanner
             }
 
-            metadataTray
+            if !store.isShowingComposerPanel {
+                metadataTray
 
-            if let error = store.errorMessage {
-                Label(error, systemImage: "exclamationmark.triangle")
-                    .font(.caption)
-                    .foregroundStyle(Color(SpacePalette.danger))
-                    .frame(maxWidth: .infinity, alignment: .leading)
-                    .lineLimit(2)
-                    .accessibilityIdentifier("recently.composer.error")
+                if let error = store.errorMessage {
+                    Label(error, systemImage: "exclamationmark.triangle")
+                        .font(.caption)
+                        .foregroundStyle(Color(SpacePalette.danger))
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                        .lineLimit(2)
+                        .accessibilityIdentifier("recently.composer.error")
+                }
             }
 
             inputRow
         }
-        .padding(.horizontal, Spacing.regular)
-        .padding(.vertical, Spacing.small)
+        .padding(.horizontal, Spacing.small)
+        .padding(.vertical, Spacing.xSmall)
         .onChange(of: store.text) { _, _ in
             store.textDidChange()
         }
@@ -43,101 +46,9 @@ struct RecentlyInlineComposerView: View {
 
     @ViewBuilder
     private var metadataTray: some View {
-        if store.context != nil || store.isChoosingContext || !store.links.isEmpty {
-            VStack(spacing: Spacing.xSmall) {
-                if store.isChoosingContext {
-                    contextCandidates
-                } else if let context = store.context {
-                    RecentlyContextCardView(context: context) {
-                        store.removeContext()
-                    }
-                }
-
-                if !store.links.isEmpty {
-                    ScrollView(.horizontal) {
-                        LazyHStack(spacing: Spacing.small) {
-                            ForEach(store.links) { preview in
-                                ComposerLinkSelectionCard(preview: preview) {
-                                    store.toggleLink(preview.url)
-                                }
-                            }
-                        }
-                    }
-                    .scrollIndicators(.hidden)
-                    .frame(height: 84)
-                    .accessibilityLabel("Link enrichments")
-                }
-            }
-            .frame(maxHeight: 140)
-            .clipped()
+        if store.context != nil || !store.selectedLinks.isEmpty {
+            RecentlyComposerSelectionTray(store: store)
         }
-    }
-
-    private var contextCandidates: some View {
-        ScrollView(.horizontal) {
-            LazyHStack(spacing: Spacing.small) {
-                HStack(spacing: Spacing.small) {
-                    Image(systemName: "magnifyingglass")
-                        .font(.caption)
-                        .foregroundStyle(Color(SpacePalette.subtle))
-                    TextField("Find context", text: $store.contextSearch)
-                        .textInputAutocapitalization(.never)
-                        .autocorrectionDisabled()
-                        .font(.caption)
-                }
-                .padding(.horizontal, Spacing.medium)
-                .frame(width: 142, height: 44)
-                .background(Color(SpacePalette.inset), in: .rect(cornerRadius: Radius.control))
-
-                if store.isLoadingContexts {
-                    ProgressView()
-                        .frame(width: 44, height: 44)
-                        .accessibilityLabel("Loading context")
-                } else if store.contextCandidates.isEmpty {
-                    Text("No matches")
-                        .font(.caption)
-                        .foregroundStyle(Color(SpacePalette.subtle))
-                        .frame(height: 44)
-                } else {
-                    ForEach(store.contextCandidates) { candidate in
-                        Button {
-                            store.selectContext(candidate)
-                        } label: {
-                            HStack(spacing: Spacing.small) {
-                                Image(systemName: candidate.kind.systemImage)
-                                    .foregroundStyle(Color(SpacePalette.accent))
-                                VStack(alignment: .leading, spacing: 1) {
-                                    Text(candidate.kind.title)
-                                        .font(.caption2)
-                                        .foregroundStyle(Color(SpacePalette.subtle))
-                                    Text(candidate.title)
-                                        .font(.caption.weight(.medium))
-                                        .foregroundStyle(Color(SpacePalette.primary))
-                                        .lineLimit(1)
-                                }
-                            }
-                            .padding(.horizontal, Spacing.medium)
-                            .frame(width: 174, height: 44, alignment: .leading)
-                            .background(
-                                Color(SpacePalette.inset),
-                                in: .rect(cornerRadius: Radius.control)
-                            )
-                            .overlay {
-                                RoundedRectangle(cornerRadius: Radius.control, style: .continuous)
-                                    .stroke(Color(.separator).opacity(0.4), lineWidth: 0.5)
-                            }
-                        }
-                        .buttonStyle(.plain)
-                        .accessibilityIdentifier(
-                            "recently.composer.context.candidate.\(candidate.kind.rawValue).\(candidate.id)"
-                        )
-                    }
-                }
-            }
-        }
-        .scrollIndicators(.hidden)
-        .frame(height: 44)
-        .accessibilityLabel("Choose context")
     }
 
     private var editingBanner: some View {
@@ -156,170 +67,176 @@ struct RecentlyInlineComposerView: View {
         .frame(minHeight: 24)
     }
 
+    private func executeSlashCommand(_ command: RecentlySlashCommand) {
+        store.executeSlashCommand(command)
+    }
+
     private var inputRow: some View {
-        HStack(alignment: .bottom, spacing: Spacing.small) {
-            Button("Choose context", systemImage: "paperclip") {
+        HStack(alignment: .bottom, spacing: Spacing.xSmall) {
+            Button {
                 store.toggleContextPicker()
-                inputFocused = true
+            } label: {
+                Image(systemName: "paperclip")
+                    .font(.system(size: 22, weight: .medium))
+                    .foregroundStyle(
+                        store.context != nil || store.isChoosingContext || !store.links.isEmpty
+                            ? Color(SpacePalette.accent)
+                            : Color(SpacePalette.primary)
+                    )
+                    .frame(width: 44, height: 44)
+                    .background {
+                        if reduceTransparency {
+                            Circle().fill(Color(SpacePalette.surface))
+                        } else {
+                            Circle()
+                                .fill(.clear)
+                                .glassEffect(.regular.interactive(), in: Circle())
+                        }
+                    }
+                    .overlay {
+                        Circle()
+                            .stroke(Color.white.opacity(0.52), lineWidth: 0.5)
+                    }
+                    .contentShape(Circle())
             }
-            .labelStyle(.iconOnly)
-            .font(.body.weight(.medium))
-            .buttonStyle(.glass)
-            .tint(
-                store.context != nil || store.isChoosingContext
-                    ? Color(SpacePalette.accent)
-                    : Color(SpacePalette.muted)
-            )
-            .frame(width: 44, height: 44)
+            .buttonStyle(.plain)
+            .accessibilityLabel("Add context or media")
+            .accessibilityHint("Search internal context or TMDB")
             .accessibilityIdentifier("recently.composer.context")
 
-            TextField("Share something…", text: $store.text, axis: .vertical)
-                .lineLimit(1 ... 6)
-                .focused($inputFocused)
-                .font(.body)
-                .composerFieldSurface()
-                .accessibilityIdentifier("recently.composer.text")
+            HStack(alignment: .bottom, spacing: 0) {
+                TextField(inputPlaceholder, text: inputText, axis: .vertical)
+                    .lineLimit(store.isChoosingContext ? 1 ... 1 : 1 ... 6)
+                    .focused($inputFocused)
+                    .font(.body)
+                    .autocorrectionDisabled(store.isChoosingContext)
+                    .padding(.leading, 14)
+                    .padding(.vertical, 10)
+                    .frame(minHeight: 44, alignment: .leading)
+                    .layoutPriority(1)
+                    .onSubmit {
+                        guard !store.isChoosingContext else { return }
+                        if let command = store.slashCommands.first {
+                            executeSlashCommand(command)
+                        }
+                    }
+                    .accessibilityIdentifier(
+                        store.isChoosingContext
+                            ? "recently.composer.attachment.search"
+                            : "recently.composer.text"
+                    )
 
+                if store.isChoosingContext {
+                    searchTrailingControl
+                } else {
+                    submitButton
+                }
+            }
+            .background {
+                let shape = RoundedRectangle(
+                    cornerRadius: Radius.composer,
+                    style: .continuous
+                )
+                if reduceTransparency {
+                    shape.fill(Color(SpacePalette.inset))
+                } else {
+                    shape
+                        .fill(.clear)
+                        .glassEffect(.regular, in: shape)
+                }
+            }
+            .overlay {
+                RoundedRectangle(cornerRadius: Radius.composer, style: .continuous)
+                    .stroke(Color.white.opacity(0.42), lineWidth: 0.5)
+            }
+        }
+    }
+
+    private var inputText: Binding<String> {
+        Binding(
+            get: { store.isChoosingContext ? store.contextSearch : store.text },
+            set: { value in
+                if store.isChoosingContext {
+                    store.contextSearch = value
+                } else {
+                    store.text = value
+                }
+            }
+        )
+    }
+
+    private var inputPlaceholder: String {
+        store.isChoosingContext ? store.attachmentSearchPlaceholder : "Share something…"
+    }
+
+    @ViewBuilder
+    private var searchTrailingControl: some View {
+        if store.contextSearch.isEmpty {
+            Image(systemName: "magnifyingglass")
+                .font(.system(size: 17, weight: .semibold))
+                .foregroundStyle(Color(SpacePalette.subtle))
+                .frame(width: 44, height: 44)
+                .accessibilityHidden(true)
+        } else {
+            Button("Clear search", systemImage: "xmark.circle.fill") {
+                store.contextSearch = ""
+            }
+            .labelStyle(.iconOnly)
+            .buttonStyle(.plain)
+            .font(.system(size: 17, weight: .semibold))
+            .foregroundStyle(Color(SpacePalette.subtle))
+            .frame(width: 44, height: 44)
+            .contentShape(.rect)
+        }
+    }
+
+    private var submitButton: some View {
+        Button {
+            if let command = store.slashCommands.first {
+                executeSlashCommand(command)
+            } else {
+                Task { await store.submit() }
+            }
+        } label: {
             Group {
                 if store.isSaving {
                     ProgressView()
-                        .frame(width: 44, height: 44)
+                        .controlSize(.small)
                 } else {
-                    Button(store.isEditing ? "Save" : "Publish", systemImage: "arrow.up") {
-                        Task { await store.submit() }
-                    }
-                    .labelStyle(.iconOnly)
-                    .font(.body.weight(.semibold))
-                    .buttonStyle(.glassProminent)
-                    .tint(Color(SpacePalette.accent))
-                    .disabled(!store.canSubmit)
-                    .frame(width: 44, height: 44)
-                    .accessibilityIdentifier("recently.composer.post")
+                    Image(systemName: "paperplane.fill")
                 }
             }
-        }
-    }
-}
-
-private struct ComposerLinkSelectionCard: View {
-    let preview: ComposerLinkPreview
-    let toggle: () -> Void
-
-    var body: some View {
-        Button(action: toggle) {
-            Group {
-                if let card = preview.card {
-                    switch card.variant {
-                    case .poster:
-                        poster(card)
-                    case .fallback:
-                        fallback(card)
-                    }
+            .font(.system(size: 17, weight: .semibold))
+            .foregroundStyle(.white)
+            .frame(width: 40, height: 40)
+            .background {
+                let tint = store.canSubmit || store.isSaving
+                    ? Color(SpacePalette.accent)
+                    : Color(SpacePalette.subtle).opacity(0.18)
+                if reduceTransparency {
+                    Circle().fill(tint)
                 } else {
-                    unresolved
+                    Circle()
+                        .fill(.clear)
+                        .glassEffect(.regular.tint(tint).interactive(), in: Circle())
                 }
             }
-            .frame(width: 184, height: 80)
-            .background(Color(SpacePalette.inset), in: .rect(cornerRadius: Radius.control))
             .overlay {
-                RoundedRectangle(cornerRadius: Radius.control, style: .continuous)
-                    .stroke(
-                        preview.isSelected
-                            ? Color(SpacePalette.accent)
-                            : Color(.separator).opacity(0.5),
-                        lineWidth: preview.isSelected ? 2 : 0.5
-                    )
+                Circle()
+                    .stroke(Color.white.opacity(0.58), lineWidth: 0.5)
             }
-            .overlay(alignment: .topTrailing) {
-                Image(systemName: preview.isSelected ? "checkmark.circle.fill" : "circle")
-                    .font(.caption)
-                    .foregroundStyle(
-                        preview.isSelected
-                            ? Color(SpacePalette.accent)
-                            : Color(SpacePalette.subtle)
-                    )
-                    .padding(6)
-            }
-            .opacity(preview.isSelected ? 1 : 0.58)
-            .contentShape(.rect)
         }
         .buttonStyle(.plain)
-        .accessibilityIdentifier("recently.composer.enrichment")
-        .accessibilityLabel("\(preview.card?.title ?? preview.url), link enrichment")
-        .accessibilityValue(preview.isSelected ? "Selected" : "Not selected")
+        .frame(width: 44, height: 44)
+        .contentShape(.rect)
+        .disabled(!store.canSubmit)
+        .accessibilityLabel(submitAccessibilityLabel)
+        .accessibilityIdentifier("recently.composer.post")
     }
 
-    private func poster(_ card: MediaCard) -> some View {
-        HStack(spacing: Spacing.small) {
-            ComposerArtwork(url: card.artworkURL, accent: card.accent)
-                .frame(width: 52, height: 80)
-            copy(card)
-                .padding(.trailing, Spacing.small)
-        }
-    }
-
-    private func fallback(_ card: MediaCard) -> some View {
-        HStack(spacing: Spacing.small) {
-            copy(card)
-                .padding(.leading, Spacing.medium)
-            if card.artworkURL != nil {
-                ComposerArtwork(url: card.artworkURL, accent: card.accent)
-                    .frame(width: 52, height: 52)
-                    .clipShape(.rect(cornerRadius: 8))
-                    .padding(.trailing, Spacing.small)
-            }
-        }
-    }
-
-    private func copy(_ card: MediaCard) -> some View {
-        VStack(alignment: .leading, spacing: 2) {
-            Text(card.category.uppercased())
-                .font(.system(size: 9, weight: .semibold))
-                .tracking(0.8)
-                .foregroundStyle(Color(SpacePalette.subtle))
-            Text(card.title)
-                .font(.caption.weight(.semibold))
-                .foregroundStyle(Color(SpacePalette.primary))
-                .lineLimit(2)
-            Text(card.host ?? card.metaLine)
-                .font(.caption2)
-                .foregroundStyle(Color(SpacePalette.muted))
-                .lineLimit(1)
-        }
-        .frame(maxWidth: .infinity, alignment: .leading)
-    }
-
-    private var unresolved: some View {
-        HStack(spacing: Spacing.medium) {
-            Image(systemName: "link")
-                .font(.title3)
-                .foregroundStyle(Color(SpacePalette.muted))
-            VStack(alignment: .leading, spacing: Spacing.xSmall) {
-                Text(URL(string: preview.url)?.host() ?? "Link")
-                    .font(.caption.weight(.semibold))
-                    .foregroundStyle(Color(SpacePalette.primary))
-                    .lineLimit(1)
-                Text(preview.isResolving ? "Resolving…" : "No rich preview")
-                    .font(.caption2)
-                    .foregroundStyle(Color(SpacePalette.subtle))
-            }
-            Spacer(minLength: 0)
-            if preview.isResolving { ProgressView().controlSize(.small) }
-        }
-        .padding(.horizontal, Spacing.medium)
-    }
-}
-
-private struct ComposerArtwork: View {
-    let url: URL?
-    let accent: Color
-
-    var body: some View {
-        AsyncImage(url: url) { image in
-            image.resizable().scaledToFill()
-        } placeholder: {
-            Rectangle().fill(accent.opacity(0.18))
-        }
-        .clipped()
+    private var submitAccessibilityLabel: String {
+        if store.isSaving { return "Publishing" }
+        if let command = store.slashCommands.first { return "Run \(command.title)" }
+        return store.isEditing ? "Save" : "Publish"
     }
 }

--- a/apps/ios/Space/Recently/RecentlySlashCommand.swift
+++ b/apps/ios/Space/Recently/RecentlySlashCommand.swift
@@ -1,0 +1,89 @@
+import SpaceCore
+
+enum RecentlySlashCommand: String, CaseIterable, Identifiable {
+    enum SearchScope {
+        case context
+        case tmdb
+    }
+
+    struct Invocation {
+        let range: Range<String.Index>
+        let query: String
+    }
+
+    case tmdb
+    case context
+    case post
+    case note
+    case page
+    case recently
+
+    var id: String { rawValue }
+    var title: String { "/\(rawValue)" }
+
+    var detailTitle: String {
+        switch self {
+        case .tmdb: "Search TMDB"
+        case .context: "Search Space"
+        case .post: "Find a post"
+        case .note: "Find a note"
+        case .page: "Find a page"
+        case .recently: "Find a Recently entry"
+        }
+    }
+
+    var summary: String {
+        switch self {
+        case .tmdb: "Search movies and TV"
+        case .context: "Attach any Space content"
+        case .post: "Find a post"
+        case .note: "Find a note"
+        case .page: "Find a page"
+        case .recently: "Reference a Recently entry"
+        }
+    }
+
+    var systemImage: String {
+        switch self {
+        case .tmdb: "film.stack.fill"
+        case .context: "link"
+        case .post: "doc.text.fill"
+        case .note: "note.text"
+        case .page: "doc.fill"
+        case .recently: "text.bubble.fill"
+        }
+    }
+
+    var searchScope: SearchScope {
+        self == .tmdb ? .tmdb : .context
+    }
+
+    var contextKind: RecentlyContext.Kind? {
+        switch self {
+        case .tmdb, .context: nil
+        case .post: .post
+        case .note: .note
+        case .page: .page
+        case .recently: .recently
+        }
+    }
+
+    static func invocation(in text: String) -> Invocation? {
+        guard !text.isEmpty else { return nil }
+
+        let start = text.lastIndex(where: \.isWhitespace)
+            .map { text.index(after: $0) } ?? text.startIndex
+        guard start < text.endIndex, text[start] == "/" else { return nil }
+
+        let queryStart = text.index(after: start)
+        let query = String(text[queryStart...]).lowercased()
+        guard query.allSatisfy(\.isLetter) else { return nil }
+
+        return Invocation(range: start ..< text.endIndex, query: query)
+    }
+
+    static func suggestions(for text: String) -> [Self] {
+        guard let invocation = invocation(in: text) else { return [] }
+        return allCases.filter { $0.rawValue.hasPrefix(invocation.query) }
+    }
+}

--- a/apps/ios/Space/Recently/RecentlySlashMenuView.swift
+++ b/apps/ios/Space/Recently/RecentlySlashMenuView.swift
@@ -1,0 +1,76 @@
+import SpaceUI
+import SwiftUI
+
+struct RecentlySlashMenuView: View {
+    let commands: [RecentlySlashCommand]
+    let onSelect: (RecentlySlashCommand) -> Void
+
+    @Environment(\.accessibilityReduceTransparency) private var reduceTransparency
+
+    private let rowHeight: CGFloat = 44
+
+    var body: some View {
+        ScrollView {
+            LazyVStack(spacing: 0) {
+                ForEach(Array(commands.enumerated()), id: \.element.id) { index, command in
+                    commandRow(command)
+                        .overlay(alignment: .bottom) {
+                            if index < commands.count - 1 {
+                                Divider()
+                                    .padding(.leading, 40)
+                            }
+                        }
+                }
+            }
+        }
+        .scrollIndicators(.hidden)
+        .frame(height: min(CGFloat(commands.count) * rowHeight, rowHeight * 5))
+        .background {
+            let shape = RoundedRectangle(cornerRadius: Radius.sheet, style: .continuous)
+            if reduceTransparency {
+                shape.fill(Color(SpacePalette.surface))
+            } else {
+                shape
+                    .fill(.clear)
+                    .glassEffect(.regular, in: shape)
+            }
+        }
+        .clipShape(.rect(cornerRadius: Radius.sheet, style: .continuous))
+        .accessibilityIdentifier("recently.composer.slash.menu")
+    }
+
+    private func commandRow(_ command: RecentlySlashCommand) -> some View {
+        Button {
+            onSelect(command)
+        } label: {
+            HStack(spacing: Spacing.small) {
+                Image(systemName: command.systemImage)
+                    .font(.system(size: 17, weight: .medium))
+                    .foregroundStyle(Color(SpacePalette.accent))
+                    .frame(width: 24)
+
+                HStack(alignment: .firstTextBaseline, spacing: 5) {
+                    Text(command.title)
+                        .font(.subheadline.weight(.semibold))
+                        .foregroundStyle(Color(SpacePalette.primary))
+                    Text(command.summary)
+                        .font(.caption)
+                        .foregroundStyle(Color(SpacePalette.subtle))
+                        .lineLimit(1)
+                }
+                .frame(maxWidth: .infinity, alignment: .leading)
+
+                Image(systemName: "chevron.right")
+                    .font(.caption2.weight(.semibold))
+                    .foregroundStyle(Color(SpacePalette.subtle).opacity(0.72))
+            }
+            .padding(.horizontal, Spacing.medium)
+            .frame(height: rowHeight)
+            .contentShape(.rect)
+        }
+        .buttonStyle(.plain)
+        .accessibilityIdentifier("recently.composer.slash.\(command.rawValue)")
+        .accessibilityLabel("\(command.title), \(command.summary)")
+        .accessibilityHint("Opens the corresponding search")
+    }
+}

--- a/apps/ios/Space/Recently/RecentlyViewController.swift
+++ b/apps/ios/Space/Recently/RecentlyViewController.swift
@@ -17,6 +17,7 @@ final class RecentlyViewController: UIViewController {
         onSaved: { [weak self] in self?.applySnapshot() }
     )
     private var composerController: UIHostingController<RecentlyInlineComposerView>!
+    private var composerPanelController: UIHostingController<RecentlyComposerPanelView>!
     private var collectionView: UICollectionView!
     private var dataSource: UICollectionViewDiffableDataSource<Section, String>!
     private let refreshControl = UIRefreshControl()
@@ -60,6 +61,24 @@ final class RecentlyViewController: UIViewController {
         ])
         controller.didMove(toParent: self)
         composerController = controller
+
+        let panelController = UIHostingController(
+            rootView: RecentlyComposerPanelView(store: composerStore)
+        )
+        panelController.sizingOptions = .intrinsicContentSize
+        panelController.view.backgroundColor = .clear
+        panelController.view.setContentCompressionResistancePriority(.required, for: .vertical)
+
+        addChild(panelController)
+        view.addSubview(panelController.view)
+        panelController.view.translatesAutoresizingMaskIntoConstraints = false
+        NSLayoutConstraint.activate([
+            panelController.view.leadingAnchor.constraint(equalTo: view.leadingAnchor),
+            panelController.view.trailingAnchor.constraint(equalTo: view.trailingAnchor),
+            panelController.view.bottomAnchor.constraint(equalTo: controller.view.topAnchor),
+        ])
+        panelController.didMove(toParent: self)
+        composerPanelController = panelController
     }
 
     private func configureCollectionView() {
@@ -89,6 +108,9 @@ final class RecentlyViewController: UIViewController {
             collectionView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
             collectionView.bottomAnchor.constraint(equalTo: composerController.view.topAnchor),
         ])
+
+        view.bringSubviewToFront(composerPanelController.view)
+        view.bringSubviewToFront(composerController.view)
 
         let registration = UICollectionView.CellRegistration<UICollectionViewListCell, RecentlyCard> {
             [weak self] cell, _, entry in
@@ -156,10 +178,10 @@ final class RecentlyViewController: UIViewController {
         }
 
         var configuration = UIContentUnavailableConfiguration.empty()
-        if let message = store.errorMessage {
+        if store.errorMessage != nil {
             configuration.image = UIImage(systemName: "exclamationmark.triangle")
             configuration.text = "Could not load Recently"
-            configuration.secondaryText = message
+            configuration.secondaryText = "Check the Space server connection, then try again."
             var retry = UIButton.Configuration.glass()
             retry.title = "Retry"
             retry.cornerStyle = .capsule

--- a/apps/ios/SpaceUITests/PairingFlowUITests.swift
+++ b/apps/ios/SpaceUITests/PairingFlowUITests.swift
@@ -191,6 +191,51 @@ final class PairingFlowUITests: XCTestCase {
         settle(0.5)
         capture(app, name: "31-composer-keyboard-empty")
 
+        editor.typeText("/")
+        XCTAssertTrue(
+            app.descendants(matching: .any)["recently.composer.slash.menu"]
+                .waitForExistence(timeout: 5),
+            "slash menu did not open"
+        )
+        XCTAssertTrue(app.buttons["recently.composer.slash.tmdb"].exists)
+        XCTAssertTrue(app.buttons["recently.composer.slash.context"].exists)
+        capture(app, name: "31a-composer-slash-menu")
+
+        editor.typeText("tm")
+        XCTAssertTrue(
+            app.buttons["recently.composer.slash.tmdb"].waitForExistence(timeout: 5),
+            "slash menu did not filter to TMDB"
+        )
+        XCTAssertFalse(app.buttons["recently.composer.slash.context"].exists)
+        let tmdbCommand = app.buttons["recently.composer.slash.tmdb"]
+        XCTAssertTrue(tmdbCommand.isHittable, "the visible TMDB command was not tappable")
+        tmdbCommand.tap()
+
+        let tmdbSearch = app.textFields["recently.composer.attachment.search"]
+        XCTAssertTrue(
+            tmdbSearch.waitForExistence(timeout: 5),
+            "the TMDB command did not open attachment search"
+        )
+        XCTAssertTrue(
+            app.descendants(matching: .any)["recently.composer.command.detail"].exists,
+            "the command detail panel did not appear"
+        )
+        XCTAssertTrue(
+            app.keyboards.firstMatch.waitForExistence(timeout: 5),
+            "command search did not retain the keyboard"
+        )
+        capture(app, name: "31b-composer-slash-tmdb")
+
+        app.buttons["recently.composer.command.back"].tap()
+        XCTAssertTrue(
+            app.descendants(matching: .any)["recently.composer.slash.menu"]
+                .waitForExistence(timeout: 5),
+            "command detail did not return to the slash menu"
+        )
+        app.buttons["recently.composer.slash.tmdb"].tap()
+        XCTAssertTrue(tmdbSearch.waitForExistence(timeout: 5))
+        app.buttons["recently.composer.command.close"].tap()
+
         let message =
             "Local verification confirms that the keyboard-bound composer grows naturally "
             + "while metadata remains visible above the input. "
@@ -199,7 +244,7 @@ final class PairingFlowUITests: XCTestCase {
         capture(app, name: "32-composer-auto-size")
 
         app.buttons["recently.composer.context"].tap()
-        let contextSearch = app.textFields["Find context"]
+        let contextSearch = app.textFields["recently.composer.attachment.search"]
         XCTAssertTrue(
             contextSearch.waitForExistence(timeout: 15),
             "context picker never appeared"
@@ -214,9 +259,9 @@ final class PairingFlowUITests: XCTestCase {
         XCTAssertTrue(context.waitForExistence(timeout: 15), "seeded note context is missing")
         context.tap()
         XCTAssertTrue(
-            app.staticTexts["Note context, Keyboard composer field notes"]
+            app.descendants(matching: .any)["recently.composer.selection.context"]
                 .waitForExistence(timeout: 10),
-            "selected context card never appeared"
+            "selected context receipt never appeared"
         )
         capture(app, name: "34-composer-context-selected")
 


### PR DESCRIPTION
## Summary

- add authenticated, throttled TMDB text search to the enrichment API
- redesign the Recently composer around a compact native Glass slash menu and command detail flow
- fix command-item hit testing and preserve selected TMDB attachments in the composer

## Validation

- Core enrichment tests: 55 passed
- SpaceCore RecentlyService tests: 14 passed
- Core OpenAPI contract check passed
- Core TypeScript check passed
- iOS Simulator build passed
- Simulator interaction smoke test passed for menu selection, keyboard retention, back navigation, and dismissal

## Notes

The local test environment could not perform a live external TMDB request; the request and normalization path is covered by focused Core and SpaceCore tests.