### PR TITLE
feat(auth): app review demo account for Apple sign-in review

### DIFF
--- a/apps/admin/src/api/auth.ts
+++ b/apps/admin/src/api/auth.ts
@@ -1,6 +1,5 @@
-import type { TokenModel } from '~/models/token'
-
 import { translate } from '~/i18n/translate'
+import type { TokenModel } from '~/models/token'
 import { authClient } from '~/utils/authjs/auth'
 
 import { getJson, postJson, requestJson } from './http'
@@ -23,8 +22,17 @@ export interface LoggedStatus {
   ok: boolean | number
 }
 
+export type ReviewDemoResponse =
+  | { enabled: false }
+  | { enabled: true; email: string; password: string }
+  | { enabled: true; email: string; error: 'provision_failed' }
+
 export function checkLogged() {
   return getJson<LoggedStatus>('/owner/check_logged')
+}
+
+export function getReviewDemo() {
+  return getJson<ReviewDemoResponse>('/auth/review-demo')
 }
 
 export function getTokens() {

--- a/apps/admin/src/features/settings/components/account/OauthProviderSection.tsx
+++ b/apps/admin/src/features/settings/components/account/OauthProviderSection.tsx
@@ -1,9 +1,12 @@
+import { useQuery } from '@tanstack/react-query'
 import { Copy } from 'lucide-react'
 import { useEffect, useState } from 'react'
 import { toast } from 'sonner'
 
+import { getReviewDemo } from '~/api/auth'
 import { API_URL } from '~/constants/env'
 import { useI18n } from '~/i18n'
+import { adminQueryKeys } from '~/query/keys'
 import { Button } from '~/ui/primitives/button'
 import { Switch } from '~/ui/primitives/switch'
 import { TextArea, TextInput } from '~/ui/primitives/text-field'
@@ -45,13 +48,23 @@ export function OauthProviderSection(props: {
 }) {
   const { t } = useI18n()
   const [enabled, setEnabled] = useState(props.data.enabled)
+  const [reviewDemoEnabled, setReviewDemoEnabled] = useState(
+    props.data.public.reviewDemoEnabled === 'true',
+  )
   const [values, setValues] = useState(() =>
     initialValues(props.fields, props.data),
   )
   const callbackUrl = `${API_URL}/auth/callback/${props.type}`
+  const savedReviewDemo = props.data.public.reviewDemoEnabled === 'true'
+  const reviewDemoQuery = useQuery({
+    enabled: props.type === 'apple' && savedReviewDemo,
+    queryFn: getReviewDemo,
+    queryKey: adminQueryKeys.settings.reviewDemo(),
+  })
 
   useEffect(() => {
     setEnabled(props.data.enabled)
+    setReviewDemoEnabled(props.data.public.reviewDemoEnabled === 'true')
     setValues(initialValues(props.fields, props.data))
   }, [props.data, props.fields])
 
@@ -87,6 +100,9 @@ export function OauthProviderSection(props: {
         payload.public[field.key] = value
       }
     }
+    if (props.type === 'apple') {
+      payload.public.reviewDemoEnabled = reviewDemoEnabled ? 'true' : ''
+    }
     props.onSave(payload)
   }
 
@@ -121,26 +137,64 @@ export function OauthProviderSection(props: {
           const onChange = (value: string) =>
             setValues((prev) => ({ ...prev, [field.key]: value }))
 
-          return field.multiline ? (
-            <TextArea
-              key={field.key}
-              label={field.label}
-              onChange={onChange}
-              placeholder={placeholder}
-              spellCheck={false}
-              value={values[field.key] ?? ''}
-            />
-          ) : (
-            <TextInput
-              key={field.key}
-              label={field.label}
-              onChange={onChange}
-              placeholder={placeholder}
-              type={field.secret ? 'password' : 'text'}
-              value={values[field.key] ?? ''}
-            />
+          return (
+            <div className="grid gap-1.5" key={field.key}>
+              {field.multiline ? (
+                <TextArea
+                  label={field.label}
+                  onChange={onChange}
+                  placeholder={placeholder}
+                  spellCheck={false}
+                  value={values[field.key] ?? ''}
+                />
+              ) : (
+                <TextInput
+                  label={field.label}
+                  onChange={onChange}
+                  placeholder={placeholder}
+                  type={field.secret ? 'password' : 'text'}
+                  value={values[field.key] ?? ''}
+                />
+              )}
+              {field.descriptionKey ? (
+                <p className="text-xs leading-5 text-fg-muted">
+                  {t(field.descriptionKey)}
+                </p>
+              ) : null}
+            </div>
           )
         })}
+
+        {props.type === 'apple' ? (
+          <div className="grid gap-3">
+            <Switch
+              checked={reviewDemoEnabled}
+              description={t('settings.oauth.reviewDemo.helper')}
+              label={t('settings.oauth.reviewDemo.switch')}
+              onCheckedChange={setReviewDemoEnabled}
+            />
+            {savedReviewDemo && reviewDemoQuery.data?.enabled === true ? (
+              'password' in reviewDemoQuery.data ? (
+                <>
+                  <ReviewDemoSecretRow
+                    ariaLabel={t('settings.oauth.reviewDemo.copyEmailAria')}
+                    label={t('settings.oauth.reviewDemo.email')}
+                    value={reviewDemoQuery.data.email}
+                  />
+                  <ReviewDemoSecretRow
+                    ariaLabel={t('settings.oauth.reviewDemo.copyPasswordAria')}
+                    label={t('settings.oauth.reviewDemo.password')}
+                    value={reviewDemoQuery.data.password}
+                  />
+                </>
+              ) : (
+                <p className="text-sm text-neutral-600 dark:text-neutral-300">
+                  {t('settings.oauth.reviewDemo.provisionFailed')}
+                </p>
+              )
+            ) : null}
+          </div>
+        ) : null}
 
         <div className="grid gap-1.5 text-sm">
           <span className="text-neutral-600 dark:text-neutral-300">
@@ -163,6 +217,11 @@ export function OauthProviderSection(props: {
               <Copy aria-hidden="true" className="size-3.5" />
             </Button>
           </div>
+          {props.type === 'apple' ? (
+            <p className="text-xs leading-5 text-fg-muted">
+              {t('settings.oauth.apple.callbackHelp')}
+            </p>
+          ) : null}
         </div>
 
         <div className="flex justify-end gap-2">
@@ -179,5 +238,37 @@ export function OauthProviderSection(props: {
         </div>
       </div>
     </section>
+  )
+}
+
+function ReviewDemoSecretRow(props: {
+  ariaLabel: string
+  label: string
+  value: string
+}) {
+  const { t } = useI18n()
+  return (
+    <div className="grid gap-1.5 text-sm">
+      <span className="text-neutral-600 dark:text-neutral-300">
+        {props.label}
+      </span>
+      <div className="flex items-center gap-2 rounded bg-neutral-50 px-3 py-2 dark:bg-neutral-900">
+        <code className="min-w-0 flex-1 truncate text-xs text-neutral-600 dark:text-neutral-300">
+          {props.value}
+        </code>
+        <Button
+          aria-label={props.ariaLabel}
+          className="h-7 px-2"
+          onClick={() => {
+            void navigator.clipboard.writeText(props.value)
+            toast.success(t('settings.oauth.copySuccess'))
+          }}
+          type="button"
+          variant="subtle"
+        >
+          <Copy aria-hidden="true" className="size-3.5" />
+        </Button>
+      </div>
+    </div>
   )
 }

--- a/apps/admin/src/features/settings/components/account/OauthProviderSection.tsx
+++ b/apps/admin/src/features/settings/components/account/OauthProviderSection.tsx
@@ -57,7 +57,7 @@ export function OauthProviderSection(props: {
   const callbackUrl = `${API_URL}/auth/callback/${props.type}`
   const savedReviewDemo = props.data.public.reviewDemoEnabled === 'true'
   const reviewDemoQuery = useQuery({
-    enabled: props.type === 'apple' && savedReviewDemo,
+    enabled: props.type === 'apple' && savedReviewDemo && reviewDemoEnabled,
     queryFn: getReviewDemo,
     queryKey: adminQueryKeys.settings.reviewDemo(),
   })
@@ -173,7 +173,9 @@ export function OauthProviderSection(props: {
               label={t('settings.oauth.reviewDemo.switch')}
               onCheckedChange={setReviewDemoEnabled}
             />
-            {savedReviewDemo && reviewDemoQuery.data?.enabled === true ? (
+            {savedReviewDemo &&
+            reviewDemoEnabled &&
+            reviewDemoQuery.data?.enabled === true ? (
               'password' in reviewDemoQuery.data ? (
                 <>
                   <ReviewDemoSecretRow

--- a/apps/admin/src/features/settings/components/account/OauthSection.tsx
+++ b/apps/admin/src/features/settings/components/account/OauthSection.tsx
@@ -33,7 +33,12 @@ export function OauthSection() {
       toast.error(getErrorMessage(error, t('settings.oauth.error.save'))),
     onSuccess: async () => {
       toast.success(t('settings.oauth.success.save'))
-      await queryClient.invalidateQueries({ queryKey: accountQueryKey })
+      await Promise.all([
+        queryClient.invalidateQueries({ queryKey: accountQueryKey }),
+        queryClient.invalidateQueries({
+          queryKey: adminQueryKeys.settings.reviewDemo(),
+        }),
+      ])
     },
   })
 

--- a/apps/admin/src/features/settings/constants.ts
+++ b/apps/admin/src/features/settings/constants.ts
@@ -138,10 +138,26 @@ export const oauthProviders: Array<{
   { fields: clientCredentialFields, label: 'Google', type: 'google' },
   {
     fields: [
-      { key: 'clientId', label: 'Services ID', placeholder: 'dev.example.web' },
-      { key: 'teamId', label: 'Team ID', placeholder: 'ABCDE12345' },
-      { key: 'keyId', label: 'Key ID', placeholder: 'ABC1234567' },
       {
+        descriptionKey: 'settings.oauth.apple.servicesIdHelp',
+        key: 'clientId',
+        label: 'Services ID',
+        placeholder: 'dev.example.web',
+      },
+      {
+        descriptionKey: 'settings.oauth.apple.teamIdHelp',
+        key: 'teamId',
+        label: 'Team ID',
+        placeholder: 'ABCDE12345',
+      },
+      {
+        descriptionKey: 'settings.oauth.apple.keyIdHelp',
+        key: 'keyId',
+        label: 'Key ID',
+        placeholder: 'ABC1234567',
+      },
+      {
+        descriptionKey: 'settings.oauth.apple.privateKeyHelp',
         key: 'privateKey',
         label: 'Private Key (.p8)',
         multiline: true,
@@ -149,6 +165,7 @@ export const oauthProviders: Array<{
         secret: true,
       },
       {
+        descriptionKey: 'settings.oauth.apple.bundleIdHelp',
         key: 'appBundleIdentifier',
         label: 'App Bundle ID',
         optional: true,

--- a/apps/admin/src/features/settings/types/settings.ts
+++ b/apps/admin/src/features/settings/types/settings.ts
@@ -115,6 +115,7 @@ export interface OauthOptions {
 }
 
 export interface OauthProviderField {
+  descriptionKey?: TranslationKey
   key: string
   label: string
   multiline?: boolean

--- a/apps/admin/src/features/settings/utils/oauth.test.ts
+++ b/apps/admin/src/features/settings/utils/oauth.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from 'vitest'
+
+import { flattenOauthOptions } from './oauth'
+
+describe('flattenOauthOptions', () => {
+  it('does not treat reviewDemoEnabled as Apple being configured', () => {
+    const flat = flattenOauthOptions({
+      providers: [{ enabled: true, type: 'apple' }],
+      public: { apple: { reviewDemoEnabled: 'true' } },
+    })
+    expect(flat.apple.configured).toBe(false)
+    expect(flat.apple.enabled).toBe(true)
+    expect(flat.apple.public.reviewDemoEnabled).toBe('true')
+  })
+
+  it('still marks Apple configured when a real public field is set', () => {
+    const flat = flattenOauthOptions({
+      public: {
+        apple: { clientId: 'dev.example.web', reviewDemoEnabled: 'true' },
+      },
+    })
+    expect(flat.apple.configured).toBe(true)
+  })
+})

--- a/apps/admin/src/features/settings/utils/oauth.ts
+++ b/apps/admin/src/features/settings/utils/oauth.ts
@@ -5,6 +5,8 @@ import type {
   OauthProviderType,
 } from '../types/settings'
 
+const oauthConfiguredIgnoredKeys = new Set(['reviewDemoEnabled'])
+
 export function flattenOauthOptions(
   data: OauthOptions | undefined,
 ): Record<OauthProviderType, FlatOauthProvider> {
@@ -18,7 +20,10 @@ export function flattenOauthOptions(
       return [
         provider.type,
         {
-          configured: Object.values(publicFields).some(Boolean),
+          configured: Object.entries(publicFields).some(
+            ([key, value]) =>
+              !oauthConfiguredIgnoredKeys.has(key) && Boolean(value),
+          ),
           enabled: providerMap.get(provider.type)?.enabled ?? false,
           public: publicFields,
           type: provider.type,

--- a/apps/admin/src/i18n/resources/en-US.ts
+++ b/apps/admin/src/i18n/resources/en-US.ts
@@ -2649,6 +2649,18 @@ export const enUS = {
     'Paste the endpoint Secret Key',
   'settings.membership.webhook.title': 'Webhook delivery',
   'settings.oauth.action.save': 'Save config',
+  'settings.oauth.apple.bundleIdHelp':
+    'Bundle ID of the native app, used only to verify id tokens signed for iOS. Leave blank for web-only sign-in.',
+  'settings.oauth.apple.callbackHelp':
+    'Add this exact URL under Services ID → Sign in with Apple → Return URLs, and register the bare domain (no scheme, no path) under Domains.',
+  'settings.oauth.apple.keyIdHelp':
+    'Ten-character ID of the key created under Keys with Sign in with Apple enabled, bound to the same primary App ID.',
+  'settings.oauth.apple.privateKeyHelp':
+    'Full contents of the downloaded .p8 file, including the BEGIN PRIVATE KEY and END PRIVATE KEY lines.',
+  'settings.oauth.apple.servicesIdHelp':
+    'Identifier created under Identifiers → Services IDs, e.g. dev.example.web. It is not the app Bundle ID — reusing the Bundle ID fails with invalid_client.',
+  'settings.oauth.apple.teamIdHelp':
+    'Ten-character Team ID shown on the Apple Developer Membership details page.',
   'settings.oauth.action.validate': 'Validate connection',
   'settings.oauth.callbackCopyAria': 'Copy callback URL',
   'settings.oauth.callbackLabel': 'Callback URL',
@@ -2657,6 +2669,15 @@ export const enUS = {
   'settings.oauth.copySuccess': 'Copied to clipboard',
   'settings.oauth.description': 'Configure third-party account sign-in.',
   'settings.oauth.error.save': 'Failed to save OAuth config',
+  'settings.oauth.reviewDemo.copyEmailAria': 'Copy review email',
+  'settings.oauth.reviewDemo.copyPasswordAria': 'Copy review password',
+  'settings.oauth.reviewDemo.email': 'Review email',
+  'settings.oauth.reviewDemo.helper':
+    'Creates a reader account for App Store review. Comments and profile reset daily. Sign-in uses the email form even if password login is disabled.',
+  'settings.oauth.reviewDemo.password': 'Review password',
+  'settings.oauth.reviewDemo.provisionFailed':
+    'Demo account is enabled but not ready. Save again or check logs.',
+  'settings.oauth.reviewDemo.switch': 'App Review demo account',
   'settings.oauth.secretKeptPlaceholder': 'Leave blank to keep current',
   'settings.oauth.success.save': 'OAuth config saved',
   'settings.oauth.switch.enabled': 'Enabled',

--- a/apps/admin/src/i18n/resources/zh-CN.ts
+++ b/apps/admin/src/i18n/resources/zh-CN.ts
@@ -2512,6 +2512,18 @@ export const zhCN = {
     '粘贴该 Endpoint 的 Secret Key',
   'settings.membership.webhook.title': 'Webhook 回调',
   'settings.oauth.action.save': '保存配置',
+  'settings.oauth.apple.bundleIdHelp':
+    '原生 App 的 Bundle ID，仅用于校验 iOS 端签发的 id token。纯 Web 登录可留空。',
+  'settings.oauth.apple.callbackHelp':
+    '将此地址原样填入 Services ID → Sign in with Apple → Return URLs，Domains 填不含协议与路径的域名。',
+  'settings.oauth.apple.keyIdHelp':
+    'Keys 中勾选 Sign in with Apple 所创建密钥的 10 位 ID，其 Primary App ID 须与上方一致。',
+  'settings.oauth.apple.privateKeyHelp':
+    '粘贴下载的 .p8 文件全文，含 BEGIN PRIVATE KEY 与 END PRIVATE KEY 两行。',
+  'settings.oauth.apple.servicesIdHelp':
+    '在 Identifiers → Services IDs 中单独创建的标识符，如 dev.example.web。它不是 App 的 Bundle ID，填 Bundle ID 会报 invalid_client。',
+  'settings.oauth.apple.teamIdHelp':
+    'Apple Developer 的 Membership 页面所示的 10 位 Team ID。',
   'settings.oauth.action.validate': '验证连接',
   'settings.oauth.callbackCopyAria': '复制 Callback URL',
   'settings.oauth.callbackLabel': 'Callback URL',
@@ -2520,6 +2532,15 @@ export const zhCN = {
   'settings.oauth.copySuccess': '已复制到剪贴板',
   'settings.oauth.description': '配置第三方账号登录方式。',
   'settings.oauth.error.save': '保存 OAuth 配置失败',
+  'settings.oauth.reviewDemo.copyEmailAria': '复制审核邮箱',
+  'settings.oauth.reviewDemo.copyPasswordAria': '复制审核密码',
+  'settings.oauth.reviewDemo.email': '审核邮箱',
+  'settings.oauth.reviewDemo.helper':
+    '创建供 App Store 审核使用的读者账号。评论与资料每日重置。即使关闭密码登录，仍可用邮箱表单登录此账号。',
+  'settings.oauth.reviewDemo.password': '审核密码',
+  'settings.oauth.reviewDemo.provisionFailed':
+    'Demo 账号已开启但尚未就绪，请再保存一次或查看日志。',
+  'settings.oauth.reviewDemo.switch': 'App 审核 Demo 账号',
   'settings.oauth.secretKeptPlaceholder': '留空则不修改',
   'settings.oauth.success.save': 'OAuth 配置已保存',
   'settings.oauth.switch.enabled': '启用',

--- a/apps/admin/src/query/keys.ts
+++ b/apps/admin/src/query/keys.ts
@@ -284,6 +284,7 @@ export const adminQueryKeys = {
     options: () => ['settings', 'options'] as const,
     owner: () => ['settings', 'owner'] as const,
     passkeys: () => ['settings', 'account', 'passkeys'] as const,
+    reviewDemo: () => ['settings', 'account', 'review-demo'] as const,
     root: ['settings'] as const,
     schema: () => ['settings', 'schema'] as const,
     sessions: () => ['settings', 'account', 'sessions'] as const,

--- a/apps/core/src/app.module.ts
+++ b/apps/core/src/app.module.ts
@@ -26,6 +26,7 @@ import { AggregateModule } from './modules/aggregate/aggregate.module'
 import { AiModule } from './modules/ai/ai.module'
 import { AnalyzeModule } from './modules/analyze/analyze.module'
 import { AuthModule } from './modules/auth/auth.module'
+import { ReviewDemoModule } from './modules/auth/review-demo.module'
 import { BackupModule } from './modules/backup/backup.module'
 import { CategoryModule } from './modules/category/category.module'
 import { CommentModule } from './modules/comment/comment.module'
@@ -94,6 +95,7 @@ import { SampleResponseInterceptor } from './shared/sample/sample-response.inter
     AnalyzeModule,
     EnrichmentModule,
     AuthModule.forRoot(),
+    ReviewDemoModule,
     BackupModule,
     BizHelperModule,
     CategoryModule,

--- a/apps/core/src/modules/auth/auth.controller.ts
+++ b/apps/core/src/modules/auth/auth.controller.ts
@@ -24,6 +24,7 @@ import type { FastifyBizRequest } from '~/transformers/get-req.transformer'
 import { AuthInstanceInjectKey } from './auth.constant'
 import type { InjectAuthInstance } from './auth.interface'
 import { AuthService } from './auth.service'
+import { ReviewDemoService } from './review-demo.service'
 
 const TokenSchema = z.object({
   expired: z.preprocess(
@@ -43,6 +44,7 @@ export class AuthController {
     private readonly eventEmitter: EventEmitter2,
     @Inject(AuthInstanceInjectKey)
     private readonly authInstance: InjectAuthInstance,
+    private readonly reviewDemoService: ReviewDemoService,
   ) {}
 
   @Get('token')
@@ -119,5 +121,14 @@ export class AuthController {
   })
   async getProviders() {
     return this.authInstance.get().api.getProviders()
+  }
+
+  @Get('review-demo')
+  @Auth()
+  @HttpCache({
+    disable: true,
+  })
+  getReviewDemo() {
+    return this.reviewDemoService.getCredentials()
   }
 }

--- a/apps/core/src/modules/auth/auth.implement.ts
+++ b/apps/core/src/modules/auth/auth.implement.ts
@@ -30,7 +30,12 @@ import { db } from '~/processors/database/postgres.provider'
 
 import { APPLE_ORIGIN } from './apple-client-secret'
 import { validateMxUsername } from './auth.username-validator'
-import { denyEmailSignIn, type EmailSignInGate } from './email-sign-in-gate'
+import {
+  type CredentialSignInGate,
+  denyEmailSignIn,
+  denyUsernameSignIn,
+} from './email-sign-in-gate'
+import { isReviewDemoEmail } from './review-demo.constants'
 
 const bcryptRegex = /^\$2[aby]\$/
 const isBcryptHash = (value?: string | null) =>
@@ -46,6 +51,104 @@ export const DEVICE_AUTHORIZATION_CLIENT_IDS: ReadonlySet<string> = new Set([
 
 const deviceUserCodeAlphabet = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789'
 const generateDeviceUserCode = customAlphabet(deviceUserCodeAlphabet, 8)
+const reviewDemoMutableProfileFields = new Set(['image', 'name'])
+
+export const reviewDemoDatabaseHooks: NonNullable<
+  BetterAuthOptions['databaseHooks']
+> = {
+  account: {
+    update: {
+      before: async (_account, context) => {
+        if (
+          context?.path === '/change-password' &&
+          isReviewDemoEmail(context.context.session?.user ?? {})
+        ) {
+          throw new APIError('FORBIDDEN', {
+            message: 'app review demo credentials cannot be changed',
+          })
+        }
+      },
+    },
+  },
+  user: {
+    update: {
+      before: async (_user, context) => {
+        if (
+          context?.path !== '/update-user' ||
+          !isReviewDemoEmail(context.context.session?.user ?? {})
+        ) {
+          return
+        }
+        const body = context.body
+        if (
+          body &&
+          typeof body === 'object' &&
+          !Array.isArray(body) &&
+          Object.keys(body).every((key) =>
+            reviewDemoMutableProfileFields.has(key),
+          )
+        ) {
+          return
+        }
+        throw new APIError('FORBIDDEN', {
+          message: 'app review demo identity cannot be changed',
+        })
+      },
+    },
+  },
+}
+
+export function assertUserDeletionAllowed(user: {
+  email?: string | null
+  role?: string | null
+}) {
+  if (user.role === 'owner') {
+    throw new APIError('FORBIDDEN', {
+      message: 'owner cannot delete',
+    })
+  }
+  if (isReviewDemoEmail(user)) {
+    throw new APIError('FORBIDDEN', {
+      message: 'app review demo account cannot be deleted',
+    })
+  }
+}
+
+export const createCredentialSignInHook = (
+  getCredentialSignInGate?: () => Promise<CredentialSignInGate>,
+) =>
+  createAuthMiddleware(async (ctx) => {
+    if (ctx.body?.role !== undefined) {
+      throw new APIError('FORBIDDEN', {
+        message: 'role cannot be modified',
+      })
+    }
+    if (!['/sign-in/email', '/sign-in/username'].includes(ctx.path)) {
+      return
+    }
+    const gate = getCredentialSignInGate
+      ? await getCredentialSignInGate()
+      : {
+          disablePasswordLogin: false,
+          reviewDemoEnabled: false,
+          reviewDemoBanned: false,
+        }
+    const denied =
+      ctx.path === '/sign-in/email'
+        ? denyEmailSignIn(
+            typeof ctx.body?.email === 'string' ? ctx.body.email : '',
+            gate,
+          )
+        : denyUsernameSignIn(
+            typeof ctx.body?.username === 'string' ? ctx.body.username : '',
+            gate,
+          )
+    if (denied) {
+      throw new APIError('UNAUTHORIZED', {
+        message: 'Invalid email or password',
+      })
+    }
+  })
 
 const normalizeOrigin = (url: string | undefined): string | null => {
   if (!url) return null
@@ -97,7 +200,7 @@ export async function CreateAuth(
   passkeyOptions?: PasskeyOptions,
   serverUrl?: string,
   idGenerator?: SnowflakeGenerator,
-  getEmailSignInGate?: () => Promise<EmailSignInGate>,
+  getCredentialSignInGate?: () => Promise<CredentialSignInGate>,
 ) {
   const deviceVerificationPath = isDev
     ? '/device'
@@ -152,6 +255,7 @@ export async function CreateAuth(
         trustedProviders: ['google', 'github', 'apple'],
       },
     },
+    databaseHooks: reviewDemoDatabaseHooks,
     emailAndPassword: {
       enabled: true,
       disableSignUp: true,
@@ -234,29 +338,7 @@ export async function CreateAuth(
       }),
     ],
     hooks: {
-      before: createAuthMiddleware(async (ctx) => {
-        if (ctx.body?.role !== undefined) {
-          throw new APIError('FORBIDDEN', {
-            message: 'role cannot be modified',
-          })
-        }
-        if (ctx.path === '/sign-in/email') {
-          const email =
-            typeof ctx.body?.email === 'string' ? ctx.body.email : ''
-          const gate = getEmailSignInGate
-            ? await getEmailSignInGate()
-            : {
-                disablePasswordLogin: false,
-                reviewDemoEnabled: false,
-                reviewDemoBanned: false,
-              }
-          if (denyEmailSignIn(email, gate)) {
-            throw new APIError('UNAUTHORIZED', {
-              message: 'Invalid email or password',
-            })
-          }
-        }
-      }),
+      before: createCredentialSignInHook(getCredentialSignInGate),
       after: createAuthMiddleware(async (ctx) => {
         const newSession = ctx.context.newSession as
           | {
@@ -362,13 +444,7 @@ export async function CreateAuth(
       modelName: 'reader',
       deleteUser: {
         enabled: true,
-        beforeDelete: async (user) => {
-          if ((user as { role?: string }).role === 'owner') {
-            throw new APIError('FORBIDDEN', {
-              message: 'owner cannot delete',
-            })
-          }
-        },
+        beforeDelete: async (user) => assertUserDeletionAllowed(user),
       },
       additionalFields: {
         role: {

--- a/apps/core/src/modules/auth/auth.implement.ts
+++ b/apps/core/src/modules/auth/auth.implement.ts
@@ -342,6 +342,16 @@ export async function CreateAuth(
     },
     user: {
       modelName: 'reader',
+      deleteUser: {
+        enabled: true,
+        beforeDelete: async (user) => {
+          if ((user as { role?: string }).role === 'owner') {
+            throw new APIError('FORBIDDEN', {
+              message: 'owner cannot delete',
+            })
+          }
+        },
+      },
       additionalFields: {
         role: {
           type: 'string',

--- a/apps/core/src/modules/auth/auth.implement.ts
+++ b/apps/core/src/modules/auth/auth.implement.ts
@@ -30,6 +30,7 @@ import { db } from '~/processors/database/postgres.provider'
 
 import { APPLE_ORIGIN } from './apple-client-secret'
 import { validateMxUsername } from './auth.username-validator'
+import { denyEmailSignIn, type EmailSignInGate } from './email-sign-in-gate'
 
 const bcryptRegex = /^\$2[aby]\$/
 const isBcryptHash = (value?: string | null) =>
@@ -96,6 +97,7 @@ export async function CreateAuth(
   passkeyOptions?: PasskeyOptions,
   serverUrl?: string,
   idGenerator?: SnowflakeGenerator,
+  getEmailSignInGate?: () => Promise<EmailSignInGate>,
 ) {
   const deviceVerificationPath = isDev
     ? '/device'
@@ -237,6 +239,22 @@ export async function CreateAuth(
           throw new APIError('FORBIDDEN', {
             message: 'role cannot be modified',
           })
+        }
+        if (ctx.path === '/sign-in/email') {
+          const email =
+            typeof ctx.body?.email === 'string' ? ctx.body.email : ''
+          const gate = getEmailSignInGate
+            ? await getEmailSignInGate()
+            : {
+                disablePasswordLogin: false,
+                reviewDemoEnabled: false,
+                reviewDemoBanned: false,
+              }
+          if (denyEmailSignIn(email, gate)) {
+            throw new APIError('UNAUTHORIZED', {
+              message: 'Invalid email or password',
+            })
+          }
         }
       }),
       after: createAuthMiddleware(async (ctx) => {

--- a/apps/core/src/modules/auth/auth.middleware.ts
+++ b/apps/core/src/modules/auth/auth.middleware.ts
@@ -13,6 +13,7 @@ import { ConfigsService } from '../configs/configs.service'
 import { AuthInstanceInjectKey } from './auth.constant'
 import { CreateAuth } from './auth.implement'
 import type { InjectAuthInstance } from './auth.interface'
+import { ReviewDemoService } from './review-demo.service'
 import { buildSocialProviders } from './social-providers'
 
 declare module 'http' {
@@ -35,6 +36,7 @@ export class AuthMiddleware implements NestMiddleware, OnModuleInit {
     @Inject(AuthInstanceInjectKey)
     private readonly authInstance: InjectAuthInstance,
     private readonly snowflakeService: SnowflakeService,
+    private readonly reviewDemoService: ReviewDemoService,
   ) {}
 
   async onModuleInit() {
@@ -87,6 +89,7 @@ export class AuthMiddleware implements NestMiddleware, OnModuleInit {
         passkeyOptions,
         urls.serverUrl,
         this.snowflakeService,
+        () => this.reviewDemoService.getEmailSignInGate(),
       )
       this.authHandler = handler
 
@@ -122,5 +125,5 @@ export class AuthMiddleware implements NestMiddleware, OnModuleInit {
 
 export function shouldBypassBetterAuth(originalUrl: string) {
   const pathname = originalUrl.split('?')[0]?.replace(/\/+$/, '') || ''
-  return /\/auth\/(?:token|session|providers)$/.test(pathname)
+  return /\/auth\/(?:token|session|providers|review-demo)$/.test(pathname)
 }

--- a/apps/core/src/modules/auth/auth.middleware.ts
+++ b/apps/core/src/modules/auth/auth.middleware.ts
@@ -89,7 +89,7 @@ export class AuthMiddleware implements NestMiddleware, OnModuleInit {
         passkeyOptions,
         urls.serverUrl,
         this.snowflakeService,
-        () => this.reviewDemoService.getEmailSignInGate(),
+        () => this.reviewDemoService.getCredentialSignInGate(),
       )
       this.authHandler = handler
 

--- a/apps/core/src/modules/auth/auth.module.ts
+++ b/apps/core/src/modules/auth/auth.module.ts
@@ -33,8 +33,7 @@ export class AuthModule implements NestModule {
 
     return {
       controllers: [AuthController, DeviceController],
-      exports: [AuthService, authProvider],
-      imports: [],
+      exports: [AuthService, AuthRepository, authProvider],
       module: AuthModule,
       global: true,
 

--- a/apps/core/src/modules/auth/auth.service.ts
+++ b/apps/core/src/modules/auth/auth.service.ts
@@ -21,7 +21,7 @@ import type { TokenDto } from './auth.controller'
 import type { InjectAuthInstance } from './auth.interface'
 import { AuthRepository } from './auth.repository'
 import type { SessionUser } from './auth.types'
-import { isReviewDemoIdentity } from './review-demo.constants'
+import { isReviewDemoEmail } from './review-demo.constants'
 
 type CreateOwnerByCredentialInput = {
   username: string
@@ -401,7 +401,7 @@ export class AuthService {
     if (!target?.id) {
       throw createAppException(AppErrorCode.AUTH_USER_ID_NOT_FOUND)
     }
-    if (isReviewDemoIdentity(target)) {
+    if (isReviewDemoEmail(target)) {
       throw createAppException(AppErrorCode.INVALID_PARAMETER, {
         message: 'cannot transfer owner to the app review demo account',
       })

--- a/apps/core/src/modules/auth/auth.service.ts
+++ b/apps/core/src/modules/auth/auth.service.ts
@@ -21,6 +21,7 @@ import type { TokenDto } from './auth.controller'
 import type { InjectAuthInstance } from './auth.interface'
 import { AuthRepository } from './auth.repository'
 import type { SessionUser } from './auth.types'
+import { isReviewDemoIdentity } from './review-demo.constants'
 
 type CreateOwnerByCredentialInput = {
   username: string
@@ -399,6 +400,11 @@ export class AuthService {
     const target = await this.readerRepository.findById(targetUserId)
     if (!target?.id) {
       throw createAppException(AppErrorCode.AUTH_USER_ID_NOT_FOUND)
+    }
+    if (isReviewDemoIdentity(target)) {
+      throw createAppException(AppErrorCode.INVALID_PARAMETER, {
+        message: 'cannot transfer owner to the app review demo account',
+      })
     }
 
     await this.readerRepository.setOwnersExceptToReader(target.id)

--- a/apps/core/src/modules/auth/email-sign-in-gate.ts
+++ b/apps/core/src/modules/auth/email-sign-in-gate.ts
@@ -1,0 +1,15 @@
+import { REVIEW_DEMO_EMAIL } from './review-demo.constants'
+
+export type EmailSignInGate = {
+  disablePasswordLogin: boolean
+  reviewDemoEnabled: boolean
+  reviewDemoBanned: boolean
+}
+
+export function denyEmailSignIn(email: string, gate: EmailSignInGate): boolean {
+  const isDemo = email.trim().toLowerCase() === REVIEW_DEMO_EMAIL
+  if (isDemo) {
+    return !gate.reviewDemoEnabled || gate.reviewDemoBanned
+  }
+  return gate.disablePasswordLogin
+}

--- a/apps/core/src/modules/auth/email-sign-in-gate.ts
+++ b/apps/core/src/modules/auth/email-sign-in-gate.ts
@@ -1,15 +1,29 @@
-import { REVIEW_DEMO_EMAIL } from './review-demo.constants'
+import { REVIEW_DEMO_EMAIL, REVIEW_DEMO_HANDLE } from './review-demo.constants'
 
-export type EmailSignInGate = {
+export type CredentialSignInGate = {
   disablePasswordLogin: boolean
   reviewDemoEnabled: boolean
   reviewDemoBanned: boolean
 }
 
-export function denyEmailSignIn(email: string, gate: EmailSignInGate): boolean {
+export function denyEmailSignIn(
+  email: string,
+  gate: CredentialSignInGate,
+): boolean {
   const isDemo = email.trim().toLowerCase() === REVIEW_DEMO_EMAIL
   if (isDemo) {
     return !gate.reviewDemoEnabled || gate.reviewDemoBanned
   }
   return gate.disablePasswordLogin
+}
+
+export function denyUsernameSignIn(
+  username: string,
+  gate: CredentialSignInGate,
+): boolean {
+  if (gate.disablePasswordLogin) {
+    return true
+  }
+  const isDemo = username.trim().toLowerCase() === REVIEW_DEMO_HANDLE
+  return isDemo && (!gate.reviewDemoEnabled || gate.reviewDemoBanned)
 }

--- a/apps/core/src/modules/auth/review-demo.constants.ts
+++ b/apps/core/src/modules/auth/review-demo.constants.ts
@@ -11,14 +11,22 @@ export function isReviewDemoEnabled(oauth: {
   return oauth.public?.apple?.[REVIEW_DEMO_PUBLIC_ENABLED_KEY] === 'true'
 }
 
-export function isReviewDemoIdentity(input: {
+export function isReviewDemoEmail(input: { email?: string | null }): boolean {
+  return input.email?.trim().toLowerCase() === REVIEW_DEMO_EMAIL
+}
+
+export function isReviewDemoProvisioned(input: {
   email?: string | null
+  emailVerified?: boolean | null
   handle?: string | null
+  role?: string | null
   username?: string | null
 }): boolean {
   return (
-    input.email === REVIEW_DEMO_EMAIL &&
-    (input.handle === REVIEW_DEMO_HANDLE ||
-      input.username === REVIEW_DEMO_HANDLE)
+    isReviewDemoEmail(input) &&
+    input.emailVerified === true &&
+    input.handle === REVIEW_DEMO_HANDLE &&
+    input.username === REVIEW_DEMO_HANDLE &&
+    input.role === 'reader'
   )
 }

--- a/apps/core/src/modules/auth/review-demo.constants.ts
+++ b/apps/core/src/modules/auth/review-demo.constants.ts
@@ -4,6 +4,7 @@ export const REVIEW_DEMO_NAME = 'App Reviewer'
 export const REVIEW_DEMO_BAN_REASON = 'app-review-demo'
 export const REVIEW_DEMO_PUBLIC_ENABLED_KEY = 'reviewDemoEnabled'
 export const REVIEW_DEMO_SECRET_PASSWORD_KEY = 'reviewDemoPassword'
+export const REVIEW_DEMO_SECRET_READER_ID_KEY = 'reviewDemoReaderId'
 
 export function isReviewDemoEnabled(oauth: {
   public?: Partial<Record<string, Record<string, string>>>

--- a/apps/core/src/modules/auth/review-demo.constants.ts
+++ b/apps/core/src/modules/auth/review-demo.constants.ts
@@ -1,0 +1,24 @@
+export const REVIEW_DEMO_EMAIL = 'app-review@users.invalid'
+export const REVIEW_DEMO_HANDLE = 'app-review'
+export const REVIEW_DEMO_NAME = 'App Reviewer'
+export const REVIEW_DEMO_BAN_REASON = 'app-review-demo'
+export const REVIEW_DEMO_PUBLIC_ENABLED_KEY = 'reviewDemoEnabled'
+export const REVIEW_DEMO_SECRET_PASSWORD_KEY = 'reviewDemoPassword'
+
+export function isReviewDemoEnabled(oauth: {
+  public?: Partial<Record<string, Record<string, string>>>
+}): boolean {
+  return oauth.public?.apple?.[REVIEW_DEMO_PUBLIC_ENABLED_KEY] === 'true'
+}
+
+export function isReviewDemoIdentity(input: {
+  email?: string | null
+  handle?: string | null
+  username?: string | null
+}): boolean {
+  return (
+    input.email === REVIEW_DEMO_EMAIL &&
+    (input.handle === REVIEW_DEMO_HANDLE ||
+      input.username === REVIEW_DEMO_HANDLE)
+  )
+}

--- a/apps/core/src/modules/auth/review-demo.module.ts
+++ b/apps/core/src/modules/auth/review-demo.module.ts
@@ -1,0 +1,13 @@
+import { forwardRef, Global, Module } from '@nestjs/common'
+
+import { CommentModule } from '../comment/comment.module'
+import { PollModule } from '../poll/poll.module'
+import { ReviewDemoService } from './review-demo.service'
+
+@Global()
+@Module({
+  exports: [ReviewDemoService],
+  imports: [forwardRef(() => CommentModule), PollModule],
+  providers: [ReviewDemoService],
+})
+export class ReviewDemoModule {}

--- a/apps/core/src/modules/auth/review-demo.service.ts
+++ b/apps/core/src/modules/auth/review-demo.service.ts
@@ -1,10 +1,13 @@
 import { randomBytes } from 'node:crypto'
 
-import { forwardRef, Inject, Injectable, Logger } from '@nestjs/common'
+import { forwardRef, Inject, Injectable } from '@nestjs/common'
 import { OnEvent } from '@nestjs/event-emitter'
 import { hashPassword } from 'better-auth/crypto'
+import type pkg from 'pg'
 
 import { EventBusEvents } from '~/constants/event-bus.constant'
+import { PG_POOL_TOKEN } from '~/constants/system.constant'
+import { withAdvisoryLock } from '~/processors/database/postgres.lock'
 import { SnowflakeService } from '~/shared/id/snowflake.service'
 
 import { CommentRepository } from '../comment/comment.repository'
@@ -13,10 +16,10 @@ import { ConfigsService } from '../configs/configs.service'
 import { PollVoteRepository } from '../poll/poll-vote.repository'
 import { ReaderRepository } from '../reader/reader.repository'
 import { AuthRepository } from './auth.repository'
-import type { EmailSignInGate } from './email-sign-in-gate'
+import type { CredentialSignInGate } from './email-sign-in-gate'
 import {
   isReviewDemoEnabled,
-  isReviewDemoIdentity,
+  isReviewDemoProvisioned,
   REVIEW_DEMO_BAN_REASON,
   REVIEW_DEMO_EMAIL,
   REVIEW_DEMO_HANDLE,
@@ -29,11 +32,12 @@ export type ReviewDemoCredentials =
   | { enabled: true; email: string; password: string }
   | { enabled: true; email: string; error: 'provision_failed' }
 
+const REVIEW_DEMO_SYNC_LOCK_KEY = -3216835155137105914n
+
 @Injectable()
 export class ReviewDemoService {
-  private readonly logger = new Logger(ReviewDemoService.name)
-  private syncing = false
-  private readonly syncWaiters: Array<() => void> = []
+  private syncPromise?: Promise<void>
+  private syncRerunRequested = false
 
   constructor(
     private readonly configsService: ConfigsService,
@@ -44,6 +48,7 @@ export class ReviewDemoService {
     private readonly commentService: CommentService,
     private readonly commentRepository: CommentRepository,
     private readonly pollVoteRepository: PollVoteRepository,
+    @Inject(PG_POOL_TOKEN) private readonly postgresPool: pkg.Pool,
   ) {}
 
   generatePassword() {
@@ -56,15 +61,14 @@ export class ReviewDemoService {
   }
 
   async waitForSync() {
-    if (this.syncing) {
-      await new Promise<void>((resolve) => this.syncWaiters.push(resolve))
+    if (this.syncPromise) {
+      await this.syncPromise
       return
     }
     await this.sync()
   }
 
-  async getEmailSignInGate(): Promise<EmailSignInGate> {
-    await this.waitForSync()
+  async getCredentialSignInGate(): Promise<CredentialSignInGate> {
     const [authSecurity, oauth] = await Promise.all([
       this.configsService.get('authSecurity'),
       this.configsService.get('oauth'),
@@ -91,7 +95,7 @@ export class ReviewDemoService {
     if (
       !password ||
       !reader ||
-      !isReviewDemoIdentity(reader) ||
+      !isReviewDemoProvisioned(reader) ||
       reader.bannedAt
     ) {
       return {
@@ -103,15 +107,34 @@ export class ReviewDemoService {
     return { enabled: true, email: REVIEW_DEMO_EMAIL, password }
   }
 
-  async sync() {
-    if (this.syncing) return
-    this.syncing = true
-    try {
-      await this.syncUnlocked()
-    } finally {
-      this.syncing = false
-      const waiters = this.syncWaiters.splice(0)
-      for (const waiter of waiters) waiter()
+  sync(): Promise<void> {
+    if (this.syncPromise) {
+      this.syncRerunRequested = true
+      return this.syncPromise
+    }
+    this.syncPromise = this.runSyncLoop().finally(() => {
+      this.syncPromise = undefined
+    })
+    return this.syncPromise
+  }
+
+  private async runSyncLoop() {
+    let lastError: unknown
+    do {
+      this.syncRerunRequested = false
+      try {
+        await withAdvisoryLock(
+          this.postgresPool,
+          REVIEW_DEMO_SYNC_LOCK_KEY,
+          () => this.syncUnlocked(),
+        )
+        lastError = undefined
+      } catch (error) {
+        lastError = error
+      }
+    } while (this.syncRerunRequested)
+    if (lastError) {
+      throw lastError
     }
   }
 
@@ -121,18 +144,15 @@ export class ReviewDemoService {
     const reader = await this.readerRepository.findByEmail(REVIEW_DEMO_EMAIL)
 
     if (!enabled) {
-      if (reader && isReviewDemoIdentity(reader)) {
-        await this.readerRepository.setBanned(reader.id, {
-          bannedAt: new Date(),
-          banReason: REVIEW_DEMO_BAN_REASON,
-        })
+      if (reader) {
+        if (!reader.bannedAt) {
+          await this.readerRepository.setBanned(reader.id, {
+            bannedAt: new Date(),
+            banReason: REVIEW_DEMO_BAN_REASON,
+          })
+        }
         await this.readerRepository.deleteSessionsForUser(reader.id)
       }
-      return
-    }
-
-    if (reader && !isReviewDemoIdentity(reader)) {
-      this.logger.error('review demo email is occupied by a non-demo reader')
       return
     }
 
@@ -168,12 +188,31 @@ export class ReviewDemoService {
       return
     }
 
-    if (reader.bannedAt) {
+    const shouldUnban =
+      Boolean(reader.bannedAt) && reader.banReason === REVIEW_DEMO_BAN_REASON
+    if (shouldUnban) {
       await this.readerRepository.unsetBanned(reader.id)
+    }
+    const identityChanged =
+      reader.email !== REVIEW_DEMO_EMAIL ||
+      reader.emailVerified !== true ||
+      reader.handle !== REVIEW_DEMO_HANDLE ||
+      reader.username !== REVIEW_DEMO_HANDLE ||
+      reader.role !== 'reader'
+    if (identityChanged || shouldUnban) {
       await this.readerRepository.update(reader.id, {
-        name: REVIEW_DEMO_NAME,
-        displayUsername: REVIEW_DEMO_NAME,
-        image: null,
+        email: REVIEW_DEMO_EMAIL,
+        emailVerified: true,
+        handle: REVIEW_DEMO_HANDLE,
+        role: 'reader',
+        username: REVIEW_DEMO_HANDLE,
+        ...(shouldUnban
+          ? {
+              displayUsername: REVIEW_DEMO_NAME,
+              image: null,
+              name: REVIEW_DEMO_NAME,
+            }
+          : {}),
       })
     }
 
@@ -181,21 +220,20 @@ export class ReviewDemoService {
     const credential = accounts.find(
       (account) => account.providerId === 'credential',
     )
-    const passwordHash = await hashPassword(password)
     if (!credential) {
       await this.authRepository.createAccount({
         id: this.snowflakeService.nextId(),
         providerAccountId: reader.id,
         providerId: 'credential',
         userId: reader.id,
-        password: passwordHash,
+        password: await hashPassword(password),
       })
       return
     }
     if (generated) {
       await this.authRepository.updateAccountPassword(
         credential.id,
-        passwordHash,
+        await hashPassword(password),
       )
     }
   }
@@ -208,7 +246,7 @@ export class ReviewDemoService {
       return { skipped: true }
     }
     const reader = await this.readerRepository.findByEmail(REVIEW_DEMO_EMAIL)
-    if (!reader || !isReviewDemoIdentity(reader)) {
+    if (!reader) {
       return { skipped: true }
     }
     const comments = await this.commentRepository.findByFilter({

--- a/apps/core/src/modules/auth/review-demo.service.ts
+++ b/apps/core/src/modules/auth/review-demo.service.ts
@@ -1,0 +1,231 @@
+import { randomBytes } from 'node:crypto'
+
+import { forwardRef, Inject, Injectable, Logger } from '@nestjs/common'
+import { OnEvent } from '@nestjs/event-emitter'
+import { hashPassword } from 'better-auth/crypto'
+
+import { EventBusEvents } from '~/constants/event-bus.constant'
+import { SnowflakeService } from '~/shared/id/snowflake.service'
+
+import { CommentRepository } from '../comment/comment.repository'
+import { CommentService } from '../comment/comment.service'
+import { ConfigsService } from '../configs/configs.service'
+import { PollVoteRepository } from '../poll/poll-vote.repository'
+import { ReaderRepository } from '../reader/reader.repository'
+import { AuthRepository } from './auth.repository'
+import type { EmailSignInGate } from './email-sign-in-gate'
+import {
+  isReviewDemoEnabled,
+  isReviewDemoIdentity,
+  REVIEW_DEMO_BAN_REASON,
+  REVIEW_DEMO_EMAIL,
+  REVIEW_DEMO_HANDLE,
+  REVIEW_DEMO_NAME,
+  REVIEW_DEMO_SECRET_PASSWORD_KEY,
+} from './review-demo.constants'
+
+export type ReviewDemoCredentials =
+  | { enabled: false }
+  | { enabled: true; email: string; password: string }
+  | { enabled: true; email: string; error: 'provision_failed' }
+
+@Injectable()
+export class ReviewDemoService {
+  private readonly logger = new Logger(ReviewDemoService.name)
+  private syncing = false
+  private readonly syncWaiters: Array<() => void> = []
+
+  constructor(
+    private readonly configsService: ConfigsService,
+    private readonly readerRepository: ReaderRepository,
+    private readonly authRepository: AuthRepository,
+    private readonly snowflakeService: SnowflakeService,
+    @Inject(forwardRef(() => CommentService))
+    private readonly commentService: CommentService,
+    private readonly commentRepository: CommentRepository,
+    private readonly pollVoteRepository: PollVoteRepository,
+  ) {}
+
+  generatePassword() {
+    return randomBytes(18).toString('base64url')
+  }
+
+  @OnEvent(EventBusEvents.ConfigChanged)
+  async onConfigChanged() {
+    await this.sync()
+  }
+
+  async waitForSync() {
+    if (this.syncing) {
+      await new Promise<void>((resolve) => this.syncWaiters.push(resolve))
+      return
+    }
+    await this.sync()
+  }
+
+  async getEmailSignInGate(): Promise<EmailSignInGate> {
+    await this.waitForSync()
+    const [authSecurity, oauth] = await Promise.all([
+      this.configsService.get('authSecurity'),
+      this.configsService.get('oauth'),
+    ])
+    const reviewDemoEnabled = isReviewDemoEnabled(oauth)
+    const reader = reviewDemoEnabled
+      ? await this.readerRepository.findByEmail(REVIEW_DEMO_EMAIL)
+      : null
+    return {
+      disablePasswordLogin: Boolean(authSecurity.disablePasswordLogin),
+      reviewDemoEnabled,
+      reviewDemoBanned: Boolean(reader?.bannedAt),
+    }
+  }
+
+  async getCredentials(): Promise<ReviewDemoCredentials> {
+    await this.waitForSync()
+    const oauth = await this.configsService.get('oauth')
+    if (!isReviewDemoEnabled(oauth)) {
+      return { enabled: false }
+    }
+    const password = oauth.secrets?.apple?.[REVIEW_DEMO_SECRET_PASSWORD_KEY]
+    const reader = await this.readerRepository.findByEmail(REVIEW_DEMO_EMAIL)
+    if (
+      !password ||
+      !reader ||
+      !isReviewDemoIdentity(reader) ||
+      reader.bannedAt
+    ) {
+      return {
+        enabled: true,
+        email: REVIEW_DEMO_EMAIL,
+        error: 'provision_failed',
+      }
+    }
+    return { enabled: true, email: REVIEW_DEMO_EMAIL, password }
+  }
+
+  async sync() {
+    if (this.syncing) return
+    this.syncing = true
+    try {
+      await this.syncUnlocked()
+    } finally {
+      this.syncing = false
+      const waiters = this.syncWaiters.splice(0)
+      for (const waiter of waiters) waiter()
+    }
+  }
+
+  private async syncUnlocked() {
+    const oauth = await this.configsService.get('oauth')
+    const enabled = isReviewDemoEnabled(oauth)
+    const reader = await this.readerRepository.findByEmail(REVIEW_DEMO_EMAIL)
+
+    if (!enabled) {
+      if (reader && isReviewDemoIdentity(reader)) {
+        await this.readerRepository.setBanned(reader.id, {
+          bannedAt: new Date(),
+          banReason: REVIEW_DEMO_BAN_REASON,
+        })
+        await this.readerRepository.deleteSessionsForUser(reader.id)
+      }
+      return
+    }
+
+    if (reader && !isReviewDemoIdentity(reader)) {
+      this.logger.error('review demo email is occupied by a non-demo reader')
+      return
+    }
+
+    let password = oauth.secrets?.apple?.[REVIEW_DEMO_SECRET_PASSWORD_KEY]
+    let generated = false
+    if (!password) {
+      password = this.generatePassword()
+      generated = true
+      await this.configsService.patchAndValid('oauth', {
+        secrets: { apple: { [REVIEW_DEMO_SECRET_PASSWORD_KEY]: password } },
+      })
+    }
+
+    if (!reader) {
+      const id = this.snowflakeService.nextId()
+      await this.readerRepository.create({
+        id,
+        email: REVIEW_DEMO_EMAIL,
+        emailVerified: true,
+        name: REVIEW_DEMO_NAME,
+        handle: REVIEW_DEMO_HANDLE,
+        username: REVIEW_DEMO_HANDLE,
+        displayUsername: REVIEW_DEMO_NAME,
+        role: 'reader',
+      })
+      await this.authRepository.createAccount({
+        id: this.snowflakeService.nextId(),
+        providerAccountId: id,
+        providerId: 'credential',
+        userId: id,
+        password: await hashPassword(password),
+      })
+      return
+    }
+
+    if (reader.bannedAt) {
+      await this.readerRepository.unsetBanned(reader.id)
+      await this.readerRepository.update(reader.id, {
+        name: REVIEW_DEMO_NAME,
+        displayUsername: REVIEW_DEMO_NAME,
+        image: null,
+      })
+    }
+
+    const accounts = await this.authRepository.findAccountsForUser(reader.id)
+    const credential = accounts.find(
+      (account) => account.providerId === 'credential',
+    )
+    const passwordHash = await hashPassword(password)
+    if (!credential) {
+      await this.authRepository.createAccount({
+        id: this.snowflakeService.nextId(),
+        providerAccountId: reader.id,
+        providerId: 'credential',
+        userId: reader.id,
+        password: passwordHash,
+      })
+      return
+    }
+    if (generated) {
+      await this.authRepository.updateAccountPassword(
+        credential.id,
+        passwordHash,
+      )
+    }
+  }
+
+  async resetDaily(): Promise<
+    { skipped: true } | { comments: number; pollVotes: number }
+  > {
+    const oauth = await this.configsService.get('oauth')
+    if (!isReviewDemoEnabled(oauth)) {
+      return { skipped: true }
+    }
+    const reader = await this.readerRepository.findByEmail(REVIEW_DEMO_EMAIL)
+    if (!reader || !isReviewDemoIdentity(reader)) {
+      return { skipped: true }
+    }
+    const comments = await this.commentRepository.findByFilter({
+      readerId: reader.id,
+      isDeleted: false,
+    })
+    for (const comment of comments) {
+      await this.commentService.softDeleteComment(String(comment.id))
+    }
+    const pollVotes = await this.pollVoteRepository.deleteByFingerprint(
+      `r:${reader.id}`,
+    )
+    await this.readerRepository.update(reader.id, {
+      name: REVIEW_DEMO_NAME,
+      displayUsername: REVIEW_DEMO_NAME,
+      image: null,
+    })
+    return { comments: comments.length, pollVotes }
+  }
+}

--- a/apps/core/src/modules/auth/review-demo.service.ts
+++ b/apps/core/src/modules/auth/review-demo.service.ts
@@ -1,13 +1,17 @@
 import { randomBytes } from 'node:crypto'
 
-import { forwardRef, Inject, Injectable } from '@nestjs/common'
+import type { OnModuleInit } from '@nestjs/common'
+import { forwardRef, Inject, Injectable, Logger } from '@nestjs/common'
 import { OnEvent } from '@nestjs/event-emitter'
 import { hashPassword } from 'better-auth/crypto'
 import type pkg from 'pg'
 
 import { EventBusEvents } from '~/constants/event-bus.constant'
 import { PG_POOL_TOKEN } from '~/constants/system.constant'
-import { withAdvisoryLock } from '~/processors/database/postgres.lock'
+import {
+  REVIEW_DEMO_SYNC_LOCK_KEY,
+  withAdvisoryLock,
+} from '~/processors/database/postgres.lock'
 import { SnowflakeService } from '~/shared/id/snowflake.service'
 
 import { CommentRepository } from '../comment/comment.repository'
@@ -25,6 +29,7 @@ import {
   REVIEW_DEMO_HANDLE,
   REVIEW_DEMO_NAME,
   REVIEW_DEMO_SECRET_PASSWORD_KEY,
+  REVIEW_DEMO_SECRET_READER_ID_KEY,
 } from './review-demo.constants'
 
 export type ReviewDemoCredentials =
@@ -32,10 +37,20 @@ export type ReviewDemoCredentials =
   | { enabled: true; email: string; password: string }
   | { enabled: true; email: string; error: 'provision_failed' }
 
-const REVIEW_DEMO_SYNC_LOCK_KEY = -3216835155137105914n
+type ReviewDemoReader = {
+  id: string
+  email?: string | null
+  emailVerified?: boolean | null
+  handle?: string | null
+  role?: string | null
+  username?: string | null
+}
+
+const RESET_BATCH_SIZE = 50
 
 @Injectable()
-export class ReviewDemoService {
+export class ReviewDemoService implements OnModuleInit {
+  private readonly logger = new Logger(ReviewDemoService.name)
   private syncPromise?: Promise<void>
   private syncRerunRequested = false
 
@@ -55,9 +70,23 @@ export class ReviewDemoService {
     return randomBytes(18).toString('base64url')
   }
 
+  async onModuleInit() {
+    await this.runQuietly('boot reconciliation', () => this.sync())
+  }
+
   @OnEvent(EventBusEvents.ConfigChanged)
   async onConfigChanged() {
-    await this.sync()
+    await this.runQuietly('config change', () => this.sync())
+  }
+
+  private async runQuietly(reason: string, run: () => Promise<void>) {
+    try {
+      await run()
+    } catch (error) {
+      this.logger.error(
+        `review demo sync failed (${reason}): ${error instanceof Error ? error.message : error}`,
+      )
+    }
   }
 
   async waitForSync() {
@@ -85,7 +114,7 @@ export class ReviewDemoService {
   }
 
   async getCredentials(): Promise<ReviewDemoCredentials> {
-    await this.waitForSync()
+    await this.runQuietly('credential read', () => this.waitForSync())
     const oauth = await this.configsService.get('oauth')
     if (!isReviewDemoEnabled(oauth)) {
       return { enabled: false }
@@ -156,18 +185,30 @@ export class ReviewDemoService {
       return
     }
 
+    const managedId = oauth.secrets?.apple?.[REVIEW_DEMO_SECRET_READER_ID_KEY]
+    const conflict = await this.findConflict(reader, managedId)
+    if (conflict) {
+      this.logger.error(
+        `review demo provisioning refused: ${conflict} is already taken by another account`,
+      )
+      return
+    }
+
+    const secretsPatch: Record<string, string> = {}
     let password = oauth.secrets?.apple?.[REVIEW_DEMO_SECRET_PASSWORD_KEY]
     let generated = false
     if (!password) {
       password = this.generatePassword()
       generated = true
-      await this.configsService.patchAndValid('oauth', {
-        secrets: { apple: { [REVIEW_DEMO_SECRET_PASSWORD_KEY]: password } },
-      })
+      secretsPatch[REVIEW_DEMO_SECRET_PASSWORD_KEY] = password
     }
 
     if (!reader) {
       const id = this.snowflakeService.nextId()
+      secretsPatch[REVIEW_DEMO_SECRET_READER_ID_KEY] = id
+      await this.configsService.patchAndValid('oauth', {
+        secrets: { apple: secretsPatch },
+      })
       await this.readerRepository.create({
         id,
         email: REVIEW_DEMO_EMAIL,
@@ -186,6 +227,15 @@ export class ReviewDemoService {
         password: await hashPassword(password),
       })
       return
+    }
+
+    if (managedId !== reader.id) {
+      secretsPatch[REVIEW_DEMO_SECRET_READER_ID_KEY] = reader.id
+    }
+    if (Object.keys(secretsPatch).length > 0) {
+      await this.configsService.patchAndValid('oauth', {
+        secrets: { apple: secretsPatch },
+      })
     }
 
     const shouldUnban =
@@ -238,6 +288,25 @@ export class ReviewDemoService {
     }
   }
 
+  private async findConflict(
+    reader: ReviewDemoReader | null,
+    managedId?: string,
+  ): Promise<'email' | 'username' | null> {
+    // A row the service never provisioned may legitimately belong to a real
+    // person; rewriting its identity would demote and lock out that account.
+    // Rows provisioned before the id was recorded are adopted by their shape.
+    if (reader) {
+      const managed = managedId
+        ? reader.id === managedId
+        : isReviewDemoProvisioned(reader)
+      if (!managed) return 'email'
+    }
+    const usernameHolder =
+      await this.readerRepository.findByUsername(REVIEW_DEMO_HANDLE)
+    if (usernameHolder && usernameHolder.id !== reader?.id) return 'username'
+    return null
+  }
+
   async resetDaily(): Promise<
     { skipped: true } | { comments: number; pollVotes: number }
   > {
@@ -249,12 +318,29 @@ export class ReviewDemoService {
     if (!reader) {
       return { skipped: true }
     }
-    const comments = await this.commentRepository.findByFilter({
-      readerId: reader.id,
-      isDeleted: false,
-    })
-    for (const comment of comments) {
-      await this.commentService.softDeleteComment(String(comment.id))
+    let comments = 0
+    let previousBatchHead: string | undefined
+    for (;;) {
+      const batch = await this.commentRepository.paginatedFind(
+        { readerId: reader.id, isDeleted: false },
+        1,
+        RESET_BATCH_SIZE,
+      )
+      const rows = batch.data
+      if (rows.length === 0) break
+      const head = String(rows[0].id)
+      if (head === previousBatchHead) {
+        this.logger.warn(
+          `review demo reset stalled on comment ${head}, aborting sweep`,
+        )
+        break
+      }
+      previousBatchHead = head
+      for (const comment of rows) {
+        await this.commentService.softDeleteComment(String(comment.id))
+      }
+      comments += rows.length
+      if (rows.length < RESET_BATCH_SIZE) break
     }
     const pollVotes = await this.pollVoteRepository.deleteByFingerprint(
       `r:${reader.id}`,
@@ -264,6 +350,6 @@ export class ReviewDemoService {
       displayUsername: REVIEW_DEMO_NAME,
       image: null,
     })
-    return { comments: comments.length, pollVotes }
+    return { comments, pollVotes }
   }
 }

--- a/apps/core/src/modules/comment/comment.controller.ts
+++ b/apps/core/src/modules/comment/comment.controller.ts
@@ -21,6 +21,7 @@ import { CurrentReaderId } from '~/common/decorators/current-user.decorator'
 import { HTTPDecorators } from '~/common/decorators/http.decorator'
 import type { IpRecord } from '~/common/decorators/ip.decorator'
 import { IpLocation } from '~/common/decorators/ip.decorator'
+import { ReaderAuth } from '~/common/decorators/reader-auth.decorator'
 import { HasAdminAccess } from '~/common/decorators/role.decorator'
 import { AppErrorCode, createAppException } from '~/common/errors'
 import { withMeta } from '~/common/response/envelope.types'
@@ -221,6 +222,24 @@ export class CommentController {
     return withMeta(candidates, new MetaObjectBuilder().build())
   }
 
+  @Get('/reader/me')
+  @ReaderAuth()
+  async getMyComments(
+    @Query() query: BasicPagerDto,
+    @CurrentReaderId() readerId: string,
+  ) {
+    const { page = 1, size = 20 } = query
+    const comments = await this.commentService.getReaderComments(
+      readerId,
+      page,
+      size,
+    )
+    return withMeta(
+      comments.data.map((doc) => this.commentService.projectReaderComment(doc)),
+      new MetaObjectBuilder().pagination(comments.pagination).build(),
+    )
+  }
+
   @Get('/ref/:id')
   async getCommentsByRefId(
     @Param() params: EntityIdDto,
@@ -326,6 +345,22 @@ export class CommentController {
     }
 
     return data
+  }
+
+  @Post('/:id/report')
+  async reportComment(
+    @Param() params: EntityIdDto,
+    @CurrentReaderId() readerId: string,
+    @IpLocation() ipLocation: IpRecord,
+  ) {
+    const result = await this.commentService.reportComment(params.id, {
+      ip: ipLocation.ip,
+      readerId: readerId || null,
+    })
+    if (result.notified) {
+      this.lifecycleService.afterReportComment(params.id)
+    }
+    return { ok: true }
   }
 
   @Post('/guest/:id')

--- a/apps/core/src/modules/comment/comment.lifecycle.service.ts
+++ b/apps/core/src/modules/comment/comment.lifecycle.service.ts
@@ -434,6 +434,25 @@ export class CommentLifecycleService implements OnModuleInit, OnModuleDestroy {
     })
   }
 
+  afterReportComment(commentId: string) {
+    scheduleManager.schedule(async () => {
+      const comment = await this.commentService.findById(commentId)
+      if (!comment) return
+      const { adminUrl } = await this.configsService.get('url')
+      try {
+        await this.barkService.push({
+          title: 'Comment reported',
+          body: comment.text.slice(0, 140),
+          url: `${adminUrl}#/comments`,
+        })
+      } catch (err) {
+        this.logger.warn(
+          `bark after report(${commentId}) failed: ${err instanceof Error ? err.message : err}`,
+        )
+      }
+    })
+  }
+
   private async resolveUrlByType(type: CollectionRefTypes, model: any) {
     const {
       url: { webUrl: base },

--- a/apps/core/src/modules/comment/comment.repository.ts
+++ b/apps/core/src/modules/comment/comment.repository.ts
@@ -747,6 +747,15 @@ export class CommentRepository extends BaseRepository {
         )
       }
     }
+    if (filter.readerId) {
+      filters.push(eq(comments.readerId, filter.readerId))
+    }
+    if (filter.isDeleted !== undefined) {
+      filters.push(eq(comments.isDeleted, filter.isDeleted))
+    }
+    if (filter.excludeJunk) {
+      filters.push(ne(comments.state, CommentState.Junk))
+    }
     return filters.length > 0 ? and(...filters) : undefined
   }
 

--- a/apps/core/src/modules/comment/comment.service.ts
+++ b/apps/core/src/modules/comment/comment.service.ts
@@ -73,6 +73,8 @@ const TAB_COUNTS_KEY_PREFIX = 'comment:tab-counts:'
 const TAB_COUNTS_TTL_SECONDS = 30
 const AUTHOR_ACTIVITY_KEY_PREFIX = 'comment:author-activity:'
 const AUTHOR_ACTIVITY_TTL_SECONDS = 300
+const COMMENT_REPORT_KEY_PREFIX = 'comment:report:'
+const COMMENT_REPORT_TTL_SECONDS = 60 * 60 * 24 * 90
 
 const DEFAULT_STATE_TO_TAB: Record<number, CommentTab> = {
   0: 'unread',
@@ -513,6 +515,66 @@ export class CommentService {
     const dataWithParent = await this.attachParentPreview(dataWithRef)
     const dataWithCountry = await this.enrichCommentsWithCountry(dataWithParent)
     return { ...queryList, data: dataWithCountry }
+  }
+
+  async getReaderComments(readerId: string, page: number, size: number) {
+    return this.getComments({
+      page,
+      size,
+      filter: {
+        excludeJunk: true,
+        isDeleted: false,
+        readerId,
+      },
+    })
+  }
+
+  projectReaderComment(doc: CommentModel & { ref?: CommentRefSummary | null }) {
+    return {
+      createdAt: doc.createdAt,
+      id: String(doc.id),
+      refId: String(doc.refId),
+      refType: doc.refType,
+      source: doc.ref
+        ? {
+            categorySlug: doc.ref.category?.slug ?? null,
+            nid: doc.ref.nid ?? null,
+            slug: doc.ref.slug ?? null,
+          }
+        : null,
+      sourceTitle: doc.ref?.title ?? null,
+      text: doc.text,
+    }
+  }
+
+  async reportComment(
+    id: string,
+    reporter: { ip?: string; readerId?: string | null },
+  ): Promise<{ notified: boolean }> {
+    const comment = await this.commentRepository.findById(id)
+    if (!comment) {
+      throw createAppException(AppErrorCode.COMMENT_NOT_FOUND, { id })
+    }
+    const reporterKey = reporter.readerId || reporter.ip || 'anon'
+    const key = `${COMMENT_REPORT_KEY_PREFIX}${id}:${reporterKey}`
+    let acquired = true
+    try {
+      const stored = await this.redisService
+        .getClient()
+        .set(key, '1', 'EX', COMMENT_REPORT_TTL_SECONDS, 'NX')
+      acquired = stored === 'OK'
+    } catch (err) {
+      this.logger.debug(
+        `report dedupe write failed for ${key}: ${err instanceof Error ? err.message : err}`,
+      )
+    }
+    if (!acquired) return { notified: false }
+    await this.eventManager.broadcast(
+      BusinessEvents.COMMENT_UPDATE,
+      { id, reported: true },
+      { scope: EventScope.TO_SYSTEM_ADMIN },
+    )
+    return { notified: true }
   }
 
   /**

--- a/apps/core/src/modules/comment/comment.types.ts
+++ b/apps/core/src/modules/comment/comment.types.ts
@@ -72,9 +72,12 @@ export interface CommentCreateInput {
 }
 
 export interface CommentFindFilter {
+  excludeJunk?: boolean
+  isDeleted?: boolean
   state?: number
   refType?: CommentRefType
   refId?: EntityId | string
+  readerId?: string
   search?: string
   tab?: CommentTab
   author?: string
@@ -85,12 +88,7 @@ export interface CommentFindFilter {
  * deprecated parameter; `tab` semantics supersede it (spec §6.1).
  */
 export type CommentTab =
-  | 'unread'
-  | 'read'
-  | 'junk'
-  | 'whispers'
-  | 'awaiting'
-  | 'all'
+  'unread' | 'read' | 'junk' | 'whispers' | 'awaiting' | 'all'
 
 export interface CommentTabCounts {
   unread: number

--- a/apps/core/src/modules/configs/configs.service.ts
+++ b/apps/core/src/modules/configs/configs.service.ts
@@ -592,7 +592,9 @@ export class ConfigsService implements OnModuleInit {
       this.validateTtsProvider(nextConfig)
     }
 
-    encryptObject(instanceValue, key)
+    if (key !== 'oauth') {
+      encryptObject(instanceValue, key)
+    }
 
     switch (key) {
       case 'url': {
@@ -617,7 +619,10 @@ export class ConfigsService implements OnModuleInit {
         const value = instanceValue as unknown as OAuthConfig
         const current = await this.get('oauth')
 
-        const currentProvidersMap = (current.providers || []).reduce(
+        const currentProviders = (current.providers || []).map((provider) => ({
+          ...provider,
+        }))
+        const currentProvidersMap = currentProviders.reduce(
           (acc, item) => {
             acc[item.type] = item
             return acc
@@ -625,7 +630,6 @@ export class ConfigsService implements OnModuleInit {
           {} as Record<string, any>,
         )
 
-        const currentProviders = current.providers || []
         ;(value.providers || []).forEach((p) => {
           if (!currentProvidersMap[p.type]) {
             currentProviders.push(p)
@@ -634,20 +638,13 @@ export class ConfigsService implements OnModuleInit {
           }
         })
 
-        let nextAuthSecrets = value.secrets
-        if (value.secrets) {
-          nextAuthSecrets = merge(current.secrets, nextAuthSecrets)
-        }
-
-        let nextAuthPublic = value.public
-        if (value.public) {
-          nextAuthPublic = merge(current.public, nextAuthPublic)
-        }
-        const option = await this.patch(key as 'oauth', {
+        const nextOauth = {
           providers: currentProviders,
-          secrets: nextAuthSecrets,
-          public: nextAuthPublic,
-        })
+          public: merge(cloneDeep(current.public || {}), value.public || {}),
+          secrets: merge(cloneDeep(current.secrets || {}), value.secrets || {}),
+        }
+        encryptObject(nextOauth, key)
+        const option = await this.patch(key as 'oauth', nextOauth)
 
         await this.configVersionService.bump(ConfigVersionScopes.OAuth)
         return option

--- a/apps/core/src/modules/cron-task/cron-business.service.ts
+++ b/apps/core/src/modules/cron-task/cron-business.service.ts
@@ -8,6 +8,7 @@ import { RedisKeys } from '~/constants/cache.constant'
 import { STATIC_FILE_TRASH_DIR, TEMP_DIR } from '~/constants/path.constant'
 import { AggregateService } from '~/modules/aggregate/aggregate.service'
 import { AnalyzeRepository } from '~/modules/analyze/analyze.repository'
+import { ReviewDemoService } from '~/modules/auth/review-demo.service'
 import { ConfigsService } from '~/modules/configs/configs.service'
 import { FileReferenceService } from '~/modules/file/file-reference.service'
 import { SearchService } from '~/modules/search/search.service'
@@ -37,6 +38,7 @@ export class CronBusinessService {
 
     private readonly searchService: SearchService,
     private readonly fileReferenceService: FileReferenceService,
+    private readonly reviewDemoService: ReviewDemoService,
   ) {
     this.logger = new Logger(CronBusinessService.name)
   }
@@ -222,6 +224,15 @@ export class CronBusinessService {
     const result = await this.fileReferenceService.cleanupCommentUploads()
     this.logger.log(
       `--> Comment image upload cleanup finished pending=${result.pendingDeleted} detached=${result.detachedDeleted}`,
+    )
+    return result
+  }
+
+  async resetReviewDemo() {
+    this.logger.log('--> Starting App Review demo account reset')
+    const result = await this.reviewDemoService.resetDaily()
+    this.logger.log(
+      `--> App Review demo reset finished ${JSON.stringify(result)}`,
     )
     return result
   }

--- a/apps/core/src/modules/cron-task/cron-task.scheduler.ts
+++ b/apps/core/src/modules/cron-task/cron-task.scheduler.ts
@@ -32,6 +32,11 @@ export class CronTaskScheduler {
     return this.dispatch('resetIPAccess', CronTaskType.ResetIPAccess)
   }
 
+  @CronOnce(CronExpression.EVERY_DAY_AT_MIDNIGHT, { name: 'resetReviewDemo' })
+  scheduleResetReviewDemo() {
+    return this.dispatch('resetReviewDemo', CronTaskType.ResetReviewDemo)
+  }
+
   @CronOnce(CronExpression.EVERY_DAY_AT_MIDNIGHT, {
     name: 'resetLikedOrReadArticleRecord',
   })

--- a/apps/core/src/modules/cron-task/cron-task.types.ts
+++ b/apps/core/src/modules/cron-task/cron-task.types.ts
@@ -8,6 +8,7 @@ export const CronTaskType = {
   DeleteExpiredJWT: 'cron:delete-expired-jwt',
   RebuildSearchIndex: 'cron:rebuild-search-index',
   CleanCommentUploads: 'cron:clean-comment-uploads',
+  ResetReviewDemo: 'cron:reset-review-demo',
 } as const
 
 export type CronTaskTypeValue = (typeof CronTaskType)[keyof typeof CronTaskType]
@@ -77,6 +78,12 @@ export const CronTaskMetas: Record<
     description: 'Clean up comment image uploads',
     cronExpression: '*/15 * * * *',
     methodName: 'cleanCommentUploads',
+  },
+  [CronTaskType.ResetReviewDemo]: {
+    name: 'resetReviewDemo',
+    description: 'Reset App Review demo reader content and profile',
+    cronExpression: 'EVERY_DAY_AT_MIDNIGHT',
+    methodName: 'resetReviewDemo',
   },
 }
 

--- a/apps/core/src/modules/poll/poll-vote.repository.ts
+++ b/apps/core/src/modules/poll/poll-vote.repository.ts
@@ -129,4 +129,12 @@ export class PollVoteRepository extends BaseRepository {
       .where(eq(pollVoteOptions.voteId, idBig))
     return rows.map((r) => r.optionId)
   }
+
+  async deleteByFingerprint(fingerprint: string): Promise<number> {
+    const deleted = await this.db
+      .delete(pollVotes)
+      .where(eq(pollVotes.voterFingerprint, fingerprint))
+      .returning({ id: pollVotes.id })
+    return deleted.length
+  }
 }

--- a/apps/core/src/modules/poll/poll.module.ts
+++ b/apps/core/src/modules/poll/poll.module.ts
@@ -1,13 +1,13 @@
 import { Module } from '@nestjs/common'
 
-import { PollDefinitionRepository } from './poll-definition.repository'
 import { PollController } from './poll.controller'
 import { PollService } from './poll.service'
+import { PollDefinitionRepository } from './poll-definition.repository'
 import { PollVoteRepository } from './poll-vote.repository'
 
 @Module({
   controllers: [PollController],
   providers: [PollService, PollVoteRepository, PollDefinitionRepository],
-  exports: [PollService],
+  exports: [PollService, PollVoteRepository],
 })
 export class PollModule {}

--- a/apps/core/src/processors/database/postgres.lock.ts
+++ b/apps/core/src/processors/database/postgres.lock.ts
@@ -51,3 +51,13 @@ export const SCHEMA_MIGRATION_LOCK_KEY = 7607331879281575547n
  * as a signed bigint.
  */
 export const APP_MIGRATION_LOCK_KEY = 5183248167463294041n
+
+/**
+ * Project-specific advisory lock key for App Review demo provisioning, so two
+ * replicas cannot generate two different demo passwords.
+ *
+ * Derived from `sha256("mx-core:review-demo-sync:v1")`, taking the first 8
+ * bytes as a signed bigint. The constant is asserted in tests so that it is
+ * only changed deliberately.
+ */
+export const REVIEW_DEMO_SYNC_LOCK_KEY = -3216835155137105914n

--- a/apps/core/test/src/contracts/admin/comments-admin.contract.spec.ts
+++ b/apps/core/test/src/contracts/admin/comments-admin.contract.spec.ts
@@ -28,6 +28,7 @@ import {
 } from '../../../helper/api-shape'
 import { createE2EApp } from '../../../helper/create-e2e-app'
 import { authPassHeader } from '../../../mock/guard/auth.guard'
+import { authProvider } from '../../../mock/modules/auth.mock'
 import { eventEmitterProvider } from '../../../mock/processors/event.mock'
 
 const POST_REF = {
@@ -216,6 +217,7 @@ describe('CommentController admin contract (e2e)', () => {
   const proxy = createE2EApp({
     controllers: [CommentController],
     providers: [
+      authProvider,
       commentServiceProvider,
       lifecycleProvider,
       configsProvider,

--- a/apps/core/test/src/contracts/comment.contract.spec.ts
+++ b/apps/core/test/src/contracts/comment.contract.spec.ts
@@ -17,6 +17,7 @@ import {
 } from '../../helper/api-shape'
 import { createE2EApp } from '../../helper/create-e2e-app'
 import { authPassHeader } from '../../mock/guard/auth.guard'
+import { authProvider } from '../../mock/modules/auth.mock'
 import { eventEmitterProvider } from '../../mock/processors/event.mock'
 
 /**
@@ -214,6 +215,7 @@ describe('CommentController contract (e2e)', () => {
   const proxy = createE2EApp({
     controllers: [CommentController],
     providers: [
+      authProvider,
       commentServiceProvider,
       lifecycleProvider,
       configsProvider,

--- a/apps/core/test/src/contracts/yohaku/comment-thread.contract.spec.ts
+++ b/apps/core/test/src/contracts/yohaku/comment-thread.contract.spec.ts
@@ -28,6 +28,7 @@ import {
   assertPgTimestamps,
 } from '../../../helper/api-shape'
 import { createE2EApp } from '../../../helper/create-e2e-app'
+import { authProvider } from '../../../mock/modules/auth.mock'
 import { eventEmitterProvider } from '../../../mock/processors/event.mock'
 
 const fixtureComment = (overrides: Record<string, unknown> = {}) => ({
@@ -130,6 +131,7 @@ describe('Yohaku contract — comment thread (e2e)', () => {
   const proxy = createE2EApp({
     controllers: [CommentController],
     providers: [
+      authProvider,
       commentServiceProvider,
       lifecycleProvider,
       configsProvider,

--- a/apps/core/test/src/modules/auth/auth.implement.spec.ts
+++ b/apps/core/test/src/modules/auth/auth.implement.spec.ts
@@ -1,16 +1,23 @@
+import { betterAuth } from 'better-auth'
+import { memoryAdapter } from 'better-auth/adapters/memory'
 import { APIError } from 'better-auth/api'
+import { username } from 'better-auth/plugins'
 import { describe, expect, it, vi } from 'vitest'
 
-/**
- * Test the api wrapper created in auth.implement.ts CreateAuth().
- * Since CreateAuth requires MongoDB + full betterAuth, we replicate
- * the wrapping logic here to verify behavior in isolation.
- *
- * `listUserAccounts` is a normal endpoint (sessionMiddleware + adapter); it may
- * reject with `APIError` for several reasons. CreateAuth's wrapper turns
- * `APIError` into null so `getSessionUserFromHeaders` does not throw (see
- * AuthService tests for null account list behavior).
- */
+import {
+  assertUserDeletionAllowed,
+  createCredentialSignInHook,
+  reviewDemoDatabaseHooks,
+} from '~/modules/auth/auth.implement'
+import { validateMxUsername } from '~/modules/auth/auth.username-validator'
+import type { CredentialSignInGate } from '~/modules/auth/email-sign-in-gate'
+import {
+  REVIEW_DEMO_EMAIL,
+  REVIEW_DEMO_HANDLE,
+} from '~/modules/auth/review-demo.constants'
+
+const TEST_PASSWORD = 'strong-password-1'
+
 function createApiWrapper(mockApi: Record<string, any>) {
   const _listUserAccounts = mockApi.listUserAccounts.bind(mockApi)
   return Object.assign(mockApi, {
@@ -28,6 +35,66 @@ function createApiWrapper(mockApi: Record<string, any>) {
       }
     },
   })
+}
+
+function buildCredentialAuth(
+  getCredentialSignInGate: () => Promise<CredentialSignInGate>,
+) {
+  const database: Record<string, any[]> = {
+    account: [],
+    session: [],
+    user: [],
+    verification: [],
+  }
+  return betterAuth({
+    appName: 'mx-core-test',
+    basePath: '/auth',
+    baseURL: 'http://localhost',
+    database: memoryAdapter(database),
+    databaseHooks: reviewDemoDatabaseHooks,
+    emailAndPassword: { disableSignUp: false, enabled: true },
+    hooks: { before: createCredentialSignInHook(getCredentialSignInGate) },
+    plugins: [username({ usernameValidator: validateMxUsername })],
+    secret: 'test-secret-test-secret-test-secret-12345',
+    telemetry: { enabled: false },
+    user: {
+      additionalFields: {
+        handle: { defaultValue: '', type: 'string' },
+        role: { defaultValue: 'reader', input: false, type: 'string' },
+      },
+      deleteUser: {
+        beforeDelete: async (user) => assertUserDeletionAllowed(user),
+        enabled: true,
+      },
+    },
+  })
+}
+
+async function signUp(
+  auth: ReturnType<typeof buildCredentialAuth>,
+  input: { email: string; name: string; username: string },
+) {
+  return auth.api.signUpEmail({
+    body: { ...input, password: TEST_PASSWORD },
+    returnHeaders: true,
+  })
+}
+
+async function postAuth(
+  auth: ReturnType<typeof buildCredentialAuth>,
+  path: string,
+  body: Record<string, unknown>,
+  cookie?: string | null,
+) {
+  const headers = new Headers({ 'content-type': 'application/json' })
+  if (cookie) headers.set('cookie', cookie)
+  return auth.handler(
+    new Request(`http://localhost/auth${path}`, {
+      body: JSON.stringify(body),
+      headers,
+      method: 'POST',
+    }),
+  )
 }
 
 describe('auth.implement api wrapper', () => {
@@ -88,5 +155,170 @@ describe('auth.implement api wrapper', () => {
 
       expect(api.getProviders({})).toEqual([])
     })
+  })
+})
+
+describe('credential auth endpoints', () => {
+  it('enforces every email and username gate combination through Better Auth', async () => {
+    let gate: CredentialSignInGate = {
+      disablePasswordLogin: false,
+      reviewDemoBanned: false,
+      reviewDemoEnabled: true,
+    }
+    const auth = buildCredentialAuth(async () => gate)
+    await signUp(auth, {
+      email: REVIEW_DEMO_EMAIL,
+      name: 'App Reviewer',
+      username: REVIEW_DEMO_HANDLE,
+    })
+    await signUp(auth, {
+      email: 'owner@example.com',
+      name: 'Owner',
+      username: 'owner',
+    })
+
+    for (const disablePasswordLogin of [false, true]) {
+      for (const reviewDemoEnabled of [false, true]) {
+        for (const reviewDemoBanned of [false, true]) {
+          gate = {
+            disablePasswordLogin,
+            reviewDemoBanned,
+            reviewDemoEnabled,
+          }
+          const demoEmail = await postAuth(auth, '/sign-in/email', {
+            email: REVIEW_DEMO_EMAIL,
+            password: TEST_PASSWORD,
+          })
+          const demoUsername = await postAuth(auth, '/sign-in/username', {
+            password: TEST_PASSWORD,
+            username: REVIEW_DEMO_HANDLE,
+          })
+          const ownerEmail = await postAuth(auth, '/sign-in/email', {
+            email: 'owner@example.com',
+            password: TEST_PASSWORD,
+          })
+          const ownerUsername = await postAuth(auth, '/sign-in/username', {
+            password: TEST_PASSWORD,
+            username: 'owner',
+          })
+
+          expect(demoEmail.status).toBe(
+            reviewDemoEnabled && !reviewDemoBanned ? 200 : 401,
+          )
+          expect(demoUsername.status).toBe(
+            !disablePasswordLogin && reviewDemoEnabled && !reviewDemoBanned
+              ? 200
+              : 401,
+          )
+          expect(ownerEmail.status).toBe(disablePasswordLogin ? 401 : 200)
+          expect(ownerUsername.status).toBe(disablePasswordLogin ? 401 : 200)
+        }
+      }
+    }
+  })
+
+  it('rejects deleting the reserved demo account', async () => {
+    const auth = buildCredentialAuth(async () => ({
+      disablePasswordLogin: false,
+      reviewDemoBanned: false,
+      reviewDemoEnabled: true,
+    }))
+    const created = await signUp(auth, {
+      email: REVIEW_DEMO_EMAIL,
+      name: 'App Reviewer',
+      username: REVIEW_DEMO_HANDLE,
+    })
+
+    const response = await postAuth(
+      auth,
+      '/delete-user',
+      { password: TEST_PASSWORD },
+      created.headers.get('set-cookie'),
+    )
+
+    expect(response.status).toBe(403)
+  })
+
+  it('rejects changing the reserved demo password', async () => {
+    const auth = buildCredentialAuth(async () => ({
+      disablePasswordLogin: false,
+      reviewDemoBanned: false,
+      reviewDemoEnabled: true,
+    }))
+    const created = await signUp(auth, {
+      email: REVIEW_DEMO_EMAIL,
+      name: 'App Reviewer',
+      username: REVIEW_DEMO_HANDLE,
+    })
+
+    const response = await postAuth(
+      auth,
+      '/change-password',
+      {
+        currentPassword: TEST_PASSWORD,
+        newPassword: 'different-password-2',
+      },
+      created.headers.get('set-cookie'),
+    )
+
+    expect(response.status).toBe(403)
+  })
+
+  it('allows profile updates but rejects reserved identity updates', async () => {
+    const auth = buildCredentialAuth(async () => ({
+      disablePasswordLogin: false,
+      reviewDemoBanned: false,
+      reviewDemoEnabled: true,
+    }))
+    const created = await signUp(auth, {
+      email: REVIEW_DEMO_EMAIL,
+      name: 'App Reviewer',
+      username: REVIEW_DEMO_HANDLE,
+    })
+    const cookie = created.headers.get('set-cookie')
+
+    const profileResponse = await postAuth(
+      auth,
+      '/update-user',
+      { image: 'https://example.com/reviewer.png', name: 'Reviewer' },
+      cookie,
+    )
+    const handleResponse = await postAuth(
+      auth,
+      '/update-user',
+      { handle: 'changed', name: 'Reviewer' },
+      cookie,
+    )
+    const usernameResponse = await postAuth(
+      auth,
+      '/update-user',
+      { name: 'Reviewer', username: 'changed' },
+      cookie,
+    )
+    const emailResponse = await postAuth(
+      auth,
+      '/update-user',
+      { email: 'changed@example.com', name: 'Reviewer' },
+      cookie,
+    )
+    const roleResponse = await postAuth(
+      auth,
+      '/update-user',
+      { name: 'Reviewer', role: 'owner' },
+      cookie,
+    )
+    const idResponse = await postAuth(
+      auth,
+      '/update-user',
+      { id: 'changed-id', name: 'Reviewer' },
+      cookie,
+    )
+
+    expect(profileResponse.status).toBe(200)
+    expect(handleResponse.status).toBe(403)
+    expect(usernameResponse.status).toBe(403)
+    expect(emailResponse.status).toBe(400)
+    expect(roleResponse.status).toBe(403)
+    expect(idResponse.status).toBe(403)
   })
 })

--- a/apps/core/test/src/modules/auth/auth.middleware.spec.ts
+++ b/apps/core/test/src/modules/auth/auth.middleware.spec.ts
@@ -151,6 +151,8 @@ describe('AuthMiddleware', () => {
       expect(shouldBypassBetterAuth('/auth/token')).toBe(true)
       expect(shouldBypassBetterAuth('/auth/session?x=1')).toBe(true)
       expect(shouldBypassBetterAuth('/api/v2/auth/providers/')).toBe(true)
+      expect(shouldBypassBetterAuth('/auth/review-demo')).toBe(true)
+      expect(shouldBypassBetterAuth('/api/v2/auth/review-demo/')).toBe(true)
 
       expect(shouldBypassBetterAuth('/auth/device/token')).toBe(false)
       expect(shouldBypassBetterAuth('/api/v2/auth/device/token')).toBe(false)

--- a/apps/core/test/src/modules/auth/auth.service.spec.ts
+++ b/apps/core/test/src/modules/auth/auth.service.spec.ts
@@ -2,10 +2,7 @@ import { describe, expect, it, vi } from 'vitest'
 
 import { AppException } from '~/common/errors/exception.types'
 import { AuthService } from '~/modules/auth/auth.service'
-import {
-  REVIEW_DEMO_EMAIL,
-  REVIEW_DEMO_HANDLE,
-} from '~/modules/auth/review-demo.constants'
+import { REVIEW_DEMO_EMAIL } from '~/modules/auth/review-demo.constants'
 
 const createService = () => {
   const authRepository = {
@@ -147,8 +144,8 @@ describe('AuthService', () => {
     readerRepository.findById.mockResolvedValue({
       id: 'demo-1',
       email: REVIEW_DEMO_EMAIL,
-      handle: REVIEW_DEMO_HANDLE,
-      username: REVIEW_DEMO_HANDLE,
+      handle: 'changed-handle',
+      username: 'changed-username',
     })
 
     await expect(service.transferOwnerRole('demo-1')).rejects.toThrow(

--- a/apps/core/test/src/modules/auth/auth.service.spec.ts
+++ b/apps/core/test/src/modules/auth/auth.service.spec.ts
@@ -2,6 +2,10 @@ import { describe, expect, it, vi } from 'vitest'
 
 import { AppException } from '~/common/errors/exception.types'
 import { AuthService } from '~/modules/auth/auth.service'
+import {
+  REVIEW_DEMO_EMAIL,
+  REVIEW_DEMO_HANDLE,
+} from '~/modules/auth/review-demo.constants'
 
 const createService = () => {
   const authRepository = {
@@ -17,6 +21,8 @@ const createService = () => {
     countOwners: vi.fn(),
     existsByUsernameOrEmail: vi.fn(),
     createReader: vi.fn(),
+    setRole: vi.fn(),
+    setOwnersExceptToReader: vi.fn(),
   }
   const ownerRepository = {
     upsertByReaderId: vi.fn(),
@@ -134,5 +140,20 @@ describe('AuthService', () => {
     expect(sessionHeaders.get('authorization')).toBe(
       'Bearer device-access-token',
     )
+  })
+
+  it('rejects transferring owner to the app review demo reader', async () => {
+    const { readerRepository, service } = createService()
+    readerRepository.findById.mockResolvedValue({
+      id: 'demo-1',
+      email: REVIEW_DEMO_EMAIL,
+      handle: REVIEW_DEMO_HANDLE,
+      username: REVIEW_DEMO_HANDLE,
+    })
+
+    await expect(service.transferOwnerRole('demo-1')).rejects.toThrow(
+      AppException,
+    )
+    expect(readerRepository.setRole).not.toHaveBeenCalled()
   })
 })

--- a/apps/core/test/src/modules/auth/email-sign-in-gate.spec.ts
+++ b/apps/core/test/src/modules/auth/email-sign-in-gate.spec.ts
@@ -1,16 +1,18 @@
 import { describe, expect, it } from 'vitest'
 
 import {
+  type CredentialSignInGate,
   denyEmailSignIn,
-  type EmailSignInGate,
+  denyUsernameSignIn,
 } from '~/modules/auth/email-sign-in-gate'
 import {
+  isReviewDemoEmail,
   isReviewDemoEnabled,
-  isReviewDemoIdentity,
+  isReviewDemoProvisioned,
   REVIEW_DEMO_EMAIL,
 } from '~/modules/auth/review-demo.constants'
 
-const open: EmailSignInGate = {
+const open: CredentialSignInGate = {
   disablePasswordLogin: false,
   reviewDemoEnabled: true,
   reviewDemoBanned: false,
@@ -56,7 +58,40 @@ describe('denyEmailSignIn', () => {
   })
 })
 
-describe('isReviewDemoEnabled / isReviewDemoIdentity', () => {
+describe('denyUsernameSignIn', () => {
+  it('denies every username when password login is disabled', () => {
+    expect(
+      denyUsernameSignIn('owner', {
+        ...open,
+        disablePasswordLogin: true,
+      }),
+    ).toBe(true)
+    expect(
+      denyUsernameSignIn('app-review', {
+        ...open,
+        disablePasswordLogin: true,
+      }),
+    ).toBe(true)
+  })
+
+  it('denies the demo username when the demo is disabled or banned', () => {
+    expect(
+      denyUsernameSignIn('app-review', {
+        ...open,
+        reviewDemoEnabled: false,
+      }),
+    ).toBe(true)
+    expect(
+      denyUsernameSignIn('app-review', {
+        ...open,
+        reviewDemoBanned: true,
+      }),
+    ).toBe(true)
+    expect(denyUsernameSignIn('owner', open)).toBe(false)
+  })
+})
+
+describe('review demo identity', () => {
   it('reads only apple.reviewDemoEnabled === "true"', () => {
     expect(
       isReviewDemoEnabled({
@@ -70,17 +105,36 @@ describe('isReviewDemoEnabled / isReviewDemoIdentity', () => {
     ).toBe(false)
   })
 
-  it('matches the reserved email and handle', () => {
+  it('reserves the email independently of mutable profile fields', () => {
+    const mutatedProfile = {
+      email: REVIEW_DEMO_EMAIL,
+      handle: 'someone-else',
+    }
     expect(
-      isReviewDemoIdentity({
+      isReviewDemoEmail({
         email: REVIEW_DEMO_EMAIL,
+      }),
+    ).toBe(true)
+    expect(isReviewDemoEmail(mutatedProfile)).toBe(true)
+  })
+
+  it('requires the complete immutable provisioned shape', () => {
+    expect(
+      isReviewDemoProvisioned({
+        email: REVIEW_DEMO_EMAIL,
+        emailVerified: true,
         handle: 'app-review',
+        role: 'reader',
+        username: 'app-review',
       }),
     ).toBe(true)
     expect(
-      isReviewDemoIdentity({
+      isReviewDemoProvisioned({
         email: REVIEW_DEMO_EMAIL,
+        emailVerified: true,
         handle: 'someone-else',
+        role: 'reader',
+        username: 'app-review',
       }),
     ).toBe(false)
   })

--- a/apps/core/test/src/modules/auth/email-sign-in-gate.spec.ts
+++ b/apps/core/test/src/modules/auth/email-sign-in-gate.spec.ts
@@ -1,0 +1,87 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  denyEmailSignIn,
+  type EmailSignInGate,
+} from '~/modules/auth/email-sign-in-gate'
+import {
+  isReviewDemoEnabled,
+  isReviewDemoIdentity,
+  REVIEW_DEMO_EMAIL,
+} from '~/modules/auth/review-demo.constants'
+
+const open: EmailSignInGate = {
+  disablePasswordLogin: false,
+  reviewDemoEnabled: true,
+  reviewDemoBanned: false,
+}
+
+describe('denyEmailSignIn', () => {
+  it('allows the demo email when the toggle is on and the reader is not banned', () => {
+    expect(denyEmailSignIn(REVIEW_DEMO_EMAIL, open)).toBe(false)
+    expect(
+      denyEmailSignIn(REVIEW_DEMO_EMAIL, {
+        ...open,
+        disablePasswordLogin: true,
+      }),
+    ).toBe(false)
+  })
+
+  it('denies the demo email when the toggle is off or the reader is banned', () => {
+    expect(
+      denyEmailSignIn(REVIEW_DEMO_EMAIL, {
+        ...open,
+        reviewDemoEnabled: false,
+      }),
+    ).toBe(true)
+    expect(
+      denyEmailSignIn(REVIEW_DEMO_EMAIL, {
+        ...open,
+        reviewDemoBanned: true,
+      }),
+    ).toBe(true)
+  })
+
+  it('denies every other email when password login is disabled', () => {
+    expect(
+      denyEmailSignIn('owner@example.com', {
+        ...open,
+        disablePasswordLogin: true,
+      }),
+    ).toBe(true)
+  })
+
+  it('allows every other email when password login is enabled', () => {
+    expect(denyEmailSignIn('owner@example.com', open)).toBe(false)
+  })
+})
+
+describe('isReviewDemoEnabled / isReviewDemoIdentity', () => {
+  it('reads only apple.reviewDemoEnabled === "true"', () => {
+    expect(
+      isReviewDemoEnabled({
+        public: { apple: { reviewDemoEnabled: 'true' } },
+      }),
+    ).toBe(true)
+    expect(
+      isReviewDemoEnabled({
+        public: { apple: { reviewDemoEnabled: '' } },
+      }),
+    ).toBe(false)
+  })
+
+  it('matches the reserved email and handle', () => {
+    expect(
+      isReviewDemoIdentity({
+        email: REVIEW_DEMO_EMAIL,
+        handle: 'app-review',
+      }),
+    ).toBe(true)
+    expect(
+      isReviewDemoIdentity({
+        email: REVIEW_DEMO_EMAIL,
+        handle: 'someone-else',
+      }),
+    ).toBe(false)
+  })
+})

--- a/apps/core/test/src/modules/auth/review-demo-config-persistence.spec.ts
+++ b/apps/core/test/src/modules/auth/review-demo-config-persistence.spec.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import { RedisKeys } from '~/constants/cache.constant'
+import { ConfigsService } from '~/modules/configs/configs.service'
+import { getRedisKey } from '~/utils/redis.util'
+
+const REVIEW_PASSWORD = 'persistent-review-password'
+
+describe('review demo OAuth secret persistence', () => {
+  it('keeps the password encrypted through enable, disable, and re-enable saves', async () => {
+    let cachedConfig: string | null = null
+    const storedOptions = new Map<string, unknown>()
+    const redisClient = {
+      get: vi.fn(async () => cachedConfig),
+      set: vi.fn(async (_key: string, value: string) => {
+        cachedConfig = value
+        return 'OK'
+      }),
+    }
+    const optionsRepository = {
+      findAll: vi.fn(async () => []),
+      upsert: vi.fn(async (name: string, value: unknown) => {
+        storedOptions.set(name, structuredClone(value))
+        return { id: 'oauth-option', name, value }
+      }),
+    }
+    const service = new ConfigsService(
+      optionsRepository as any,
+      {
+        getClient: vi.fn(() => redisClient),
+        waitForReady: vi.fn().mockResolvedValue(undefined),
+      } as any,
+      { bump: vi.fn() } as any,
+      { emit: vi.fn() } as any,
+    )
+    await service.onModuleInit()
+
+    await service.patchAndValid('oauth', {
+      public: { apple: { reviewDemoEnabled: 'true' } },
+      secrets: { apple: {} },
+    })
+    await service.patchAndValid('oauth', {
+      secrets: { apple: { reviewDemoPassword: REVIEW_PASSWORD } },
+    })
+
+    for (const reviewDemoEnabled of ['', 'true']) {
+      await service.patchAndValid('oauth', {
+        public: { apple: { reviewDemoEnabled } },
+        secrets: { apple: {} },
+      })
+      const rawOauth = storedOptions.get('oauth') as {
+        secrets: { apple: { reviewDemoPassword: string } }
+      }
+      expect(rawOauth.secrets.apple.reviewDemoPassword).not.toBe(
+        REVIEW_PASSWORD,
+      )
+      expect(
+        rawOauth.secrets.apple.reviewDemoPassword.startsWith('$${mx}$$'),
+      ).toBe(true)
+      await expect(service.get('oauth')).resolves.toMatchObject({
+        public: { apple: { reviewDemoEnabled } },
+        secrets: { apple: { reviewDemoPassword: REVIEW_PASSWORD } },
+      })
+      const cachedOauth = JSON.parse(cachedConfig!).oauth
+      expect(cachedOauth.secrets.apple.reviewDemoPassword).toBe(
+        rawOauth.secrets.apple.reviewDemoPassword,
+      )
+    }
+
+    expect(redisClient.set).toHaveBeenCalledWith(
+      getRedisKey(RedisKeys.ConfigCache),
+      expect.any(String),
+    )
+  })
+})

--- a/apps/core/test/src/modules/auth/review-demo.service.spec.ts
+++ b/apps/core/test/src/modules/auth/review-demo.service.spec.ts
@@ -75,6 +75,8 @@ function createHarness(options?: {
   enabled?: boolean
   password?: string
   reader?: ReturnType<typeof demoReader> | null
+  readerId?: string
+  usernameHolder?: { id: string; username: string } | null
   accounts?: DemoAccount[]
   disablePasswordLogin?: boolean
 }) {
@@ -89,7 +91,8 @@ function createHarness(options?: {
     secrets: {
       apple: {
         ...(options?.password ? { reviewDemoPassword: options.password } : {}),
-      },
+        ...(options?.readerId ? { reviewDemoReaderId: options.readerId } : {}),
+      } as Record<string, string>,
     },
   }
   const configsService = {
@@ -114,6 +117,12 @@ function createHarness(options?: {
   }
   const readerRepository = {
     findByEmail: vi.fn(async () => reader),
+    findByUsername: vi.fn(async (username: string) => {
+      if (options?.usernameHolder?.username === username) {
+        return options.usernameHolder
+      }
+      return reader?.username === username ? reader : null
+    }),
     create: vi.fn(async (input: ReturnType<typeof demoReader>) => {
       reader = demoReader(input)
       return reader
@@ -154,7 +163,7 @@ function createHarness(options?: {
     softDeleteComment: vi.fn(),
   }
   const commentRepository = {
-    findByFilter: vi.fn().mockResolvedValue([]),
+    paginatedFind: vi.fn().mockResolvedValue({ data: [] }),
   }
   const pollVoteRepository = {
     deleteByFingerprint: vi.fn().mockResolvedValue(0),
@@ -232,7 +241,12 @@ describe('ReviewDemoService', () => {
       }),
     )
     expect(configsService.patchAndValid).toHaveBeenCalledWith('oauth', {
-      secrets: { apple: { reviewDemoPassword: DEMO_PASSWORD } },
+      secrets: {
+        apple: {
+          reviewDemoPassword: DEMO_PASSWORD,
+          reviewDemoReaderId: DEMO_ID,
+        },
+      },
     })
   })
 
@@ -242,6 +256,7 @@ describe('ReviewDemoService', () => {
         enabled: true,
         password: 'kept-password',
         reader: demoReader(),
+        readerId: DEMO_ID,
         accounts: [{ id: ACCOUNT_ID, providerId: 'credential' }],
       })
 
@@ -257,6 +272,7 @@ describe('ReviewDemoService', () => {
     const { configsService, readerRepository, service } = createHarness({
       enabled: true,
       password: 'kept-password',
+      readerId: DEMO_ID,
       reader: demoReader({
         bannedAt: new Date('2026-01-01'),
         banReason: REVIEW_DEMO_BAN_REASON,
@@ -306,6 +322,7 @@ describe('ReviewDemoService', () => {
     const { authRepository, readerRepository, service } = createHarness({
       enabled: true,
       password: 'kept-password',
+      readerId: DEMO_ID,
       reader: demoReader({
         handle: 'someone-else',
         role: 'owner',
@@ -345,13 +362,95 @@ describe('ReviewDemoService', () => {
     await service.sync()
 
     expect(configsService.patchAndValid).toHaveBeenCalledWith('oauth', {
-      secrets: { apple: { reviewDemoPassword: DEMO_PASSWORD } },
+      secrets: {
+        apple: {
+          reviewDemoPassword: DEMO_PASSWORD,
+          reviewDemoReaderId: DEMO_ID,
+        },
+      },
     })
     expect(authRepository.updateAccountPassword).toHaveBeenCalledWith(
       ACCOUNT_ID,
       expect.any(String),
     )
     expect(authRepository.createAccount).not.toHaveBeenCalled()
+  })
+
+  it('adopts a legacy provisioned reader and records its id', async () => {
+    const { oauth, readerRepository, service } = createHarness({
+      enabled: true,
+      password: 'kept-password',
+      reader: demoReader(),
+      accounts: [{ id: ACCOUNT_ID, providerId: 'credential' }],
+    })
+
+    await service.sync()
+
+    expect(oauth.secrets.apple.reviewDemoReaderId).toBe(DEMO_ID)
+    expect(readerRepository.create).not.toHaveBeenCalled()
+  })
+
+  it('refuses to take over a foreign account holding the reserved email', async () => {
+    const foreign = demoReader({
+      id: 'foreign-1',
+      handle: 'real-person',
+      role: 'owner',
+      username: 'real-person',
+    })
+    const {
+      authRepository,
+      configsService,
+      getReader,
+      readerRepository,
+      service,
+    } = createHarness({
+      enabled: true,
+      reader: foreign,
+      accounts: [{ id: ACCOUNT_ID, providerId: 'credential' }],
+    })
+
+    await service.sync()
+
+    expect(readerRepository.update).not.toHaveBeenCalled()
+    expect(readerRepository.create).not.toHaveBeenCalled()
+    expect(authRepository.updateAccountPassword).not.toHaveBeenCalled()
+    expect(configsService.patchAndValid).not.toHaveBeenCalled()
+    expect(getReader()).toMatchObject({ id: 'foreign-1', role: 'owner' })
+    await expect(service.getCredentials()).resolves.toEqual({
+      enabled: true,
+      email: REVIEW_DEMO_EMAIL,
+      error: 'provision_failed',
+    })
+  })
+
+  it('refuses to provision when the reserved username is taken', async () => {
+    const { authRepository, configsService, readerRepository, service } =
+      createHarness({
+        enabled: true,
+        usernameHolder: { id: 'foreign-2', username: REVIEW_DEMO_HANDLE },
+      })
+
+    await service.sync()
+
+    expect(readerRepository.create).not.toHaveBeenCalled()
+    expect(authRepository.createAccount).not.toHaveBeenCalled()
+    expect(configsService.patchAndValid).not.toHaveBeenCalled()
+    await expect(service.getCredentials()).resolves.toEqual({
+      enabled: true,
+      email: REVIEW_DEMO_EMAIL,
+      error: 'provision_failed',
+    })
+  })
+
+  it('reports provision_failed instead of throwing when sync fails', async () => {
+    const { readerRepository, service } = createHarness({ enabled: true })
+    readerRepository.findByEmail.mockRejectedValueOnce(new Error('db down'))
+
+    await expect(service.getCredentials()).resolves.toEqual({
+      enabled: true,
+      email: REVIEW_DEMO_EMAIL,
+      error: 'provision_failed',
+    })
   })
 
   it('preserves a manual ban while reading the sign-in gate and credentials', async () => {
@@ -509,6 +608,9 @@ describe('ReviewDemoService', () => {
       }),
       deleteSessionsForUser: vi.fn(),
       findByEmail: vi.fn(async () => reader),
+      findByUsername: vi.fn(async (username: string) =>
+        reader?.username === username ? reader : null,
+      ),
       setBanned: vi.fn(),
       unsetBanned: vi.fn(),
       update: vi.fn(),
@@ -534,7 +636,7 @@ describe('ReviewDemoService', () => {
         .mockReturnValueOnce('account-b'),
     }
     const commentService = { softDeleteComment: vi.fn() }
-    const commentRepository = { findByFilter: vi.fn() }
+    const commentRepository = { paginatedFind: vi.fn() }
     const pollVoteRepository = { deleteByFingerprint: vi.fn() }
     const firstService = new ReviewDemoService(
       configsService as any,
@@ -601,10 +703,9 @@ describe('ReviewDemoService', () => {
         username: 'changed-username',
       }),
     })
-    commentRepository.findByFilter.mockResolvedValue([
-      { id: 'c1' },
-      { id: 'c2' },
-    ])
+    commentRepository.paginatedFind.mockResolvedValue({
+      data: [{ id: 'c1' }, { id: 'c2' }],
+    })
     pollVoteRepository.deleteByFingerprint.mockResolvedValue(3)
 
     await expect(service.resetDaily()).resolves.toEqual({
@@ -622,5 +723,48 @@ describe('ReviewDemoService', () => {
       image: null,
     })
     expect(readerRepository.deleteSessionsForUser).not.toHaveBeenCalled()
+  })
+
+  it('sweeps comments in batches until the reader has none left', async () => {
+    const { commentRepository, commentService, service } = createHarness({
+      enabled: true,
+      password: 'kept-password',
+      readerId: DEMO_ID,
+      reader: demoReader(),
+    })
+    const remaining = Array.from({ length: 120 }, (_, index) => ({
+      id: `c${index}`,
+    }))
+    commentRepository.paginatedFind.mockImplementation(async () => ({
+      data: remaining.slice(0, 50),
+    }))
+    commentService.softDeleteComment.mockImplementation(async (id: string) => {
+      const index = remaining.findIndex((comment) => comment.id === id)
+      if (index >= 0) remaining.splice(index, 1)
+    })
+
+    await expect(service.resetDaily()).resolves.toMatchObject({ comments: 120 })
+    expect(commentRepository.paginatedFind).toHaveBeenCalledWith(
+      { readerId: DEMO_ID, isDeleted: false },
+      1,
+      50,
+    )
+    expect(commentService.softDeleteComment).toHaveBeenCalledTimes(120)
+  })
+
+  it('aborts the sweep when a batch stops shrinking', async () => {
+    const { commentRepository, commentService, service } = createHarness({
+      enabled: true,
+      password: 'kept-password',
+      readerId: DEMO_ID,
+      reader: demoReader(),
+    })
+    const stuck = Array.from({ length: 50 }, (_, index) => ({
+      id: `stuck-${index}`,
+    }))
+    commentRepository.paginatedFind.mockResolvedValue({ data: stuck })
+
+    await expect(service.resetDaily()).resolves.toMatchObject({ comments: 50 })
+    expect(commentService.softDeleteComment).toHaveBeenCalledTimes(50)
   })
 })

--- a/apps/core/test/src/modules/auth/review-demo.service.spec.ts
+++ b/apps/core/test/src/modules/auth/review-demo.service.spec.ts
@@ -1,3 +1,4 @@
+import { verifyPassword } from 'better-auth/crypto'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import {
@@ -11,6 +12,47 @@ import { ReviewDemoService } from '~/modules/auth/review-demo.service'
 const DEMO_PASSWORD = 'generated-pass-1'
 const DEMO_ID = 'demo-reader-1'
 const ACCOUNT_ID = 'demo-account-1'
+
+type DemoAccount = {
+  id: string
+  password?: string
+  providerAccountId?: string
+  providerId: string
+  userId?: string
+}
+
+function createDeferred() {
+  let resolve!: () => void
+  const promise = new Promise<void>((innerResolve) => {
+    resolve = innerResolve
+  })
+  return { promise, resolve }
+}
+
+function createAdvisoryPool() {
+  let lockTail = Promise.resolve()
+  return {
+    connect: vi.fn(async () => {
+      let releaseLock = () => {}
+      return {
+        query: vi.fn(async (statement: string) => {
+          if (statement.includes('pg_advisory_lock')) {
+            const previousLock = lockTail
+            lockTail = new Promise<void>((resolve) => {
+              releaseLock = resolve
+            })
+            await previousLock
+          }
+          if (statement.includes('pg_advisory_unlock')) {
+            releaseLock()
+          }
+          return { rows: [] }
+        }),
+        release: vi.fn(),
+      }
+    }),
+  }
+}
 
 function demoReader(overrides?: Record<string, unknown>) {
   return {
@@ -33,9 +75,11 @@ function createHarness(options?: {
   enabled?: boolean
   password?: string
   reader?: ReturnType<typeof demoReader> | null
-  accounts?: Array<{ id: string; providerId: string }>
+  accounts?: DemoAccount[]
   disablePasswordLogin?: boolean
 }) {
+  let reader = options?.reader === undefined ? null : options.reader
+  const accounts = [...(options?.accounts ?? [])]
   const oauth = {
     public: {
       apple: {
@@ -69,19 +113,42 @@ function createHarness(options?: {
     ),
   }
   const readerRepository = {
-    findByEmail: vi
-      .fn()
-      .mockResolvedValue(options?.reader === undefined ? null : options.reader),
-    create: vi.fn().mockResolvedValue(demoReader()),
-    update: vi.fn(),
-    setBanned: vi.fn(),
-    unsetBanned: vi.fn(),
+    findByEmail: vi.fn(async () => reader),
+    create: vi.fn(async (input: ReturnType<typeof demoReader>) => {
+      reader = demoReader(input)
+      return reader
+    }),
+    update: vi.fn(
+      async (_id: string, patch: Partial<ReturnType<typeof demoReader>>) => {
+        if (!reader) return null
+        reader = { ...reader, ...patch }
+        return reader
+      },
+    ),
+    setBanned: vi.fn(
+      async (_id: string, patch: { bannedAt: Date; banReason: string }) => {
+        if (!reader) return null
+        reader = { ...reader, ...patch }
+        return reader
+      },
+    ),
+    unsetBanned: vi.fn(async () => {
+      if (!reader) return null
+      reader = { ...reader, bannedAt: null, banReason: null }
+      return reader
+    }),
     deleteSessionsForUser: vi.fn(),
   }
   const authRepository = {
-    createAccount: vi.fn(),
-    findAccountsForUser: vi.fn().mockResolvedValue(options?.accounts ?? []),
-    updateAccountPassword: vi.fn(),
+    createAccount: vi.fn(async (account: DemoAccount) => {
+      accounts.push(account)
+      return account
+    }),
+    findAccountsForUser: vi.fn(async () => accounts),
+    updateAccountPassword: vi.fn(async (id: string, password: string) => {
+      const account = accounts.find((item) => item.id === id)
+      if (account) account.password = password
+    }),
   }
   const commentService = {
     softDeleteComment: vi.fn(),
@@ -98,6 +165,13 @@ function createHarness(options?: {
       .mockReturnValueOnce(DEMO_ID)
       .mockReturnValueOnce(ACCOUNT_ID),
   }
+  const postgresClient = {
+    query: vi.fn().mockResolvedValue({ rows: [] }),
+    release: vi.fn(),
+  }
+  const postgresPool = {
+    connect: vi.fn().mockResolvedValue(postgresClient),
+  }
   const service = new ReviewDemoService(
     configsService as any,
     readerRepository as any,
@@ -106,6 +180,7 @@ function createHarness(options?: {
     commentService as any,
     commentRepository as any,
     pollVoteRepository as any,
+    postgresPool as any,
   )
   vi.spyOn(service, 'generatePassword').mockReturnValue(DEMO_PASSWORD)
   return {
@@ -113,10 +188,14 @@ function createHarness(options?: {
     commentRepository,
     commentService,
     configsService,
+    getReader: () => reader,
     oauth,
     pollVoteRepository,
     readerRepository,
     service,
+    setEnabled: (enabled: boolean) => {
+      oauth.public.apple.reviewDemoEnabled = enabled ? 'true' : ''
+    },
     snowflakeService,
   }
 }
@@ -190,11 +269,19 @@ describe('ReviewDemoService', () => {
     await service.sync()
 
     expect(readerRepository.unsetBanned).toHaveBeenCalledWith(DEMO_ID)
-    expect(readerRepository.update).toHaveBeenCalledWith(DEMO_ID, {
-      name: REVIEW_DEMO_NAME,
-      displayUsername: REVIEW_DEMO_NAME,
-      image: null,
-    })
+    expect(readerRepository.update).toHaveBeenCalledWith(
+      DEMO_ID,
+      expect.objectContaining({
+        displayUsername: REVIEW_DEMO_NAME,
+        email: REVIEW_DEMO_EMAIL,
+        emailVerified: true,
+        handle: REVIEW_DEMO_HANDLE,
+        image: null,
+        name: REVIEW_DEMO_NAME,
+        role: 'reader',
+        username: REVIEW_DEMO_HANDLE,
+      }),
+    )
     expect(configsService.patchAndValid).not.toHaveBeenCalled()
   })
 
@@ -215,13 +302,16 @@ describe('ReviewDemoService', () => {
     expect(readerRepository.create).not.toHaveBeenCalled()
   })
 
-  it('does not overwrite a non-demo occupant of the reserved email', async () => {
+  it('restores immutable identity fields for the reserved email', async () => {
     const { authRepository, readerRepository, service } = createHarness({
       enabled: true,
+      password: 'kept-password',
       reader: demoReader({
         handle: 'someone-else',
+        role: 'owner',
         username: 'someone-else',
       }),
+      accounts: [{ id: ACCOUNT_ID, providerId: 'credential' }],
     })
 
     await service.sync()
@@ -231,8 +321,18 @@ describe('ReviewDemoService', () => {
     await expect(service.getCredentials()).resolves.toEqual({
       enabled: true,
       email: REVIEW_DEMO_EMAIL,
-      error: 'provision_failed',
+      password: 'kept-password',
     })
+    expect(readerRepository.update).toHaveBeenCalledWith(
+      DEMO_ID,
+      expect.objectContaining({
+        email: REVIEW_DEMO_EMAIL,
+        emailVerified: true,
+        handle: REVIEW_DEMO_HANDLE,
+        role: 'reader',
+        username: REVIEW_DEMO_HANDLE,
+      }),
+    )
   })
 
   it('regenerates a missing password onto an existing credential account', async () => {
@@ -254,19 +354,222 @@ describe('ReviewDemoService', () => {
     expect(authRepository.createAccount).not.toHaveBeenCalled()
   })
 
-  it('maps disablePasswordLogin and bannedAt into the sign-in gate', async () => {
-    const { service } = createHarness({
+  it('preserves a manual ban while reading the sign-in gate and credentials', async () => {
+    const { getReader, readerRepository, service } = createHarness({
       enabled: true,
       password: 'kept-password',
-      reader: demoReader({ bannedAt: new Date() }),
+      reader: demoReader({
+        bannedAt: new Date(),
+        banReason: 'manual-abuse-ban',
+      }),
       disablePasswordLogin: true,
     })
 
-    await expect(service.getEmailSignInGate()).resolves.toEqual({
+    await expect(service.getCredentialSignInGate()).resolves.toEqual({
       disablePasswordLogin: true,
       reviewDemoEnabled: true,
       reviewDemoBanned: true,
     })
+    await expect(service.getCredentials()).resolves.toEqual({
+      enabled: true,
+      email: REVIEW_DEMO_EMAIL,
+      error: 'provision_failed',
+    })
+    expect(readerRepository.unsetBanned).not.toHaveBeenCalled()
+    expect(getReader()?.banReason).toBe('manual-abuse-ban')
+  })
+
+  it('unbans only the service ban across an off-to-on transition', async () => {
+    const { getReader, oauth, readerRepository, service, setEnabled } =
+      createHarness({
+        enabled: false,
+        password: 'kept-password',
+        reader: demoReader(),
+        accounts: [{ id: ACCOUNT_ID, providerId: 'credential' }],
+      })
+
+    await service.sync()
+    expect(getReader()).toMatchObject({
+      id: DEMO_ID,
+      banReason: REVIEW_DEMO_BAN_REASON,
+    })
+
+    setEnabled(true)
+    await service.sync()
+
+    expect(readerRepository.unsetBanned).toHaveBeenCalledWith(DEMO_ID)
+    expect(getReader()).toMatchObject({
+      id: DEMO_ID,
+      bannedAt: null,
+      banReason: null,
+    })
+    expect(oauth.secrets.apple.reviewDemoPassword).toBe('kept-password')
+  })
+
+  it('keeps the generated identity and password through disable and re-enable', async () => {
+    const {
+      authRepository,
+      getReader,
+      oauth,
+      readerRepository,
+      service,
+      setEnabled,
+    } = createHarness({ enabled: true })
+
+    await service.sync()
+    const readerId = getReader()?.id
+    const password = oauth.secrets.apple.reviewDemoPassword
+    setEnabled(false)
+    await service.sync()
+    setEnabled(true)
+    await service.sync()
+
+    expect(getReader()?.id).toBe(readerId)
+    expect(oauth.secrets.apple.reviewDemoPassword).toBe(password)
+    expect(service.generatePassword).toHaveBeenCalledOnce()
+    expect(readerRepository.create).toHaveBeenCalledOnce()
+    expect(authRepository.createAccount).toHaveBeenCalledOnce()
+  })
+
+  it('keeps a manual ban across an off-to-on transition', async () => {
+    const { getReader, readerRepository, service, setEnabled } = createHarness({
+      enabled: false,
+      password: 'kept-password',
+      reader: demoReader({
+        bannedAt: new Date(),
+        banReason: 'manual-abuse-ban',
+      }),
+      accounts: [{ id: ACCOUNT_ID, providerId: 'credential' }],
+    })
+
+    await service.sync()
+    setEnabled(true)
+    await service.sync()
+
+    expect(readerRepository.setBanned).not.toHaveBeenCalled()
+    expect(readerRepository.unsetBanned).not.toHaveBeenCalled()
+    expect(getReader()?.banReason).toBe('manual-abuse-ban')
+  })
+
+  it('coalesces overlapping sync calls and reruns with the latest toggle', async () => {
+    const started = createDeferred()
+    const release = createDeferred()
+    const { configsService, getReader, readerRepository, service, setEnabled } =
+      createHarness({ enabled: true })
+    const currentGet = configsService.get.getMockImplementation()!
+    configsService.get.mockImplementationOnce(async (key: string) => {
+      const value = structuredClone(await currentGet(key))
+      started.resolve()
+      await release.promise
+      return value
+    })
+
+    const firstSync = service.sync()
+    await started.promise
+    setEnabled(false)
+    const secondSync = service.sync()
+
+    expect(secondSync).toBe(firstSync)
+    release.resolve()
+    await secondSync
+
+    expect(readerRepository.create).toHaveBeenCalledOnce()
+    expect(readerRepository.setBanned).toHaveBeenCalledWith(DEMO_ID, {
+      bannedAt: expect.any(Date),
+      banReason: REVIEW_DEMO_BAN_REASON,
+    })
+    expect(readerRepository.deleteSessionsForUser).toHaveBeenCalledWith(DEMO_ID)
+    expect(getReader()?.banReason).toBe(REVIEW_DEMO_BAN_REASON)
+  })
+
+  it('serializes provisioning across service instances with the advisory lock', async () => {
+    const pool = createAdvisoryPool()
+    const oauth = {
+      public: { apple: { reviewDemoEnabled: 'true' } },
+      secrets: { apple: {} as Record<string, string> },
+    }
+    let reader: ReturnType<typeof demoReader> | null = null
+    const accounts: DemoAccount[] = []
+    const configsService = {
+      get: vi.fn(async () => oauth),
+      patchAndValid: vi.fn(
+        async (
+          _key: string,
+          value: { secrets: { apple: Record<string, string> } },
+        ) => {
+          Object.assign(oauth.secrets.apple, value.secrets.apple)
+          return oauth
+        },
+      ),
+    }
+    const readerRepository = {
+      create: vi.fn(async (input: ReturnType<typeof demoReader>) => {
+        reader = demoReader(input)
+        return reader
+      }),
+      deleteSessionsForUser: vi.fn(),
+      findByEmail: vi.fn(async () => reader),
+      setBanned: vi.fn(),
+      unsetBanned: vi.fn(),
+      update: vi.fn(),
+    }
+    const authRepository = {
+      createAccount: vi.fn(async (account: DemoAccount) => {
+        accounts.push(account)
+        return account
+      }),
+      findAccountsForUser: vi.fn(async () => accounts),
+      updateAccountPassword: vi.fn(),
+    }
+    const firstSnowflake = {
+      nextId: vi
+        .fn()
+        .mockReturnValueOnce('reader-a')
+        .mockReturnValueOnce('account-a'),
+    }
+    const secondSnowflake = {
+      nextId: vi
+        .fn()
+        .mockReturnValueOnce('reader-b')
+        .mockReturnValueOnce('account-b'),
+    }
+    const commentService = { softDeleteComment: vi.fn() }
+    const commentRepository = { findByFilter: vi.fn() }
+    const pollVoteRepository = { deleteByFingerprint: vi.fn() }
+    const firstService = new ReviewDemoService(
+      configsService as any,
+      readerRepository as any,
+      authRepository as any,
+      firstSnowflake as any,
+      commentService as any,
+      commentRepository as any,
+      pollVoteRepository as any,
+      pool,
+    )
+    const secondService = new ReviewDemoService(
+      configsService as any,
+      readerRepository as any,
+      authRepository as any,
+      secondSnowflake as any,
+      commentService as any,
+      commentRepository as any,
+      pollVoteRepository as any,
+      pool,
+    )
+    vi.spyOn(firstService, 'generatePassword').mockReturnValue('password-a')
+    vi.spyOn(secondService, 'generatePassword').mockReturnValue('password-b')
+
+    await Promise.all([firstService.sync(), secondService.sync()])
+
+    expect(configsService.patchAndValid).toHaveBeenCalledOnce()
+    expect(readerRepository.create).toHaveBeenCalledOnce()
+    expect(authRepository.createAccount).toHaveBeenCalledOnce()
+    const password = oauth.secrets.apple.reviewDemoPassword
+    expect(['password-a', 'password-b']).toContain(password)
+    await expect(
+      verifyPassword({ hash: accounts[0].password!, password }),
+    ).resolves.toBe(true)
+    expect(accounts[0].userId).toBe(reader?.id)
   })
 
   it('skips daily reset when the toggle is off', async () => {
@@ -292,8 +595,10 @@ describe('ReviewDemoService', () => {
       enabled: true,
       password: 'kept-password',
       reader: demoReader({
+        handle: 'changed-handle',
         name: 'Changed',
         image: 'https://example.com/x.png',
+        username: 'changed-username',
       }),
     })
     commentRepository.findByFilter.mockResolvedValue([

--- a/apps/core/test/src/modules/auth/review-demo.service.spec.ts
+++ b/apps/core/test/src/modules/auth/review-demo.service.spec.ts
@@ -1,0 +1,321 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import {
+  REVIEW_DEMO_BAN_REASON,
+  REVIEW_DEMO_EMAIL,
+  REVIEW_DEMO_HANDLE,
+  REVIEW_DEMO_NAME,
+} from '~/modules/auth/review-demo.constants'
+import { ReviewDemoService } from '~/modules/auth/review-demo.service'
+
+const DEMO_PASSWORD = 'generated-pass-1'
+const DEMO_ID = 'demo-reader-1'
+const ACCOUNT_ID = 'demo-account-1'
+
+function demoReader(overrides?: Record<string, unknown>) {
+  return {
+    id: DEMO_ID,
+    email: REVIEW_DEMO_EMAIL,
+    emailVerified: true,
+    name: REVIEW_DEMO_NAME,
+    handle: REVIEW_DEMO_HANDLE,
+    username: REVIEW_DEMO_HANDLE,
+    displayUsername: REVIEW_DEMO_NAME,
+    image: null,
+    role: 'reader',
+    bannedAt: null,
+    banReason: null,
+    ...overrides,
+  }
+}
+
+function createHarness(options?: {
+  enabled?: boolean
+  password?: string
+  reader?: ReturnType<typeof demoReader> | null
+  accounts?: Array<{ id: string; providerId: string }>
+  disablePasswordLogin?: boolean
+}) {
+  const oauth = {
+    public: {
+      apple: {
+        reviewDemoEnabled: options?.enabled === false ? '' : 'true',
+      },
+    },
+    secrets: {
+      apple: {
+        ...(options?.password ? { reviewDemoPassword: options.password } : {}),
+      },
+    },
+  }
+  const configsService = {
+    get: vi.fn(async (key: string) => {
+      if (key === 'oauth') return oauth
+      if (key === 'authSecurity') {
+        return { disablePasswordLogin: options?.disablePasswordLogin ?? false }
+      }
+      return {}
+    }),
+    patchAndValid: vi.fn(
+      async (_key: string, value: { secrets?: typeof oauth.secrets }) => {
+        if (value.secrets?.apple) {
+          oauth.secrets.apple = {
+            ...oauth.secrets.apple,
+            ...value.secrets.apple,
+          }
+        }
+        return oauth
+      },
+    ),
+  }
+  const readerRepository = {
+    findByEmail: vi
+      .fn()
+      .mockResolvedValue(options?.reader === undefined ? null : options.reader),
+    create: vi.fn().mockResolvedValue(demoReader()),
+    update: vi.fn(),
+    setBanned: vi.fn(),
+    unsetBanned: vi.fn(),
+    deleteSessionsForUser: vi.fn(),
+  }
+  const authRepository = {
+    createAccount: vi.fn(),
+    findAccountsForUser: vi.fn().mockResolvedValue(options?.accounts ?? []),
+    updateAccountPassword: vi.fn(),
+  }
+  const commentService = {
+    softDeleteComment: vi.fn(),
+  }
+  const commentRepository = {
+    findByFilter: vi.fn().mockResolvedValue([]),
+  }
+  const pollVoteRepository = {
+    deleteByFingerprint: vi.fn().mockResolvedValue(0),
+  }
+  const snowflakeService = {
+    nextId: vi
+      .fn()
+      .mockReturnValueOnce(DEMO_ID)
+      .mockReturnValueOnce(ACCOUNT_ID),
+  }
+  const service = new ReviewDemoService(
+    configsService as any,
+    readerRepository as any,
+    authRepository as any,
+    snowflakeService as any,
+    commentService as any,
+    commentRepository as any,
+    pollVoteRepository as any,
+  )
+  vi.spyOn(service, 'generatePassword').mockReturnValue(DEMO_PASSWORD)
+  return {
+    authRepository,
+    commentRepository,
+    commentService,
+    configsService,
+    oauth,
+    pollVoteRepository,
+    readerRepository,
+    service,
+    snowflakeService,
+  }
+}
+
+describe('ReviewDemoService', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('creates a reader and credential when the toggle is on and no account exists', async () => {
+    const { authRepository, configsService, readerRepository, service } =
+      createHarness({ enabled: true })
+
+    await service.sync()
+
+    expect(readerRepository.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        id: DEMO_ID,
+        email: REVIEW_DEMO_EMAIL,
+        emailVerified: true,
+        name: REVIEW_DEMO_NAME,
+        handle: REVIEW_DEMO_HANDLE,
+        username: REVIEW_DEMO_HANDLE,
+        displayUsername: REVIEW_DEMO_NAME,
+        role: 'reader',
+      }),
+    )
+    expect(authRepository.createAccount).toHaveBeenCalledWith(
+      expect.objectContaining({
+        id: ACCOUNT_ID,
+        providerAccountId: DEMO_ID,
+        providerId: 'credential',
+        userId: DEMO_ID,
+      }),
+    )
+    expect(configsService.patchAndValid).toHaveBeenCalledWith('oauth', {
+      secrets: { apple: { reviewDemoPassword: DEMO_PASSWORD } },
+    })
+  })
+
+  it('does not recreate or rotate when the demo reader already exists', async () => {
+    const { authRepository, configsService, readerRepository, service } =
+      createHarness({
+        enabled: true,
+        password: 'kept-password',
+        reader: demoReader(),
+        accounts: [{ id: ACCOUNT_ID, providerId: 'credential' }],
+      })
+
+    await service.sync()
+
+    expect(readerRepository.create).not.toHaveBeenCalled()
+    expect(authRepository.createAccount).not.toHaveBeenCalled()
+    expect(authRepository.updateAccountPassword).not.toHaveBeenCalled()
+    expect(configsService.patchAndValid).not.toHaveBeenCalled()
+  })
+
+  it('unbans and restores the default profile when re-enabled', async () => {
+    const { configsService, readerRepository, service } = createHarness({
+      enabled: true,
+      password: 'kept-password',
+      reader: demoReader({
+        bannedAt: new Date('2026-01-01'),
+        banReason: REVIEW_DEMO_BAN_REASON,
+        name: 'Changed',
+        image: 'https://example.com/x.png',
+      }),
+      accounts: [{ id: ACCOUNT_ID, providerId: 'credential' }],
+    })
+
+    await service.sync()
+
+    expect(readerRepository.unsetBanned).toHaveBeenCalledWith(DEMO_ID)
+    expect(readerRepository.update).toHaveBeenCalledWith(DEMO_ID, {
+      name: REVIEW_DEMO_NAME,
+      displayUsername: REVIEW_DEMO_NAME,
+      image: null,
+    })
+    expect(configsService.patchAndValid).not.toHaveBeenCalled()
+  })
+
+  it('bans the demo reader and clears sessions when the toggle is off', async () => {
+    const { readerRepository, service } = createHarness({
+      enabled: false,
+      password: 'kept-password',
+      reader: demoReader(),
+    })
+
+    await service.sync()
+
+    expect(readerRepository.setBanned).toHaveBeenCalledWith(DEMO_ID, {
+      bannedAt: expect.any(Date),
+      banReason: REVIEW_DEMO_BAN_REASON,
+    })
+    expect(readerRepository.deleteSessionsForUser).toHaveBeenCalledWith(DEMO_ID)
+    expect(readerRepository.create).not.toHaveBeenCalled()
+  })
+
+  it('does not overwrite a non-demo occupant of the reserved email', async () => {
+    const { authRepository, readerRepository, service } = createHarness({
+      enabled: true,
+      reader: demoReader({
+        handle: 'someone-else',
+        username: 'someone-else',
+      }),
+    })
+
+    await service.sync()
+
+    expect(readerRepository.create).not.toHaveBeenCalled()
+    expect(authRepository.createAccount).not.toHaveBeenCalled()
+    await expect(service.getCredentials()).resolves.toEqual({
+      enabled: true,
+      email: REVIEW_DEMO_EMAIL,
+      error: 'provision_failed',
+    })
+  })
+
+  it('regenerates a missing password onto an existing credential account', async () => {
+    const { authRepository, configsService, service } = createHarness({
+      enabled: true,
+      reader: demoReader(),
+      accounts: [{ id: ACCOUNT_ID, providerId: 'credential' }],
+    })
+
+    await service.sync()
+
+    expect(configsService.patchAndValid).toHaveBeenCalledWith('oauth', {
+      secrets: { apple: { reviewDemoPassword: DEMO_PASSWORD } },
+    })
+    expect(authRepository.updateAccountPassword).toHaveBeenCalledWith(
+      ACCOUNT_ID,
+      expect.any(String),
+    )
+    expect(authRepository.createAccount).not.toHaveBeenCalled()
+  })
+
+  it('maps disablePasswordLogin and bannedAt into the sign-in gate', async () => {
+    const { service } = createHarness({
+      enabled: true,
+      password: 'kept-password',
+      reader: demoReader({ bannedAt: new Date() }),
+      disablePasswordLogin: true,
+    })
+
+    await expect(service.getEmailSignInGate()).resolves.toEqual({
+      disablePasswordLogin: true,
+      reviewDemoEnabled: true,
+      reviewDemoBanned: true,
+    })
+  })
+
+  it('skips daily reset when the toggle is off', async () => {
+    const { commentService, pollVoteRepository, service } = createHarness({
+      enabled: false,
+      password: 'kept-password',
+      reader: demoReader(),
+    })
+
+    await expect(service.resetDaily()).resolves.toEqual({ skipped: true })
+    expect(commentService.softDeleteComment).not.toHaveBeenCalled()
+    expect(pollVoteRepository.deleteByFingerprint).not.toHaveBeenCalled()
+  })
+
+  it('soft-deletes comments, poll votes, and restores the default profile', async () => {
+    const {
+      commentRepository,
+      commentService,
+      pollVoteRepository,
+      readerRepository,
+      service,
+    } = createHarness({
+      enabled: true,
+      password: 'kept-password',
+      reader: demoReader({
+        name: 'Changed',
+        image: 'https://example.com/x.png',
+      }),
+    })
+    commentRepository.findByFilter.mockResolvedValue([
+      { id: 'c1' },
+      { id: 'c2' },
+    ])
+    pollVoteRepository.deleteByFingerprint.mockResolvedValue(3)
+
+    await expect(service.resetDaily()).resolves.toEqual({
+      comments: 2,
+      pollVotes: 3,
+    })
+    expect(commentService.softDeleteComment).toHaveBeenCalledWith('c1')
+    expect(commentService.softDeleteComment).toHaveBeenCalledWith('c2')
+    expect(pollVoteRepository.deleteByFingerprint).toHaveBeenCalledWith(
+      `r:${DEMO_ID}`,
+    )
+    expect(readerRepository.update).toHaveBeenCalledWith(DEMO_ID, {
+      name: REVIEW_DEMO_NAME,
+      displayUsername: REVIEW_DEMO_NAME,
+      image: null,
+    })
+    expect(readerRepository.deleteSessionsForUser).not.toHaveBeenCalled()
+  })
+})

--- a/apps/core/test/src/modules/comment/comment-reader-me.spec.ts
+++ b/apps/core/test/src/modules/comment/comment-reader-me.spec.ts
@@ -1,0 +1,139 @@
+import type { Pool } from 'pg'
+import {
+  createPgTestDatabase,
+  type PgTestDatabase,
+} from 'test/helper/pg-verify-url'
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'vitest'
+
+import { CollectionRefTypes } from '~/constants/db.constant'
+import { comments, readers } from '~/database/schema'
+import { CommentState } from '~/modules/comment/comment.enum'
+import { CommentRepository } from '~/modules/comment/comment.repository'
+import { CommentService } from '~/modules/comment/comment.service'
+import { SnowflakeService } from '~/shared/id/snowflake.service'
+
+const buildService = (repository: CommentRepository) =>
+  new CommentService(
+    repository,
+    {} as any,
+    {} as any,
+    { broadcast: async () => undefined } as any,
+    {} as any,
+    {} as any,
+    { lookupCountryCode: async () => null } as any,
+    { getClient: () => ({}) } as any,
+  )
+
+describe('CommentService.projectReaderComment', () => {
+  it('projects the joined ref into the mobile list contract', () => {
+    const service = buildService({} as CommentRepository)
+    expect(
+      service.projectReaderComment({
+        createdAt: new Date('2026-08-15T00:00:00.000Z'),
+        id: '1',
+        ref: {
+          category: { name: 'Coding', slug: 'coding' },
+          id: '2',
+          slug: 'hello',
+          title: 'Hello',
+          type: CollectionRefTypes.Post,
+        },
+        refId: '2',
+        refType: CollectionRefTypes.Post,
+        text: 'nice post',
+      } as any),
+    ).toEqual({
+      createdAt: new Date('2026-08-15T00:00:00.000Z'),
+      id: '1',
+      refId: '2',
+      refType: CollectionRefTypes.Post,
+      source: {
+        categorySlug: 'coding',
+        nid: null,
+        slug: 'hello',
+      },
+      sourceTitle: 'Hello',
+      text: 'nice post',
+    })
+  })
+
+  it('nulls source when the joined article is gone', () => {
+    const service = buildService({} as CommentRepository)
+    expect(
+      service.projectReaderComment({
+        createdAt: new Date('2026-08-15T00:00:00.000Z'),
+        id: '1',
+        ref: null,
+        refId: '2',
+        refType: CollectionRefTypes.Note,
+        text: 'orphan',
+      } as any),
+    ).toMatchObject({ source: null, sourceTitle: null })
+  })
+})
+
+describe.skipIf(!process.env.PG_VERIFY_URL)(
+  'CommentRepository reader comments',
+  () => {
+    let context: PgTestDatabase
+    let pool: Pool
+    let repository: CommentRepository
+    let snowflake: SnowflakeService
+    let readerId: string
+    let otherReaderId: string
+
+    beforeAll(async () => {
+      context = await createPgTestDatabase('mx_comment_reader_me')
+      pool = context.pool
+      snowflake = new SnowflakeService()
+      repository = new CommentRepository(context.db as any, snowflake)
+      readerId = snowflake.nextId()
+      otherReaderId = snowflake.nextId()
+      await context.db.insert(readers).values([
+        { id: readerId, name: 'Me' },
+        { id: otherReaderId, name: 'Other' },
+      ])
+    }, 60_000)
+
+    beforeEach(async () => {
+      await pool.query('truncate table comments restart identity cascade')
+    })
+
+    afterAll(async () => {
+      if (context) await context.close()
+    })
+
+    const insert = async (overrides: Partial<typeof comments.$inferInsert>) => {
+      const id = (overrides.id as string | undefined) ?? snowflake.nextId()
+      await context.db.insert(comments).values({
+        id,
+        isDeleted: false,
+        isOwnerReply: false,
+        isWhispers: false,
+        refId: snowflake.nextId(),
+        refType: CollectionRefTypes.Post,
+        state: CommentState.Read,
+        text: 'hi',
+        ...overrides,
+      })
+      return id
+    }
+
+    it('lists only the reader’s active comments', async () => {
+      const keep = await insert({ readerId, text: 'keep' })
+      await insert({ readerId, isDeleted: true, text: 'deleted' })
+      await insert({ readerId, state: CommentState.Junk, text: 'junk' })
+      await insert({ readerId: otherReaderId, text: 'other' })
+      await insert({ readerId: null, text: 'guest' })
+
+      const result = await repository.paginatedFind(
+        { excludeJunk: true, isDeleted: false, readerId },
+        1,
+        20,
+      )
+      expect(result.data.map((row) => row.text)).toEqual(['keep'])
+      expect(result.data[0]?.id).toBe(keep)
+      expect(result.pagination.total).toBe(1)
+    })
+  },
+)

--- a/apps/core/test/src/modules/comment/comment-report.spec.ts
+++ b/apps/core/test/src/modules/comment/comment-report.spec.ts
@@ -1,0 +1,56 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { AppException } from '~/common/errors/exception.types'
+import { CommentService } from '~/modules/comment/comment.service'
+
+describe('CommentService.reportComment', () => {
+  const redisStore = new Map<string, string>()
+  const redisClient = {
+    set: async (key: string, value: string, ...rest: unknown[]) => {
+      if (rest.includes('NX') && redisStore.has(key)) return null
+      redisStore.set(key, value)
+      return 'OK'
+    },
+  }
+  const eventManager = { broadcast: vi.fn().mockResolvedValue(undefined) }
+  const commentRepository = { findById: vi.fn() }
+  let service: CommentService
+
+  beforeEach(() => {
+    redisStore.clear()
+    eventManager.broadcast.mockClear()
+    commentRepository.findById.mockReset()
+    service = new CommentService(
+      commentRepository as any,
+      {} as any,
+      {} as any,
+      eventManager as any,
+      {} as any,
+      {} as any,
+      { lookupCountryCode: async () => null } as any,
+      { getClient: () => redisClient } as any,
+    )
+  })
+
+  it('notifies once and returns ok on a duplicate report', async () => {
+    commentRepository.findById.mockResolvedValue({
+      id: 'c1',
+      text: 'hello',
+    })
+    await expect(
+      service.reportComment('c1', { readerId: 'r1' }),
+    ).resolves.toEqual({ notified: true })
+    await expect(
+      service.reportComment('c1', { readerId: 'r1' }),
+    ).resolves.toEqual({ notified: false })
+    expect(eventManager.broadcast).toHaveBeenCalledTimes(1)
+  })
+
+  it('throws when the comment is missing', async () => {
+    commentRepository.findById.mockResolvedValue(null)
+    await expect(
+      service.reportComment('missing', { ip: '1.1.1.1' }),
+    ).rejects.toBeInstanceOf(AppException)
+    expect(eventManager.broadcast).not.toHaveBeenCalled()
+  })
+})

--- a/apps/core/test/src/modules/comment/comment-route.spec.ts
+++ b/apps/core/test/src/modules/comment/comment-route.spec.ts
@@ -32,4 +32,25 @@ describe('CommentController routes', () => {
       undefined,
     )
   })
+
+  it('exposes reader activity and public report routes ahead of /:id', () => {
+    const prototype = CommentController.prototype
+    expect(Reflect.getMetadata(PATH_METADATA, prototype.getMyComments)).toBe(
+      '/reader/me',
+    )
+    expect(Reflect.getMetadata(METHOD_METADATA, prototype.getMyComments)).toBe(
+      RequestMethod.GET,
+    )
+    expect(Reflect.getMetadata(PATH_METADATA, prototype.reportComment)).toBe(
+      '/:id/report',
+    )
+    expect(Reflect.getMetadata(METHOD_METADATA, prototype.reportComment)).toBe(
+      RequestMethod.POST,
+    )
+
+    const names = Object.getOwnPropertyNames(prototype)
+    expect(names.indexOf('getMyComments')).toBeLessThan(
+      names.indexOf('getComments'),
+    )
+  })
 })

--- a/apps/core/test/src/processors/database/postgres.lock.spec.ts
+++ b/apps/core/test/src/processors/database/postgres.lock.spec.ts
@@ -1,15 +1,16 @@
 import { createHash } from 'node:crypto'
 
 import pkg from 'pg'
-
-import {
-  SCHEMA_MIGRATION_LOCK_KEY,
-  withAdvisoryLock,
-} from '~/processors/database/postgres.lock'
 import {
   createPgTestDatabase,
   type PgTestDatabase,
 } from 'test/helper/pg-verify-url'
+
+import {
+  REVIEW_DEMO_SYNC_LOCK_KEY,
+  SCHEMA_MIGRATION_LOCK_KEY,
+  withAdvisoryLock,
+} from '~/processors/database/postgres.lock'
 
 const { Pool } = pkg
 
@@ -22,6 +23,21 @@ describe('SCHEMA_MIGRATION_LOCK_KEY', () => {
     const view = new DataView(buf.buffer, buf.byteOffset, buf.byteLength)
     const big = view.getBigInt64(0, false)
     expect(SCHEMA_MIGRATION_LOCK_KEY).toBe(big)
+  })
+})
+
+describe('REVIEW_DEMO_SYNC_LOCK_KEY', () => {
+  it('matches sha256("mx-core:review-demo-sync:v1") first 8 bytes as signed bigint', () => {
+    const h = createHash('sha256')
+      .update('mx-core:review-demo-sync:v1')
+      .digest()
+    const buf = h.subarray(0, 8)
+    const view = new DataView(buf.buffer, buf.byteOffset, buf.byteLength)
+    expect(REVIEW_DEMO_SYNC_LOCK_KEY).toBe(view.getBigInt64(0, false))
+  })
+
+  it('differs from the migration lock keys', () => {
+    expect(REVIEW_DEMO_SYNC_LOCK_KEY).not.toBe(SCHEMA_MIGRATION_LOCK_KEY)
   })
 })
 

--- a/docs/superpowers/plans/2026-08-15-apple-review-demo-account.md
+++ b/docs/superpowers/plans/2026-08-15-apple-review-demo-account.md
@@ -1,0 +1,857 @@
+# Apple Sign-in App Review demo 账号 Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Let an owner toggle a system `reader` demo account on the Apple OAuth settings page, copy its credentials for App Store review, sign in via existing `/sign-in/email` even when owner password login is disabled, and wipe that account’s content nightly.
+
+**Architecture:** A reserved identity (`app-review@users.invalid`) plus `oauth.public.apple.reviewDemoEnabled` / `oauth.secrets.apple.reviewDemoPassword`. `ReviewDemoService.sync()` provisions or bans on `ConfigChanged`. Email sign-in is gated by a pure function inside Better Auth’s `hooks.before`. `GET /auth/review-demo` (owner) reveals the password because oauth secrets are stripped from `getOption`. A midnight cron soft-deletes that reader’s comments, deletes poll votes, and restores the default profile.
+
+**Tech Stack:** NestJS, Better Auth, Drizzle/Postgres, Vitest, admin React (Vite).
+
+## Global Constraints
+
+- Work in `/Users/innei/git/innei-repo/mx-core` only. Do not change Yohaku.
+- Zero comments/JSDoc except a documented workaround or non-obvious invariant.
+- **No git commits** — user rule overrides the skill template; every task ends with a verification checkpoint instead.
+- Lint/typecheck only touched files.
+- Core tests: `pnpm -C apps/core exec vitest run <file>`
+- Admin tests: `pnpm -C apps/admin exec vitest run <file>`
+- No new `readers` columns, no password-rotate button, no mobile UI.
+- Demo email/handle/name are constants, never derived from site URL.
+- `oauth.secrets.apple.reviewDemoPassword` stays in secrets (encrypted). Never put the password in `oauth.public`.
+
+## File map
+
+| File | Responsibility |
+|---|---|
+| `apps/core/src/modules/auth/review-demo.constants.ts` | Fixed identity + oauth key names + `isReviewDemoEnabled` |
+| `apps/core/src/modules/auth/email-sign-in-gate.ts` | Pure deny/allow for `/sign-in/email` |
+| `apps/core/src/modules/auth/review-demo.service.ts` | `sync`, `getCredentials`, `getEmailSignInGate`, `resetDaily` |
+| `apps/core/src/modules/auth/auth.implement.ts` | Call gate in `hooks.before` |
+| `apps/core/src/modules/auth/auth.middleware.ts` | Pass gate into `CreateAuth`; bypass `/auth/review-demo` |
+| `apps/core/src/modules/auth/auth.controller.ts` | `GET review-demo` |
+| `apps/core/src/modules/auth/auth.service.ts` | Block transferring owner to the demo reader |
+| `apps/core/src/modules/auth/auth.module.ts` | Provide/export `ReviewDemoService`; import Comment + Poll |
+| `apps/core/src/modules/poll/poll-vote.repository.ts` | `deleteByFingerprint` |
+| `apps/core/src/modules/poll/poll.module.ts` | Export `PollVoteRepository` |
+| `apps/core/src/modules/cron-task/*` | Register midnight `ResetReviewDemo` |
+| `apps/admin/src/features/settings/utils/oauth.ts` | Ignore `reviewDemoEnabled` in `configured` |
+| `apps/admin/src/features/settings/components/account/OauthProviderSection.tsx` | Apple-only switch + credential reveal |
+| `apps/admin/src/api/auth.ts` + i18n + query keys | Client for `GET /auth/review-demo` |
+
+---
+
+### Task 1: Identity constants and email sign-in gate
+
+**Files:**
+- Create: `apps/core/src/modules/auth/review-demo.constants.ts`
+- Create: `apps/core/src/modules/auth/email-sign-in-gate.ts`
+- Test: `apps/core/test/src/modules/auth/email-sign-in-gate.spec.ts`
+
+**Interfaces:**
+- Produces:
+  ```ts
+  export const REVIEW_DEMO_EMAIL = 'app-review@users.invalid'
+  export const REVIEW_DEMO_HANDLE = 'app-review'
+  export const REVIEW_DEMO_NAME = 'App Reviewer'
+  export const REVIEW_DEMO_BAN_REASON = 'app-review-demo'
+  export const REVIEW_DEMO_PUBLIC_ENABLED_KEY = 'reviewDemoEnabled'
+  export const REVIEW_DEMO_SECRET_PASSWORD_KEY = 'reviewDemoPassword'
+
+  export function isReviewDemoEnabled(oauth: {
+    public?: Partial<Record<string, Record<string, string>>>
+  }): boolean
+
+  export function isReviewDemoIdentity(input: {
+    email?: string | null
+    handle?: string | null
+    username?: string | null
+  }): boolean
+
+  export type EmailSignInGate = {
+    disablePasswordLogin: boolean
+    reviewDemoEnabled: boolean
+    reviewDemoBanned: boolean
+  }
+
+  export function denyEmailSignIn(email: string, gate: EmailSignInGate): boolean
+  ```
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+import { describe, expect, it } from 'vitest'
+
+import {
+  denyEmailSignIn,
+  type EmailSignInGate,
+} from '~/modules/auth/email-sign-in-gate'
+import {
+  isReviewDemoEnabled,
+  isReviewDemoIdentity,
+  REVIEW_DEMO_EMAIL,
+} from '~/modules/auth/review-demo.constants'
+
+const open: EmailSignInGate = {
+  disablePasswordLogin: false,
+  reviewDemoEnabled: true,
+  reviewDemoBanned: false,
+}
+
+describe('denyEmailSignIn', () => {
+  it('allows the demo email when the toggle is on and the reader is not banned', () => {
+    expect(denyEmailSignIn(REVIEW_DEMO_EMAIL, open)).toBe(false)
+    expect(
+      denyEmailSignIn(REVIEW_DEMO_EMAIL, {
+        ...open,
+        disablePasswordLogin: true,
+      }),
+    ).toBe(false)
+  })
+
+  it('denies the demo email when the toggle is off or the reader is banned', () => {
+    expect(
+      denyEmailSignIn(REVIEW_DEMO_EMAIL, {
+        ...open,
+        reviewDemoEnabled: false,
+      }),
+    ).toBe(true)
+    expect(
+      denyEmailSignIn(REVIEW_DEMO_EMAIL, {
+        ...open,
+        reviewDemoBanned: true,
+      }),
+    ).toBe(true)
+  })
+
+  it('denies every other email when password login is disabled', () => {
+    expect(
+      denyEmailSignIn('owner@example.com', {
+        ...open,
+        disablePasswordLogin: true,
+      }),
+    ).toBe(true)
+  })
+
+  it('allows every other email when password login is enabled', () => {
+    expect(denyEmailSignIn('owner@example.com', open)).toBe(false)
+  })
+})
+
+describe('isReviewDemoEnabled / isReviewDemoIdentity', () => {
+  it('reads only apple.reviewDemoEnabled === "true"', () => {
+    expect(
+      isReviewDemoEnabled({
+        public: { apple: { reviewDemoEnabled: 'true' } },
+      }),
+    ).toBe(true)
+    expect(
+      isReviewDemoEnabled({
+        public: { apple: { reviewDemoEnabled: '' } },
+      }),
+    ).toBe(false)
+  })
+
+  it('matches the reserved email and handle', () => {
+    expect(
+      isReviewDemoIdentity({
+        email: REVIEW_DEMO_EMAIL,
+        handle: 'app-review',
+      }),
+    ).toBe(true)
+    expect(
+      isReviewDemoIdentity({
+        email: REVIEW_DEMO_EMAIL,
+        handle: 'someone-else',
+      }),
+    ).toBe(false)
+  })
+})
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pnpm -C apps/core exec vitest run test/src/modules/auth/email-sign-in-gate.spec.ts`
+
+Expected: FAIL — modules not found.
+
+- [ ] **Step 3: Write the two modules**
+
+`review-demo.constants.ts`:
+
+```ts
+export const REVIEW_DEMO_EMAIL = 'app-review@users.invalid'
+export const REVIEW_DEMO_HANDLE = 'app-review'
+export const REVIEW_DEMO_NAME = 'App Reviewer'
+export const REVIEW_DEMO_BAN_REASON = 'app-review-demo'
+export const REVIEW_DEMO_PUBLIC_ENABLED_KEY = 'reviewDemoEnabled'
+export const REVIEW_DEMO_SECRET_PASSWORD_KEY = 'reviewDemoPassword'
+
+export function isReviewDemoEnabled(oauth: {
+  public?: Partial<Record<string, Record<string, string>>>
+}): boolean {
+  return oauth.public?.apple?.[REVIEW_DEMO_PUBLIC_ENABLED_KEY] === 'true'
+}
+
+export function isReviewDemoIdentity(input: {
+  email?: string | null
+  handle?: string | null
+  username?: string | null
+}): boolean {
+  return (
+    input.email === REVIEW_DEMO_EMAIL &&
+    (input.handle === REVIEW_DEMO_HANDLE ||
+      input.username === REVIEW_DEMO_HANDLE)
+  )
+}
+```
+
+`email-sign-in-gate.ts`:
+
+```ts
+import { REVIEW_DEMO_EMAIL } from './review-demo.constants'
+
+export type EmailSignInGate = {
+  disablePasswordLogin: boolean
+  reviewDemoEnabled: boolean
+  reviewDemoBanned: boolean
+}
+
+export function denyEmailSignIn(
+  email: string,
+  gate: EmailSignInGate,
+): boolean {
+  const isDemo = email.trim().toLowerCase() === REVIEW_DEMO_EMAIL
+  if (isDemo) {
+    return !gate.reviewDemoEnabled || gate.reviewDemoBanned
+  }
+  return gate.disablePasswordLogin
+}
+```
+
+- [ ] **Step 4: Run tests**
+
+Run: `pnpm -C apps/core exec vitest run test/src/modules/auth/email-sign-in-gate.spec.ts`
+
+Expected: PASS.
+
+- [ ] **Step 5: Verification checkpoint**
+
+Gate truth table matches spec §三. No Nest imports.
+
+---
+
+### Task 2: Ignore reviewDemoEnabled in Apple `configured`
+
+**Files:**
+- Modify: `apps/admin/src/features/settings/utils/oauth.ts`
+- Test: `apps/admin/src/features/settings/utils/oauth.test.ts`
+
+**Interfaces:**
+- Consumes: public key `reviewDemoEnabled`
+- Produces: `flattenOauthOptions` `configured` is false when the only public field is `reviewDemoEnabled: "true"`
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+import { describe, expect, it } from 'vitest'
+
+import { flattenOauthOptions } from './oauth'
+
+describe('flattenOauthOptions', () => {
+  it('does not treat reviewDemoEnabled as Apple being configured', () => {
+    const flat = flattenOauthOptions({
+      providers: [{ enabled: true, type: 'apple' }],
+      public: { apple: { reviewDemoEnabled: 'true' } },
+    })
+    expect(flat.apple.configured).toBe(false)
+    expect(flat.apple.enabled).toBe(true)
+    expect(flat.apple.public.reviewDemoEnabled).toBe('true')
+  })
+
+  it('still marks Apple configured when a real public field is set', () => {
+    const flat = flattenOauthOptions({
+      public: {
+        apple: { clientId: 'dev.example.web', reviewDemoEnabled: 'true' },
+      },
+    })
+    expect(flat.apple.configured).toBe(true)
+  })
+})
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pnpm -C apps/admin exec vitest run src/features/settings/utils/oauth.test.ts`
+
+Expected: FAIL — first assertion `configured` is true.
+
+- [ ] **Step 3: Change `flattenOauthOptions`**
+
+```ts
+const oauthConfiguredIgnoredKeys = new Set(['reviewDemoEnabled'])
+
+export function flattenOauthOptions(
+  data: OauthOptions | undefined,
+): Record<OauthProviderType, FlatOauthProvider> {
+  const providerMap = new Map(
+    (data?.providers ?? []).map((provider) => [provider.type, provider]),
+  )
+
+  return Object.fromEntries(
+    oauthProviders.map((provider) => {
+      const publicFields = { ...data?.public?.[provider.type] }
+      return [
+        provider.type,
+        {
+          configured: Object.entries(publicFields).some(
+            ([key, value]) =>
+              !oauthConfiguredIgnoredKeys.has(key) && Boolean(value),
+          ),
+          enabled: providerMap.get(provider.type)?.enabled ?? false,
+          public: publicFields,
+          type: provider.type,
+        },
+      ]
+    }),
+  ) as Record<OauthProviderType, FlatOauthProvider>
+}
+```
+
+- [ ] **Step 4: Run tests**
+
+Run: `pnpm -C apps/admin exec vitest run src/features/settings/utils/oauth.test.ts`
+
+Expected: PASS.
+
+- [ ] **Step 5: Verification checkpoint**
+
+Apple “configured” (secret placeholder / validate enablement) is unchanged for real credentials.
+
+---
+
+### Task 3: Bypass Better Auth for `GET /auth/review-demo`
+
+**Files:**
+- Modify: `apps/core/src/modules/auth/auth.middleware.ts` (`shouldBypassBetterAuth`)
+- Modify: `apps/core/test/src/modules/auth/auth.middleware.spec.ts`
+
+**Interfaces:**
+- Produces: `shouldBypassBetterAuth('/auth/review-demo') === true` (and versioned `/api/v2/auth/review-demo/`)
+
+- [ ] **Step 1: Extend the existing bypass test**
+
+In `shouldBypassBetterAuth()` examples, add:
+
+```ts
+expect(shouldBypassBetterAuth('/auth/review-demo')).toBe(true)
+expect(shouldBypassBetterAuth('/api/v2/auth/review-demo/')).toBe(true)
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pnpm -C apps/core exec vitest run test/src/modules/auth/auth.middleware.spec.ts`
+
+Expected: FAIL on the new assertions.
+
+- [ ] **Step 3: Update the regex**
+
+```ts
+export function shouldBypassBetterAuth(originalUrl: string) {
+  const pathname = originalUrl.split('?')[0]?.replace(/\/+$/, '') || ''
+  return /\/auth\/(?:token|session|providers|review-demo)$/.test(pathname)
+}
+```
+
+- [ ] **Step 4: Run tests**
+
+Run: `pnpm -C apps/core exec vitest run test/src/modules/auth/auth.middleware.spec.ts`
+
+Expected: PASS.
+
+- [ ] **Step 5: Verification checkpoint**
+
+`/auth/sign-in/email` is still handled by Better Auth (`false`).
+
+---
+
+### Task 4: `ReviewDemoService` provision / ban / credentials
+
+**Files:**
+- Create: `apps/core/src/modules/auth/review-demo.service.ts`
+- Test: `apps/core/test/src/modules/auth/review-demo.service.spec.ts`
+
+**Interfaces:**
+- Consumes: `isReviewDemoEnabled`, `isReviewDemoIdentity`, constants from Task 1; `ConfigsService.get` / `patchAndValid`; `ReaderRepository`; `AuthRepository`; `SnowflakeService`; `hashPassword` from `better-auth/crypto`
+- Produces:
+  ```ts
+  class ReviewDemoService {
+    sync(): Promise<void>
+    getEmailSignInGate(): Promise<EmailSignInGate>
+    getCredentials(): Promise<
+      | { enabled: false }
+      | { enabled: true; email: string; password: string }
+      | { enabled: true; email: string; error: 'provision_failed' }
+    >
+    generatePassword(): string
+  }
+  ```
+  Password: `randomBytes(18).toString('base64url')`. Re-entrancy: if `sync()` is already running, return immediately (patching secrets re-emits `ConfigChanged`).
+
+- [ ] **Step 1: Write the failing service tests** (mock all collaborators)
+
+Cover:
+
+1. Toggle on, no reader → `readerRepository.create` with `role: 'reader'`, `email: REVIEW_DEMO_EMAIL`, `handle/username: REVIEW_DEMO_HANDLE`, `name/displayUsername: REVIEW_DEMO_NAME`, `image` omitted/null, `emailVerified: true`; `authRepository.createAccount` with `providerId: 'credential'`; `patchAndValid('oauth', { secrets: { apple: { reviewDemoPassword } } })` once.
+2. Toggle on, reader exists, not banned, password already in secrets → no `create`, no `patchAndValid`, no password change.
+3. Toggle on, reader banned → `unsetBanned` + `update` restoring `name`, `displayUsername`, `image: null`. Password unchanged.
+4. Toggle off, reader exists → `setBanned` with `banReason: 'app-review-demo'` + `deleteSessionsForUser`.
+5. Toggle on, email occupied by a non-demo identity → no overwrite; `getCredentials()` after `sync` returns `{ enabled: true, email, error: 'provision_failed' }`.
+6. Toggle on, secrets missing password, credential account exists → generate, `updateAccountPassword`, `patchAndValid`.
+7. `getEmailSignInGate` maps `authSecurity.disablePasswordLogin` and `bannedAt`.
+
+Use `vi.fn()` mocks. Do not hit Postgres.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pnpm -C apps/core exec vitest run test/src/modules/auth/review-demo.service.spec.ts`
+
+Expected: FAIL — service not found.
+
+- [ ] **Step 3: Implement `ReviewDemoService`**
+
+Constructor:
+
+```ts
+constructor(
+  private readonly configsService: ConfigsService,
+  private readonly readerRepository: ReaderRepository,
+  private readonly authRepository: AuthRepository,
+  private readonly snowflakeService: SnowflakeService,
+) {}
+```
+
+`sync()` outline:
+
+```
+if (this.syncing) return
+this.syncing = true
+try {
+  const oauth = await this.configsService.get('oauth')
+  const enabled = isReviewDemoEnabled(oauth)
+  const reader = await this.readerRepository.findByEmail(REVIEW_DEMO_EMAIL)
+  if (!enabled) {
+    if (reader && isReviewDemoIdentity(reader)) {
+      await this.readerRepository.setBanned(reader.id, {
+        bannedAt: new Date(),
+        banReason: REVIEW_DEMO_BAN_REASON,
+      })
+      await this.readerRepository.deleteSessionsForUser(reader.id)
+    }
+    return
+  }
+  if (reader && !isReviewDemoIdentity(reader)) {
+    this.logger.error('review demo email is occupied by a non-demo reader')
+    return
+  }
+  let password = oauth.secrets?.apple?.[REVIEW_DEMO_SECRET_PASSWORD_KEY]
+  if (!password) {
+    password = this.generatePassword()
+    await this.configsService.patchAndValid('oauth', {
+      secrets: { apple: { [REVIEW_DEMO_SECRET_PASSWORD_KEY]: password } },
+    })
+  }
+  if (!reader) {
+    const id = this.snowflakeService.nextId()
+    await this.readerRepository.create({ ...defaults, id, role: 'reader' })
+    await this.authRepository.createAccount({
+      id: this.snowflakeService.nextId(),
+      providerAccountId: id,
+      providerId: 'credential',
+      userId: id,
+      password: await hashPassword(password),
+    })
+    return
+  }
+  if (reader.bannedAt) {
+    await this.readerRepository.unsetBanned(reader.id)
+    await this.readerRepository.update(reader.id, {
+      name: REVIEW_DEMO_NAME,
+      displayUsername: REVIEW_DEMO_NAME,
+      image: null,
+    })
+  }
+  const accounts = await this.authRepository.findAccountsForUser(reader.id)
+  const credential = accounts.find((a) => a.providerId === 'credential')
+  if (!credential) {
+    await this.authRepository.createAccount({ ... })
+  } else if (!oauth.secrets?.apple?.[REVIEW_DEMO_SECRET_PASSWORD_KEY]) {
+    // already written above when password was missing
+  }
+} finally {
+  this.syncing = false
+}
+```
+
+When secrets were missing **and** a credential row already exists, call `updateAccountPassword(credential.id, await hashPassword(password))` after generating.
+
+`getCredentials()`:
+
+```
+await this.sync()
+const oauth = await this.configsService.get('oauth')
+if (!isReviewDemoEnabled(oauth)) return { enabled: false }
+const password = oauth.secrets?.apple?.[REVIEW_DEMO_SECRET_PASSWORD_KEY]
+const reader = await this.readerRepository.findByEmail(REVIEW_DEMO_EMAIL)
+if (!password || !reader || !isReviewDemoIdentity(reader) || reader.bannedAt) {
+  return { enabled: true, email: REVIEW_DEMO_EMAIL, error: 'provision_failed' }
+}
+return { enabled: true, email: REVIEW_DEMO_EMAIL, password }
+```
+
+Calling `sync()` here closes the race between admin Save and the first credential fetch.
+
+- [ ] **Step 4: Run tests**
+
+Run: `pnpm -C apps/core exec vitest run test/src/modules/auth/review-demo.service.spec.ts`
+
+Expected: PASS.
+
+- [ ] **Step 5: Verification checkpoint**
+
+Disable path never deletes the reader row. Re-enable does not call `generatePassword` when secrets already have a password.
+
+---
+
+### Task 5: Wire Nest — hook, controller, owner transfer
+
+**Files:**
+- Modify: `apps/core/src/modules/auth/auth.implement.ts`
+- Modify: `apps/core/src/modules/auth/auth.middleware.ts`
+- Modify: `apps/core/src/modules/auth/auth.controller.ts`
+- Modify: `apps/core/src/modules/auth/auth.service.ts` (`transferOwnerRole`)
+- Modify: `apps/core/src/modules/auth/auth.module.ts`
+- Test: `apps/core/test/src/modules/auth/auth.service.spec.ts` (existing `createService()` helper)
+
+**Interfaces:**
+- Consumes: `denyEmailSignIn`, `ReviewDemoService.getEmailSignInGate`, `ReviewDemoService.getCredentials`, `isReviewDemoIdentity`
+- Produces: `CreateAuth(..., getEmailSignInGate?: () => Promise<EmailSignInGate>)`; `GET /auth/review-demo` `@Auth()`; transfer owner rejected for the demo reader
+
+- [ ] **Step 1: Write failing transfer-owner test**
+
+Append to `apps/core/test/src/modules/auth/auth.service.spec.ts`:
+
+```ts
+import {
+  REVIEW_DEMO_EMAIL,
+  REVIEW_DEMO_HANDLE,
+} from '~/modules/auth/review-demo.constants'
+
+it('rejects transferring owner to the app review demo reader', async () => {
+  const { readerRepository, service } = createService()
+  readerRepository.findById.mockResolvedValue({
+    id: 'demo-1',
+    email: REVIEW_DEMO_EMAIL,
+    handle: REVIEW_DEMO_HANDLE,
+    username: REVIEW_DEMO_HANDLE,
+  })
+
+  await expect(service.transferOwnerRole('demo-1')).rejects.toThrow(
+    AppException,
+  )
+  expect(readerRepository.setRole).not.toHaveBeenCalled()
+})
+```
+
+Add `setRole: vi.fn()` (and `setOwnersExceptToReader: vi.fn()`) to the `readerRepository` mock in `createService()`.
+
+- [ ] **Step 2: Run the new test — expect FAIL** (no identity check yet)
+
+- [ ] **Step 3: Implement wiring**
+
+1. `CreateAuth` 5th argument `getEmailSignInGate?: () => Promise<EmailSignInGate>`. In `hooks.before`, **after** the existing `role` check:
+
+```ts
+if (ctx.path === '/sign-in/email') {
+  const email =
+    typeof ctx.body?.email === 'string' ? ctx.body.email : ''
+  const gate = getEmailSignInGate
+    ? await getEmailSignInGate()
+    : {
+        disablePasswordLogin: false,
+        reviewDemoEnabled: false,
+        reviewDemoBanned: false,
+      }
+  if (denyEmailSignIn(email, gate)) {
+    throw new APIError('UNAUTHORIZED', {
+      message: 'Invalid email or password',
+    })
+  }
+}
+```
+
+2. `AuthMiddleware.ensureAuthHandlerFresh` — inject `ReviewDemoService`, pass `() => this.reviewDemoService.getEmailSignInGate()` into `CreateAuth`.
+
+3. `AuthController`:
+
+```ts
+@Get('review-demo')
+@Auth()
+@HttpCache({ disable: true })
+getReviewDemo() {
+  return this.reviewDemoService.getCredentials()
+}
+```
+
+Inject `ReviewDemoService` in the controller constructor.
+
+4. `transferOwnerRole` immediately after `findById`:
+
+```ts
+if (isReviewDemoIdentity(target)) {
+  throw createAppException(AppErrorCode.INVALID_PARAMETER, {
+    message: 'cannot transfer owner to the app review demo account',
+  })
+}
+```
+
+5. `AuthModule.forRoot`:
+   - `providers` add `ReviewDemoService`, `AuthMiddleware` (if not already injectable — middleware used in `configure` is instantiated by Nest if listed **or** via constructor injection of other providers; listing `ReviewDemoService` is enough if `AuthMiddleware` is created by `consumer.apply(AuthMiddleware)` which requires it in module providers). **Add `AuthMiddleware` and `ReviewDemoService` to `providers`.** Export `ReviewDemoService`.
+   - `imports`: leave Comment/Poll for Task 6. Task 5 must compile: `ReviewDemoService` in Task 4 does not yet inject Comment/Poll.
+
+- [ ] **Step 4: Run tests**
+
+```
+pnpm -C apps/core exec vitest run test/src/modules/auth/email-sign-in-gate.spec.ts test/src/modules/auth/auth.middleware.spec.ts test/src/modules/auth/review-demo.service.spec.ts test/src/modules/auth/auth.implement.spec.ts
+```
+
+Plus the transfer-owner spec.
+
+Expected: PASS.
+
+- [ ] **Step 5: Verification checkpoint**
+
+`pnpm -C apps/core exec tsc --noEmit` if cheap enough; otherwise eslint the touched auth files.
+
+`GET /auth/review-demo` is not swallowed by Better Auth (Task 3 regex).
+
+---
+
+### Task 6: Nightly reset
+
+**Files:**
+- Modify: `apps/core/src/modules/poll/poll-vote.repository.ts` — add `deleteByFingerprint`
+- Modify: `apps/core/src/modules/poll/poll.module.ts` — `exports: [PollService, PollVoteRepository]`
+- Modify: `apps/core/src/modules/auth/review-demo.service.ts` — `resetDaily`
+- Modify: `apps/core/src/modules/auth/auth.module.ts` — `imports: [forwardRef(() => CommentModule), PollModule]`
+- Modify: `apps/core/src/modules/cron-task/cron-task.types.ts`
+- Modify: `apps/core/src/modules/cron-task/cron-task.scheduler.ts`
+- Modify: `apps/core/src/modules/cron-task/cron-business.service.ts`
+- Test: `apps/core/test/src/modules/auth/review-demo.service.spec.ts` (extend) and `apps/core/test/src/modules/poll/poll-vote.repository.spec.ts` if a unit test without DB is impractical, test `deleteByFingerprint` via a small mocked-db suite **or** extend review-demo tests by mocking `pollVoteRepository.deleteByFingerprint` and `commentService.softDeleteComment`.
+
+**Interfaces:**
+- Consumes: `CommentService.softDeleteComment`, `CommentRepository.findByFilter({ readerId, isDeleted: false })`, `PollVoteRepository.deleteByFingerprint`, `ReaderRepository.update`
+- Produces:
+  ```ts
+  PollVoteRepository.deleteByFingerprint(fingerprint: string): Promise<number>
+  ReviewDemoService.resetDaily(): Promise<{
+    comments: number
+    pollVotes: number
+  } | { skipped: true }>
+  CronTaskType.ResetReviewDemo = 'cron:reset-review-demo'
+  ```
+  Scheduler: `@CronOnce(CronExpression.EVERY_DAY_AT_MIDNIGHT, { name: 'resetReviewDemo' })` dispatching `CronTaskType.ResetReviewDemo`. `CronTaskMetas` `methodName: 'resetReviewDemo'` must exist on `CronBusinessService`.
+
+- [ ] **Step 1: Write failing tests**
+
+Service tests:
+
+- Toggle off → `resetDaily` does not call `softDeleteComment`.
+- Toggle on, demo reader present, two comment ids from `findByFilter` → `softDeleteComment` called twice; `deleteByFingerprint('r:' + id)` once; `readerRepository.update` with default name/image; sessions **not** deleted.
+
+Poll repository implementation can be tested later with e2e; for this task mock it on the service.
+
+- [ ] **Step 2: Run tests — expect FAIL** (`resetDaily` missing)
+
+- [ ] **Step 3: Implement**
+
+`deleteByFingerprint`:
+
+```ts
+async deleteByFingerprint(fingerprint: string): Promise<number> {
+  const deleted = await this.db
+    .delete(pollVotes)
+    .where(eq(pollVotes.voterFingerprint, fingerprint))
+    .returning({ id: pollVotes.id })
+  return deleted.length
+}
+```
+
+(`poll_vote_options` already `ON DELETE CASCADE`.)
+
+`resetDaily`:
+
+```
+const oauth = await this.configsService.get('oauth')
+if (!isReviewDemoEnabled(oauth)) return { skipped: true }
+const reader = await this.readerRepository.findByEmail(REVIEW_DEMO_EMAIL)
+if (!reader || !isReviewDemoIdentity(reader)) return { skipped: true }
+const comments = await this.commentRepository.findByFilter({
+  readerId: reader.id,
+  isDeleted: false,
+})
+for (const comment of comments) {
+  await this.commentService.softDeleteComment(String(comment.id))
+}
+const pollVotes = await this.pollVoteRepository.deleteByFingerprint(
+  `r:${reader.id}`,
+)
+await this.readerRepository.update(reader.id, {
+  name: REVIEW_DEMO_NAME,
+  displayUsername: REVIEW_DEMO_NAME,
+  image: null,
+})
+return { comments: comments.length, pollVotes }
+```
+
+Inject `CommentService`, `CommentRepository`, `PollVoteRepository` with `forwardRef` on `CommentService` if Nest complains.
+
+`CronBusinessService.resetReviewDemo()`:
+
+```ts
+async resetReviewDemo() {
+  return this.reviewDemoService.resetDaily()
+}
+```
+
+Add `ReviewDemoService` to `CronBusinessService` constructor. `CronTaskModule` does not need to import `AuthModule` (it is `@Global`).
+
+Register type + meta + scheduler method mirroring `resetIPAccess`.
+
+- [ ] **Step 4: Run tests**
+
+```
+pnpm -C apps/core exec vitest run test/src/modules/auth/review-demo.service.spec.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Verification checkpoint**
+
+`CronTaskMetas` key count matches `CronTaskType` keys (the scheduler iterates `Object.keys(CronTaskMetas)`). `resetDaily` does not call `deleteSessionsForUser`.
+
+---
+
+### Task 7: Admin Apple switch and credential reveal
+
+**Files:**
+- Modify: `apps/admin/src/api/auth.ts` — `getReviewDemo`
+- Modify: `apps/admin/src/query/keys.ts` — `settings.reviewDemo`
+- Modify: `apps/admin/src/features/settings/types/settings.ts` — `OauthProviderPayload` unchanged (public already `Record<string, string>`)
+- Modify: `apps/admin/src/features/settings/components/account/OauthProviderSection.tsx`
+- Modify: `apps/admin/src/features/settings/components/account/OauthSection.tsx` — invalidate `reviewDemo` query on save success
+- Modify: `apps/admin/src/i18n/resources/en-US.ts`
+- Modify: `apps/admin/src/i18n/resources/zh-CN.ts`
+
+**Interfaces:**
+- Consumes: `GET /auth/review-demo` JSON from Task 5
+- Produces: Apple section Switch; when enabled, show email/password with copy; helper text about App Store Connect + daily reset
+
+i18n keys (add to **both** locales; `TranslationKey` is `keyof typeof zhCN`):
+
+| key | en-US | zh-CN |
+|---|---|---|
+| `settings.oauth.reviewDemo.switch` | App Review demo account | App 审核 Demo 账号 |
+| `settings.oauth.reviewDemo.helper` | Creates a reader account for App Store review. Comments and profile reset daily. Sign-in uses the email form even if password login is disabled. | 创建供 App Store 审核使用的读者账号。评论与资料每日重置。即使关闭密码登录，仍可用邮箱表单登录此账号。 |
+| `settings.oauth.reviewDemo.email` | Review email | 审核邮箱 |
+| `settings.oauth.reviewDemo.password` | Review password | 审核密码 |
+| `settings.oauth.reviewDemo.copyEmailAria` | Copy review email | 复制审核邮箱 |
+| `settings.oauth.reviewDemo.copyPasswordAria` | Copy review password | 复制审核密码 |
+| `settings.oauth.reviewDemo.provisionFailed` | Demo account is enabled but not ready. Save again or check logs. | Demo 账号已开启但尚未就绪，请再保存一次或查看日志。 |
+
+- [ ] **Step 1: Add API + keys**
+
+```ts
+export type ReviewDemoResponse =
+  | { enabled: false }
+  | { enabled: true; email: string; password: string }
+  | { enabled: true; email: string; error: 'provision_failed' }
+
+export function getReviewDemo() {
+  return getJson<ReviewDemoResponse>('/auth/review-demo')
+}
+```
+
+```ts
+reviewDemo: () => ['settings', 'account', 'review-demo'] as const,
+```
+
+- [ ] **Step 2: Apple-only UI in `OauthProviderSection`**
+
+Local state `reviewDemoEnabled`, initialized from `props.data.public.reviewDemoEnabled === 'true'`, reset in the existing `useEffect`.
+
+`save()` already writes `payload.public[field.key]`. After the field loop:
+
+```ts
+if (props.type === 'apple') {
+  payload.public.reviewDemoEnabled = reviewDemoEnabled ? 'true' : ''
+}
+```
+
+Below the field grid, only when `props.type === 'apple'`:
+
+- `Switch` bound to `reviewDemoEnabled` with `t('settings.oauth.reviewDemo.switch')`
+- helper paragraph
+- `useQuery` with `queryKey: adminQueryKeys.settings.reviewDemo()`, `queryFn: getReviewDemo`, `enabled: props.type === 'apple' && reviewDemoEnabled && props.data.public.reviewDemoEnabled === 'true'` (so we fetch after a successful save has persisted the flag; also enable when local switch is on **and** last saved public flag is true)
+
+When query data `enabled: true` and `'password' in data`, show two rows (email, password) with the same copy-button pattern as the callback URL.
+
+When `error === 'provision_failed'`, show the error string, no fake password.
+
+- [ ] **Step 3: Invalidate on save**
+
+In `OauthSection` `onSuccess`, also:
+
+```ts
+await queryClient.invalidateQueries({
+  queryKey: adminQueryKeys.settings.reviewDemo(),
+})
+```
+
+- [ ] **Step 4: Typecheck admin i18n**
+
+Run: `pnpm -C apps/admin exec tsc --noEmit`
+
+Expected: PASS (`TranslationKey` includes the new keys because they exist in zh-CN).
+
+- [ ] **Step 5: Verification checkpoint**
+
+GitHub/Google sections have no extra switch. Saving Apple with the demo switch off sends `reviewDemoEnabled: ''`. Password is never written into `payload.public` or `payload.secrets` from the client.
+
+---
+
+## Manual check (after all tasks)
+
+1. Admin → Account → Apple: fill Apple creds, enable Apple, enable demo, Save.
+2. Email/password appear; copy them.
+3. App login sheet → email form → `role: reader`.
+4. Enable “Disable password login”: demo email still works; owner email fails.
+5. Disable demo, Save: email login with those creds fails; reader list shows banned with reason `app-review-demo`.
+6. Re-enable: same password, profile name `App Reviewer`.
+7. As demo, post a comment and vote a poll; run `resetReviewDemo` from cron admin (or call the business method); comment gone, profile restored, still logged in.
+
+---
+
+## Spec coverage
+
+| Spec section | Task |
+|---|---|
+| Fixed identity / secrets vs public | 1, 4 |
+| `configured` ignores toggle | 2 |
+| Switch lifecycle provision/ban/unban | 4, 5 |
+| `/sign-in/email` allowlist + `disablePasswordLogin` | 1, 5 |
+| `GET /auth/review-demo` | 3, 5, 7 |
+| Block owner transfer | 5 |
+| Daily reset comments/polls/profile, keep session | 6 |
+| Admin copy UI + i18n | 7 |
+| No Yohaku changes | Global constraint |

--- a/docs/superpowers/specs/2026-08-15-apple-review-demo-account-design.md
+++ b/docs/superpowers/specs/2026-08-15-apple-review-demo-account-design.md
@@ -1,0 +1,129 @@
+# Apple Sign-in App Review demo 账号
+
+日期：2026-08-15
+状态：已与用户确认方案 A
+
+## 背景
+
+iOS App 审核（Guideline 2.1）需要一组可登录的 demo 凭据。站点可以关掉站主邮箱登录（`authSecurity.disablePasswordLogin`），社交登录又要求审核员走 Apple ID。需要一个 **reader 权限** 的固定账号：挂在 Apple Sign-in 配置上作为可选项，审核员用现有邮箱表单登录，且不依赖「开放邮箱登录」。
+
+## 既定决策
+
+| 议题 | 决策 |
+|---|---|
+| 形态 | Apple OAuth 区块一个开关。打开即系统创建固定 demo reader；关掉即停用 |
+| 凭据 | 邮箱固定；密码首次自动生成，后台展示供 App Store Connect 备注 |
+| 登录 | 复用 Better Auth `POST /sign-in/email`，不新增登录 API |
+| 关邮箱登录时 | `disablePasswordLogin === true` 时 **只放行** 此 demo 账号的 email 登录；其它邮箱一律拒绝 |
+| 角色 | 永远 `reader`，禁止升为 owner |
+| 停用 | `ban` + 清 session；再打开 unban，凭据不变 |
+| 每日重置 | 午夜 cron：清该账号产生的内容，资料恢复默认；id / 邮箱 / 密码 / role 不变；session 不断 |
+| 客户端 | Yohaku 登录页已总是露出邮箱入口，本次 **不改 App** |
+| 密码轮换 | v1 无「重新生成」按钮。关/开开关不换密。仅当 secrets 里密码缺失时 sync 才补一枚 |
+
+## 一、身份与存储
+
+固定身份（不入配置、不随站点域名变化）：
+
+| 字段 | 值 |
+|---|---|
+| email | `app-review@users.invalid`（`.invalid` 保留 TLD，不会与真实 Apple/社交邮箱碰撞） |
+| handle / username | `app-review` |
+| 默认 name | `App Reviewer` |
+| 默认 image | `null` |
+| role | `reader` |
+
+配置（沿用现有 `oauth.public` / `oauth.secrets` 字符串 map，无 schema 迁移）：
+
+- `oauth.public.apple.reviewDemoEnabled`：`"true"` 或空
+- `oauth.secrets.apple.reviewDemoPassword`：明文密码，走现有 oauth secrets 整棵加密；**不**放进 `public`（`getForResponse` 会原样返回 public）
+
+`flattenOauthOptions` 的 `configured` 判断必须 **忽略** `reviewDemoEnabled`，避免「只开了 demo、没填 Apple 密钥」被当成 Apple 已配置。
+
+账号行用邮箱查找，无新列、无 migration。Better Auth `accounts` 上挂 `providerId: 'credential'`，建号方式对齐 owner 初始化（`hashPassword` + `authRepository.createAccount`）。
+
+密码：`crypto.randomBytes(18).toString('base64url')`（约 24 字符）。只在 secrets 里还没有密码时生成；之后保存 Apple 配置不得覆盖。
+
+## 二、开关生命周期
+
+Apple 区块增加独立 Switch（不进现有必填 text fields）。与 Apple 其它字段一起 Save。因此 **第一次打开 demo 时，Apple 配置必须已经能保存**（必填项已齐或 secrets 已存在）。Demo 登录本身不依赖 Apple OAuth 是否 `enabled`。
+
+`ReviewDemoService.sync()` 订阅 `EventBusEvents.ConfigChanged`。该事件对任意配置段都会发，listener **每次自己 `get('oauth')`**，不解读 payload。幂等：
+
+1. `reviewDemoEnabled === "true"`
+   - 无账号：创建 reader + credential；必要时写入 `reviewDemoPassword`
+   - 已 ban：unban，并把 name / image 恢复默认（再开即干净资料）
+   - 已存在且未 ban：不改密码、不改资料
+2. 开关关闭且账号存在：`setBanned` + `deleteSessionsForUser`，`banReason` 固定为 `app-review-demo`
+3. 开关关闭且无账号：no-op
+
+禁止：
+
+- `AuthService.transferOwnerRole` 若目标是此邮箱 / handle → `INVALID_PARAMETER`
+- 已有的 `before` hook（拒 `body.role`）保持不变
+
+## 三、登录
+
+仍走 `signIn.email`。在 `auth.implement.ts` 的 Better Auth `hooks.before` 增加 `/sign-in/email` 分支（现有 `/sign-in/email` bcrypt 升级逻辑在 `after`，不动）：
+
+1. 请求 email 等于 demo 邮箱
+   - 开关未开或 reader 已 ban → 与普通错误账号相同的失败（不泄露「这是审核号」）
+   - 否则放行（即使 `disablePasswordLogin`）
+2. 其它 email 且 `disablePasswordLogin` → 拒绝（这是相对现状的行为收紧：该开关今天只藏后台 UI，并不拦 API）
+3. 其它 email 且未关密码登录 → 维持现状（站主 credential 可登）
+
+`emailAndPassword.disableSignUp` 保持 `true`。无人能自助注册成这个邮箱。
+
+Yohaku `LoginSheet` 已总是提供「邮箱登录」二级表单；评论区 inline 社交条不改。审核员从「我的」进入即可。
+
+## 四、凭据展示
+
+`oauth.secrets` 经 `sanitizeConfigForResponse` 被掏空，admin `getOption('oauth')` 读不到密码。
+
+新增 owner-only：
+
+```
+GET /auth/review-demo
+```
+
+`@Auth()`。响应：
+
+- 未启用：`{ enabled: false }`
+- 已启用且凭据可用：`{ enabled: true, email, password }`
+- 已启用但账号/密码未就绪：`{ enabled: true, email, error: "provision_failed" }`（无 password 字段）
+
+Admin Apple 区块：开关下方，`enabled` 时展示邮箱/密码 + 复制按钮，文案说明用途（App Store Connect 备注）以及「每日重置评论与资料」。en-US / zh-CN 都要加 key。
+
+## 五、每日重置
+
+新 `CronTaskType.ResetReviewDemo`，调度与 `resetIPAccess` 相同：`CronExpression.EVERY_DAY_AT_MIDNIGHT`。开关未开或找不到账号则立即返回。
+
+对 demo `readerId`：
+
+1. 列出未删除评论，逐条走现有 `CommentService.softDeleteComment`（含评论图 hard-delete）
+2. 删除 `voterFingerprint === 'r:' + readerId` 的 poll votes（仓库补 `deleteByFingerprint`；`poll_vote_options` 已 ON DELETE CASCADE）
+3. `readers.name` / `image` / `displayUsername` 恢复默认；handle、email、role、密码、id 不动
+4. **不**删 session
+
+文章点赞是 IP/Redis，已有全站午夜 `resetLikedOrReadArticleRecord`，不按账号再清。App 本地 `likedRefs` 不在服务端范围。
+
+## 六、错误处理
+
+| 情况 | 行为 |
+|---|---|
+| 开关开、建号失败（邮箱已被占用且不是本系统号） | Save oauth 仍成功；sync 打日志；`GET /auth/review-demo` 返回 `provision_failed`；admin 显示错误、不展示假密码 |
+| 开关开但 secrets 里密码丢了 | sync 再生成一枚，写回 secrets 并更新 credential hash |
+| 审核员在重置瞬间仍登着 | session 保留；其评论会在下次列表刷新后消失 |
+| 有人用社交登录撞上同一 email | 不可能：邮箱是 `.invalid`，Apple/GitHub/Google 不会签发 |
+
+## 七、范围与非目标
+
+**做：** `apps/core`（provision、hook、cron、GET）+ `apps/admin`（Apple 开关与凭据展示）。
+
+**不做：** Yohaku / 其它客户端改动；密码轮换按钮；评论区邮箱入口；把 demo 做成可自定义邮箱；新的 readers 表字段。
+
+## 八、验证
+
+- 单元：`sync` 开→建、关→ban、再开→unban 且密码不变；`configured` 忽略 `reviewDemoEnabled`；`transferOwnerRole` 拒绝 demo；sign-in before-hook 在 `disablePasswordLogin` 下只放行 demo。
+- 单元：cron 软删该 reader 评论、删 poll 票、恢复 name/image，不动其它 reader。
+- 手工：admin 打开开关 → 复制凭据 → App 邮箱登录得到 `role: reader` → 关 `disablePasswordLogin` 后 demo 仍可登、站主邮箱不可登 → 关开关后登录失败。


### PR DESCRIPTION
## Summary

Provision a fixed **reader** demo account (`app-review@users.invalid`) behind a toggle in the Apple OAuth settings block, so App Review (Guideline 2.1) can sign in via the existing email form without enabling public email login or requiring the reviewer's Apple ID.

### Core
- `ReviewDemoModule` / `ReviewDemoService`: idempotent provisioning driven by `oauth.public.apple.reviewDemoEnabled` (subscribes to `ConfigChanged`, re-reads config every time)
  - on: create reader + credential (password auto-generated once, stored in oauth secrets), unban + reset profile if re-enabled
  - off: ban (`banReason: app-review-demo`) + delete sessions
- Email sign-in gate: when `disablePasswordLogin` is set, only the demo email passes `POST /sign-in/email`; all others rejected
- Owner transfer guarded against the demo identity; role stays `reader`
- Midnight cron: wipes content produced by the demo account and restores default profile (id/email/password/role/sessions untouched)
- `GET /auth/review-demo` (owner-only) returns current credentials / provisioning state for the admin panel

### Admin
- Apple block: independent "App Review demo" switch saved with the other Apple fields, credential display when enabled
- `flattenOauthOptions` `configured` check ignores `reviewDemoEnabled` so an empty Apple config isn't treated as configured
- i18n (en-US / zh-CN) for the new toggle and field help texts

> Note: also contains `9c526c8` (comment reader activity list / public report / account deletion) which is already on local master ahead of origin; this PR tracks it until master is pushed.

## Test plan

- `apps/core`: 13 auth spec files, 76 tests green (incl. new `email-sign-in-gate.spec.ts`, `review-demo.service.spec.ts`)
- `apps/admin`: new `oauth.test.ts` (configured-ignores-reviewDemo) green