### PR TITLE
feat(translation): glossary-based tag translation + Lexical image caption translation

### DIFF
--- a/apps/core/src/common/response/meta-builder.ts
+++ b/apps/core/src/common/response/meta-builder.ts
@@ -3,6 +3,7 @@ import type { z } from 'zod'
 import type {
   EnrichmentEntry,
   EntryTranslation,
+  GlossaryMeta,
   InteractionMeta,
 } from './meta.types'
 import { BaseResponseMetaSchema } from './meta.types'
@@ -62,6 +63,11 @@ export class MetaObjectBuilder<
   interaction(value: InteractionMeta | Map<string, InteractionMeta>): this {
     ;(this.meta as Record<string, unknown>).interaction =
       value instanceof Map ? Object.fromEntries(value) : value
+    return this
+  }
+
+  glossary(value: GlossaryMeta): this {
+    ;(this.meta as Record<string, unknown>).glossary = value
     return this
   }
 

--- a/apps/core/src/common/response/meta.types.ts
+++ b/apps/core/src/common/response/meta.types.ts
@@ -26,6 +26,14 @@ export const EntryTranslationSchema = z
   })
   .strict()
 
+export const GlossaryMetaSchema = z
+  .object({
+    tags: z
+      .array(z.object({ source: z.string(), translated: z.string() }))
+      .optional(),
+  })
+  .strict()
+
 export const InteractionMetaSchema = z
   .object({
     isLiked: z.boolean().optional(),
@@ -144,6 +152,7 @@ export const BaseResponseMetaSchema = z.object({
     .union([InteractionMetaSchema, z.record(z.string(), InteractionMetaSchema)])
     .optional(),
   enrichments: z.record(z.string().url(), EnrichmentEntrySchema).optional(),
+  glossary: GlossaryMetaSchema.optional(),
 })
 
 export const PostResponseMetaSchema = BaseResponseMetaSchema.extend({
@@ -174,6 +183,7 @@ export type Pagination = z.infer<typeof PaginationSchema>
 export type ArticleTranslation = z.infer<typeof ArticleTranslationSchema>
 export type EntryTranslation = z.infer<typeof EntryTranslationSchema>
 export type InteractionMeta = z.infer<typeof InteractionMetaSchema>
+export type GlossaryMeta = z.infer<typeof GlossaryMetaSchema>
 export type EnrichmentEntry = z.infer<typeof EnrichmentEntrySchema>
 export type RelatedRef = z.infer<typeof RelatedRefSchema>
 export type ArticleRefMap = Record<string, RelatedRef>

--- a/apps/core/src/modules/ai/ai-translation/ai-translation-event-handler.service.ts
+++ b/apps/core/src/modules/ai/ai-translation/ai-translation-event-handler.service.ts
@@ -30,6 +30,10 @@ interface NoteDocumentLike {
   weather?: unknown
 }
 
+interface PostDocumentLike {
+  tags?: unknown
+}
+
 @Injectable()
 export class AiTranslationEventHandlerService {
   private readonly logger = new Logger(AiTranslationEventHandlerService.name)
@@ -207,6 +211,38 @@ export class AiTranslationEventHandlerService {
     } catch (err: any) {
       this.logger.error(`Note entry generation failed: ${err.message}`)
     }
+  }
+
+  @OnEvent(BusinessEvents.POST_CREATE)
+  @OnEvent(BusinessEvents.POST_UPDATE)
+  @OnEvent(BusinessEvents.POST_REPUBLISH)
+  async handlePostTagEntry(event: { id: string }) {
+    if (!(await this.isAutoEntryEnabled())) return
+    if (!event.id) return
+    const post = await this.databaseService.findGlobalById(event.id)
+    if (!post) return
+    const values = this.collectPostTagValues(post.document)
+    if (!values.length) return
+    try {
+      await this.translationEntryService.generateForValues(values)
+    } catch (err: any) {
+      this.logger.error(`Post tag entry generation failed: ${err.message}`)
+    }
+  }
+
+  private collectPostTagValues(
+    doc: unknown,
+  ): Parameters<TranslationEntryService['generateForValues']>[0] {
+    const tags = (doc as PostDocumentLike).tags
+    if (!Array.isArray(tags)) return []
+    return tags
+      .filter((tag): tag is string => typeof tag === 'string' && !!tag.trim())
+      .map((tag) => ({
+        keyPath: 'post.tag' as const,
+        keyType: 'dict' as const,
+        lookupKey: TranslationEntryService.hashSourceText(tag),
+        sourceText: tag,
+      }))
   }
 
   // === Helpers ===

--- a/apps/core/src/modules/ai/ai-translation/ai-translation.repository.ts
+++ b/apps/core/src/modules/ai/ai-translation/ai-translation.repository.ts
@@ -425,6 +425,13 @@ export class TranslationEntryRepository extends BaseRepository {
     super(db)
   }
 
+  async listDistinctPostTags(): Promise<string[]> {
+    const rows = await this.db
+      .selectDistinct({ tag: sql<string>`unnest(${posts.tags})` })
+      .from(posts)
+    return rows.map((row) => row.tag).filter(Boolean)
+  }
+
   async listByBatch(
     lang: string,
     lookups: Array<{

--- a/apps/core/src/modules/ai/ai-translation/lexical-translation-parser.ts
+++ b/apps/core/src/modules/ai/ai-translation/lexical-translation-parser.ts
@@ -146,6 +146,47 @@ function extractPollSegments(
   }
 }
 
+function pushStringProperty(
+  holder: any,
+  property: string,
+  propertySegments: PropertySegment[],
+  counter: { t: number; p: number },
+  ctx: BlockContext,
+): void {
+  const value = holder?.[property]
+  if (typeof value !== 'string' || !value.trim()) return
+  propertySegments.push({
+    id: `p_${counter.p++}`,
+    text: value,
+    node: holder,
+    property,
+    blockId: ctx.blockId,
+    rootIndex: ctx.rootIndex,
+  })
+}
+
+function extractImageSegments(
+  node: any,
+  propertySegments: PropertySegment[],
+  counter: { t: number; p: number },
+  ctx: BlockContext,
+): void {
+  pushStringProperty(node, 'caption', propertySegments, counter, ctx)
+  pushStringProperty(node, 'altText', propertySegments, counter, ctx)
+}
+
+function extractGallerySegments(
+  node: any,
+  propertySegments: PropertySegment[],
+  counter: { t: number; p: number },
+  ctx: BlockContext,
+): void {
+  if (!Array.isArray(node.images)) return
+  for (const image of node.images) {
+    pushStringProperty(image, 'alt', propertySegments, counter, ctx)
+  }
+}
+
 // Registry for node types whose translatable text lives in an opaque payload
 // rather than children/whitelisted properties. `extract` replaces the normal
 // walk for that node; `restore` runs over the whole tree after translations
@@ -174,6 +215,8 @@ const COMPLEX_NODE_EXTRACTORS: Record<string, ComplexNodeExtractor> = {
   },
   [LEXICAL_CONTEXT_MERMAID_TYPE]: { extract: extractMermaidSegments },
   poll: { extract: extractPollSegments },
+  image: { extract: extractImageSegments },
+  gallery: { extract: extractGallerySegments },
 }
 
 function walkNode(

--- a/apps/core/src/modules/ai/ai-translation/strategies/lexical-translation.strategy.ts
+++ b/apps/core/src/modules/ai/ai-translation/strategies/lexical-translation.strategy.ts
@@ -20,7 +20,6 @@ import {
 import { TranslationReviewerService } from '../reviewer.service'
 import {
   decodeTags,
-  encodeTags,
   isMetaFieldUnchanged,
   META_SUBTITLE_KEY,
   META_SUMMARY_KEY,
@@ -443,21 +442,6 @@ export class LexicalTranslationStrategy
       removedMetaKeys.add(META_SUMMARY_KEY)
     }
 
-    if (content.tags?.length) {
-      const encodedTags = encodeTags(content.tags)
-      if (!isMetaFieldUnchanged(oldMetaHashes, 'tags', encodedTags)) {
-        metaUnits.push({
-          id: META_TAGS_KEY,
-          payload: encodedTags,
-          meta: 'meta.tags',
-        })
-      } else if (existing.tags?.length) {
-        allTranslations.set(META_TAGS_KEY, encodeTags(existing.tags))
-      }
-    } else if (oldMetaHashes?.tags || existing.tags?.length) {
-      removedMetaKeys.add(META_TAGS_KEY)
-    }
-
     const totalEntries = contentUnits.length + metaUnits.length
 
     this.logger.log(
@@ -728,14 +712,6 @@ export class LexicalTranslationStrategy
         meta: 'meta.summary',
       })
     }
-    if (content.tags?.length) {
-      units.push({
-        id: META_TAGS_KEY,
-        payload: encodeTags(content.tags),
-        meta: 'meta.tags',
-      })
-    }
-
     return units
   }
 

--- a/apps/core/src/modules/ai/ai-translation/strategies/markdown-translation.strategy.ts
+++ b/apps/core/src/modules/ai/ai-translation/strategies/markdown-translation.strategy.ts
@@ -12,7 +12,6 @@ import {
 import { TranslationReviewerService } from '../reviewer.service'
 import {
   decodeTags,
-  encodeTags,
   META_SUBTITLE_KEY,
   META_SUMMARY_KEY,
   META_TAGS_KEY,
@@ -219,9 +218,6 @@ export class MarkdownTranslationStrategy
     }
     if (initial.summary) {
       fullTranslations[META_SUMMARY_KEY] = initial.summary
-    }
-    if (initial.tags?.length) {
-      fullTranslations[META_TAGS_KEY] = encodeTags(initial.tags)
     }
     for (const paragraph of paragraphs) {
       fullTranslations[paragraph.id] = paragraph.text

--- a/apps/core/src/modules/ai/ai-translation/translation-entry.schema.ts
+++ b/apps/core/src/modules/ai/ai-translation/translation-entry.schema.ts
@@ -7,6 +7,7 @@ const validKeyPaths = [
   'topic.description',
   'note.mood',
   'note.weather',
+  'post.tag',
 ] as const
 
 export const GenerateEntriesSchema = z

--- a/apps/core/src/modules/ai/ai-translation/translation-entry.service.ts
+++ b/apps/core/src/modules/ai/ai-translation/translation-entry.service.ts
@@ -261,6 +261,16 @@ export class TranslationEntryService {
       })
     }
 
+    const tags = await this.entryRepository.listDistinctPostTags()
+    for (const tag of tags) {
+      values.push({
+        keyPath: 'post.tag',
+        keyType: 'dict',
+        lookupKey: TranslationEntryService.hashSourceText(tag),
+        sourceText: tag,
+      })
+    }
+
     return values
   }
 
@@ -525,7 +535,11 @@ export class TranslationEntryService {
   }
 
   private isDictKeyPath(keyPath: TranslationEntryKeyPath): boolean {
-    return keyPath === 'note.mood' || keyPath === 'note.weather'
+    return (
+      keyPath === 'note.mood' ||
+      keyPath === 'note.weather' ||
+      keyPath === 'post.tag'
+    )
   }
 
   private async getCachedDictTranslations(

--- a/apps/core/src/modules/ai/ai-translation/translation-entry.types.ts
+++ b/apps/core/src/modules/ai/ai-translation/translation-entry.types.ts
@@ -3,6 +3,7 @@ export type TranslationEntryKeyPath =
   | 'note.title'
   | 'note.mood'
   | 'note.weather'
+  | 'post.tag'
   | 'topic.name'
   | 'topic.description'
   | 'topic.introduce'

--- a/apps/core/src/modules/ai/prompts/translation-chunk-base.system.md
+++ b/apps/core/src/modules/ai/prompts/translation-chunk-base.system.md
@@ -37,6 +37,7 @@ Do not merely polish or rewrite the source language. The returned natural-langua
 - DO NOT translate segment IDs or keys
 - If title/subtitle/summary/tags keys are present in segments, translate them too
 - For __tags__, preserve the ||| delimiter between tags
+- Segments tagged property.caption / property.altText / property.alt are short figure captions or alt text: translate as captions, keep filenames and product names unchanged
 - Some segment values may be group objects with this shape:
   {"type":"text.group","segments":[{"id":"t_0","text":"part A"},{"id":"t_1","text":"part B"}]}
 - For a group object:

--- a/apps/core/src/modules/category/category.controller.ts
+++ b/apps/core/src/modules/category/category.controller.ts
@@ -24,6 +24,7 @@ import { TranslationEntryService } from '~/modules/ai/ai-translation/translation
 import {
   applyArticleTranslationInPlace,
   applyTranslationEntriesInPlace,
+  buildTagGlossary,
   type EntryMaps,
   type EntryRule,
   TranslationService,
@@ -59,6 +60,26 @@ export class CategoryController {
     private readonly translationService: TranslationService,
     private readonly translationEntryService: TranslationEntryService,
   ) {}
+
+  private batchTagGlossary(
+    lang: string,
+    tags: Iterable<string>,
+  ): Promise<EntryMaps> {
+    const sourceTexts = new Set([...tags].filter(Boolean))
+    return this.translationEntryService.getTranslationsBatch(lang, {
+      dictLookups: sourceTexts.size
+        ? [{ keyPath: 'post.tag', sourceTexts }]
+        : [],
+    })
+  }
+
+  private applyTagGlossary(
+    metaBuilder: MetaObjectBuilder<any>,
+    entryMaps: EntryMaps,
+  ) {
+    const tags = buildTagGlossary(entryMaps)
+    if (tags.length) metaBuilder.glossary({ tags })
+  }
 
   @Get('/')
   async getCategories(
@@ -199,24 +220,32 @@ export class CategoryController {
             publishedOnly: !isAuthenticated,
           })
 
+    const listMetaBuilder = new MetaObjectBuilder().view('card')
+
     if (lang && Array.isArray(result) && result.length) {
-      const entryMaps = await this.translationEntryService.getTranslationsBatch(
-        lang,
-        {
-          entityLookups: [
-            {
-              keyPath: 'category.name',
-              lookupKeys: new Set(result.map((cat: any) => String(cat.id))),
-            },
-          ],
-        },
-      )
-      for (const cat of result as any[]) {
-        applyTranslationEntriesInPlace(cat, entryMaps, CATEGORY_NAME_RULES)
+      if (type === CategoryType.Tag) {
+        const entryMaps = await this.batchTagGlossary(
+          lang,
+          result.map((tag: any) => tag.name),
+        )
+        this.applyTagGlossary(listMetaBuilder, entryMaps)
+      } else {
+        const entryMaps =
+          await this.translationEntryService.getTranslationsBatch(lang, {
+            entityLookups: [
+              {
+                keyPath: 'category.name',
+                lookupKeys: new Set(result.map((cat: any) => String(cat.id))),
+              },
+            ],
+          })
+        for (const cat of result as any[]) {
+          applyTranslationEntriesInPlace(cat, entryMaps, CATEGORY_NAME_RULES)
+        }
       }
     }
 
-    return withMeta(result, new MetaObjectBuilder().view('card').build())
+    return withMeta(result, listMetaBuilder.build())
   }
 
   @Get('/:query')
@@ -260,6 +289,11 @@ export class CategoryController {
           }
         }
         if (titleMeta.size > 0) tagMetaBuilder.translation(titleMeta)
+        const entryMaps = await this.batchTagGlossary(lang, [
+          query,
+          ...data.flatMap((post: any) => post.tags ?? []),
+        ])
+        this.applyTagGlossary(tagMetaBuilder, entryMaps)
       }
       return withMeta({ tag: query, data }, tagMetaBuilder.build())
     }
@@ -299,6 +333,10 @@ export class CategoryController {
         modifiedAt: post.modifiedAt ?? null,
       }))
 
+      const tagNames = new Set<string>([
+        ...(tagsSum ?? []).map((item: any) => item.name),
+        ...children.flatMap((post: any) => post.tags ?? []),
+      ])
       const [entryMaps, { results, meta: titleMeta }] = await Promise.all([
         this.translationEntryService.getTranslationsBatch(lang, {
           entityLookups: [
@@ -307,6 +345,9 @@ export class CategoryController {
               lookupKeys: new Set([String(res.id)]),
             },
           ],
+          dictLookups: tagNames.size
+            ? [{ keyPath: 'post.tag', sourceTexts: tagNames }]
+            : [],
         }),
         articles.length
           ? this.translationService.collectArticleTranslations({
@@ -330,6 +371,7 @@ export class CategoryController {
       }
 
       if (titleMeta.size > 0) metaBuilder.translation(titleMeta)
+      this.applyTagGlossary(metaBuilder, entryMaps)
     }
 
     return withMeta({ ...res, count, children, tagsSum }, metaBuilder.build())

--- a/apps/core/src/modules/post/post.controller.ts
+++ b/apps/core/src/modules/post/post.controller.ts
@@ -22,6 +22,7 @@ import {
   applyTranslationEntriesInPlace,
   type ArticleTranslationInput,
   buildArticleTranslationMeta,
+  buildTagGlossary,
   type EntryMaps,
   type EntryRule,
   TranslationService,
@@ -111,19 +112,36 @@ export class PostController {
     return effectiveN
   }
 
-  private async batchCategoryEntryTranslations(
+  private async batchEntryTranslations(
     lang: string,
-    posts: Array<{ category?: { id: unknown } | null } | null | undefined>,
+    posts: Array<
+      | { category?: { id: unknown } | null; tags?: string[] | null }
+      | null
+      | undefined
+    >,
   ): Promise<EntryMaps> {
     const categoryIds = new Set<string>()
+    const tags = new Set<string>()
     for (const post of posts) {
       if (post?.category?.id) categoryIds.add(String(post.category.id))
+      for (const tag of post?.tags ?? []) tags.add(tag)
     }
     return this.translationEntryService.getTranslationsBatch(lang, {
       entityLookups: categoryIds.size
         ? [{ keyPath: 'category.name', lookupKeys: categoryIds }]
         : [],
+      dictLookups: tags.size
+        ? [{ keyPath: 'post.tag', sourceTexts: tags }]
+        : [],
     })
+  }
+
+  private applyTagGlossary(
+    metaBuilder: MetaObjectBuilder<any>,
+    entryMaps: EntryMaps,
+  ) {
+    const tags = buildTagGlossary(entryMaps)
+    if (tags.length) metaBuilder.glossary({ tags })
   }
 
   @Get('/')
@@ -178,7 +196,7 @@ export class PostController {
           targetLang: lang,
           fields: ['title', 'text', 'content', 'contentFormat'],
         }),
-        this.batchCategoryEntryTranslations(lang ?? '', res.data),
+        this.batchEntryTranslations(lang ?? '', res.data),
       ])
 
     for (const doc of res.data) {
@@ -226,6 +244,7 @@ export class PostController {
     if (translationMeta.size > 0) {
       metaBuilder.translation(translationMeta)
     }
+    if (lang) this.applyTagGlossary(metaBuilder, entryMaps)
 
     return withMeta(res.data, metaBuilder.build())
   }
@@ -300,7 +319,7 @@ export class PostController {
           tags: doc.tags,
         },
       }),
-      this.batchCategoryEntryTranslations(lang ?? '', [doc]),
+      this.batchEntryTranslations(lang ?? '', [doc]),
     ])
 
     applyArticleTranslationInPlace(
@@ -349,6 +368,7 @@ export class PostController {
       ],
     ])
     metaBuilder.translation(translationMap)
+    if (lang) this.applyTagGlossary(metaBuilder, entryMaps)
 
     if (skills.length > 0) metaBuilder.skills(skills)
 
@@ -414,7 +434,7 @@ export class PostController {
         },
       }),
       this.translationService.getCachedTitles(relatedIds, lang),
-      this.batchCategoryEntryTranslations(lang ?? '', [postDocument]),
+      this.batchEntryTranslations(lang ?? '', [postDocument]),
       this.aiInsightsService
         .hasInsightsInLang(postDocument.id, insightsLang)
         .catch(() => false),
@@ -499,6 +519,7 @@ export class PostController {
       ],
     ])
     metaBuilder.translation(translationMap)
+    if (lang) this.applyTagGlossary(metaBuilder, entryMaps)
 
     if (skills.length > 0) metaBuilder.skills(skills)
 

--- a/apps/core/src/processors/helper/helper.lexical.service.ts
+++ b/apps/core/src/processors/helper/helper.lexical.service.ts
@@ -141,6 +141,22 @@ export class LexicalService {
       segments.push(node.diagram)
     }
 
+    if (node.type === 'image') {
+      for (const field of ['caption', 'altText']) {
+        if (typeof node[field] === 'string' && node[field].trim()) {
+          segments.push(node[field])
+        }
+      }
+    }
+
+    if (node.type === 'gallery' && Array.isArray(node.images)) {
+      for (const image of node.images) {
+        if (typeof image?.alt === 'string' && image.alt.trim()) {
+          segments.push(image.alt)
+        }
+      }
+    }
+
     if (node.type === 'poll') {
       if (typeof node.question === 'string' && node.question.trim()) {
         segments.push(node.question)

--- a/apps/core/src/processors/helper/helper.translation.service.ts
+++ b/apps/core/src/processors/helper/helper.translation.service.ts
@@ -72,10 +72,17 @@ const ALL_TRANSLATABLE_FIELDS: readonly ArticleTranslatableField[] = [
   'text',
   'subtitle',
   'summary',
-  'tags',
   'content',
   'contentFormat',
 ]
+
+export type TagGlossaryPair = { source: string; translated: string }
+
+export function buildTagGlossary(maps: EntryMaps): TagGlossaryPair[] {
+  const dictMap = maps.dictMaps.get('post.tag')
+  if (!dictMap) return []
+  return [...dictMap].map(([source, translated]) => ({ source, translated }))
+}
 
 export function buildArticleTranslationMeta(
   result: TranslationResult,
@@ -240,7 +247,7 @@ export class TranslationService {
         text: translation.text,
         subtitle: translation.subtitle ?? originalData.subtitle,
         summary: translation.summary ?? originalData.summary,
-        tags: translation.tags ?? originalData.tags,
+        tags: originalData.tags,
         isTranslated: true,
         sourceLang: translation.sourceLang,
         translationMeta: {
@@ -352,7 +359,6 @@ export class TranslationService {
       'text',
       'subtitle',
       'summary',
-      'tags',
       'content',
       'translationMeta',
     ]
@@ -405,7 +411,7 @@ export class TranslationService {
                 text: translation.text,
                 subtitle: translation.subtitle ?? article.subtitle,
                 summary: translation.summary ?? article.summary,
-                tags: translation.tags ?? article.tags,
+                tags: article.tags,
                 content: translation.content ?? undefined,
                 contentFormat: translation.contentFormat ?? undefined,
                 isTranslated: true,

--- a/apps/core/test/src/modules/ai/ai-translation-event-handler.service.spec.ts
+++ b/apps/core/test/src/modules/ai/ai-translation-event-handler.service.spec.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import { AiTranslationEventHandlerService } from '~/modules/ai/ai-translation/ai-translation-event-handler.service'
+import { TranslationEntryService } from '~/modules/ai/ai-translation/translation-entry.service'
+
+const createHandler = (options: { autoEntry?: boolean } = {}) => {
+  const configService = {
+    get: vi.fn().mockResolvedValue({
+      enableTranslation: options.autoEntry ?? true,
+      enableAutoGenerateTranslation: options.autoEntry ?? true,
+    }),
+  }
+  const databaseService = {
+    findGlobalById: vi.fn().mockResolvedValue({
+      type: 'Post',
+      document: { id: 'post-1', tags: ['机器学习', '', 'Rust'] },
+    }),
+  }
+  const translationEntryService = {
+    generateForValues: vi.fn().mockResolvedValue({ created: 0, skipped: 0 }),
+  }
+  const handler = new AiTranslationEventHandlerService(
+    {} as any,
+    configService as any,
+    databaseService as any,
+    translationEntryService as any,
+  )
+  return { handler, databaseService, translationEntryService }
+}
+
+describe('AiTranslationEventHandlerService post tags', () => {
+  it('generates post.tag dictionary entries for every non-empty tag', async () => {
+    const { handler, translationEntryService } = createHandler()
+
+    await handler.handlePostTagEntry({ id: 'post-1' })
+
+    expect(translationEntryService.generateForValues).toHaveBeenCalledWith([
+      {
+        keyPath: 'post.tag',
+        keyType: 'dict',
+        lookupKey: TranslationEntryService.hashSourceText('机器学习'),
+        sourceText: '机器学习',
+      },
+      {
+        keyPath: 'post.tag',
+        keyType: 'dict',
+        lookupKey: TranslationEntryService.hashSourceText('Rust'),
+        sourceText: 'Rust',
+      },
+    ])
+  })
+
+  it('does nothing when auto entry generation is disabled', async () => {
+    const { handler, databaseService, translationEntryService } = createHandler(
+      { autoEntry: false },
+    )
+
+    await handler.handlePostTagEntry({ id: 'post-1' })
+
+    expect(databaseService.findGlobalById).not.toHaveBeenCalled()
+    expect(translationEntryService.generateForValues).not.toHaveBeenCalled()
+  })
+
+  it('skips posts without tags', async () => {
+    const { handler, databaseService, translationEntryService } =
+      createHandler()
+    databaseService.findGlobalById.mockResolvedValue({
+      type: 'Post',
+      document: { id: 'post-1', tags: [] },
+    })
+
+    await handler.handlePostTagEntry({ id: 'post-1' })
+
+    expect(translationEntryService.generateForValues).not.toHaveBeenCalled()
+  })
+})

--- a/apps/core/test/src/modules/ai/lexical-translation-parser.spec.ts
+++ b/apps/core/test/src/modules/ai/lexical-translation-parser.spec.ts
@@ -1453,4 +1453,108 @@ describe('lexical-translation-parser', () => {
       expect(propertySegments[0].rootIndex).toBe(1)
     })
   })
+
+  describe('image and gallery caption translation', () => {
+    const imageNode = (payload: {
+      caption?: string
+      altText?: string
+      blockId?: string
+    }) => ({
+      type: 'image',
+      version: 1,
+      src: 'https://example.com/a.png',
+      altText: payload.altText ?? '',
+      width: 800,
+      height: 600,
+      caption: payload.caption,
+      ...(payload.blockId && { $: { blockId: payload.blockId } }),
+    })
+
+    it('parses image → caption + altText property segments, nothing else', () => {
+      const json = makeEditorState([
+        paragraph(textNode('intro')),
+        imageNode({
+          caption: '图一：ChimeraX 渲染',
+          altText: '蛋白质结构',
+          blockId: 'img-block',
+        }),
+      ])
+      const { segments, propertySegments } = parseLexicalForTranslation(json)
+
+      expect(segments).toHaveLength(1)
+      expect(propertySegments).toHaveLength(2)
+      const [caption, alt] = propertySegments
+      expect(caption.text).toBe('图一：ChimeraX 渲染')
+      expect(caption.property).toBe('caption')
+      expect(caption.blockId).toBe('img-block')
+      expect(caption.rootIndex).toBe(1)
+      expect(alt.text).toBe('蛋白质结构')
+      expect(alt.property).toBe('altText')
+    })
+
+    it('skips empty caption and altText', () => {
+      const json = makeEditorState([imageNode({ caption: '   ', altText: '' })])
+      const { segments, propertySegments } = parseLexicalForTranslation(json)
+      expect(segments).toHaveLength(0)
+      expect(propertySegments).toHaveLength(0)
+    })
+
+    it('round-trip: translated caption written back, src preserved', () => {
+      const json = makeEditorState([
+        imageNode({ caption: '图一', altText: '结构' }),
+      ])
+      const result = parseLexicalForTranslation(json)
+      const translations = new Map<string, string>()
+      for (const prop of result.propertySegments) {
+        translations.set(
+          prop.id,
+          prop.property === 'caption' ? 'Figure 1' : 'Structure',
+        )
+      }
+      const restored = JSON.parse(
+        restoreLexicalTranslation(result, translations),
+      )
+      const node = restored.root.children[0]
+      expect(node.caption).toBe('Figure 1')
+      expect(node.altText).toBe('Structure')
+      expect(node.src).toBe('https://example.com/a.png')
+      expect(node.width).toBe(800)
+    })
+
+    it('parses gallery → one alt segment per image with alt', () => {
+      const json = makeEditorState([
+        {
+          type: 'gallery',
+          version: 1,
+          layout: 'grid',
+          images: [
+            { src: 'https://example.com/1.png', alt: '第一张' },
+            { src: 'https://example.com/2.png' },
+            { src: 'https://example.com/3.png', alt: '第三张' },
+          ],
+          $: { blockId: 'gal-block' },
+        },
+      ])
+      const result = parseLexicalForTranslation(json)
+      expect(result.segments).toHaveLength(0)
+      expect(result.propertySegments.map((p) => p.text)).toEqual([
+        '第一张',
+        '第三张',
+      ])
+      expect(result.propertySegments[0].property).toBe('alt')
+      expect(result.propertySegments[0].blockId).toBe('gal-block')
+
+      const translations = new Map(
+        result.propertySegments.map((p, i) => [p.id, `Image ${i + 1}`]),
+      )
+      const restored = JSON.parse(
+        restoreLexicalTranslation(result, translations),
+      )
+      expect(restored.root.children[0].images.map((i: any) => i.alt)).toEqual([
+        'Image 1',
+        undefined,
+        'Image 2',
+      ])
+    })
+  })
 })

--- a/apps/core/test/src/modules/ai/translation-entry.service.spec.ts
+++ b/apps/core/test/src/modules/ai/translation-entry.service.spec.ts
@@ -6,6 +6,7 @@ import { TranslationEntryService } from '~/modules/ai/ai-translation/translation
 
 const createService = () => {
   const repository = createPgRepositoryMock<TranslationEntryRepository>()
+  repository.listDistinctPostTags.mockResolvedValue([])
   const categoryService = { findAllCategory: vi.fn().mockResolvedValue([]) }
   const noteService = {
     findRecent: vi.fn().mockResolvedValue([]),
@@ -98,6 +99,32 @@ describe('TranslationEntryService', () => {
       .map((v: any) => v.sourceText)
     expect(moods.sort()).toEqual(['happy', 'sad'])
     expect(weathers).toEqual(['sunny'])
+  })
+
+  it('seeds post.tag dictionary entries from distinct post tags', async () => {
+    const { repository, service } = createService()
+    repository.listDistinctPostTags.mockResolvedValue(['机器学习', 'Rust'])
+
+    const values = await service.collectSourceValues()
+
+    const tags = values.filter((v) => v.keyPath === 'post.tag')
+    expect(tags.map((v) => v.sourceText)).toEqual(['机器学习', 'Rust'])
+    expect(tags.every((v) => v.keyType === 'dict')).toBe(true)
+    expect(tags[0].lookupKey).toBe(
+      TranslationEntryService.hashSourceText('机器学习'),
+    )
+  })
+
+  it('serves post.tag translations from the dictionary cache', async () => {
+    const { redis, repository, service } = createService()
+    redis.hmget.mockResolvedValue(['Machine Learning'])
+
+    const result = await service.getTranslationsForDict('post.tag', 'en', [
+      '机器学习',
+    ])
+
+    expect(repository.listByBatch).not.toHaveBeenCalled()
+    expect(result.get('机器学习')).toBe('Machine Learning')
   })
 
   it('updates dictionary cache after PG dictionary entry updates', async () => {

--- a/apps/core/test/src/processors/helper/helper.lexical.service.spec.ts
+++ b/apps/core/test/src/processors/helper/helper.lexical.service.spec.ts
@@ -1018,6 +1018,35 @@ describe('LexicalService', () => {
       expect(updatedBlock.text).toContain('Afternoon')
       expect(originalBlock.fingerprint).not.toBe(updatedBlock.fingerprint)
     })
+
+    it('changes the fingerprint when an image caption or gallery alt changes', () => {
+      const image = (caption: string) => ({
+        type: 'image',
+        version: 1,
+        src: 'https://example.com/a.png',
+        altText: 'alt',
+        caption,
+        $: { blockId: 'img0001' },
+      })
+      const gallery = (alt: string) => ({
+        type: 'gallery',
+        version: 1,
+        images: [{ src: 'https://example.com/1.png', alt }],
+        $: { blockId: 'gal0001' },
+      })
+
+      const [img1, gal1] = service.extractRootBlocks(
+        makeEditorState([image('图一'), gallery('第一张')]),
+      )
+      const [img2, gal2] = service.extractRootBlocks(
+        makeEditorState([image('图二'), gallery('第二张')]),
+      )
+
+      expect(img1.text).toContain('图一')
+      expect(img1.fingerprint).not.toBe(img2.fingerprint)
+      expect(gal1.text).toContain('第一张')
+      expect(gal1.fingerprint).not.toBe(gal2.fingerprint)
+    })
   })
 
   // ── Error handling ──

--- a/apps/core/test/src/processors/helper/helper.translation.service.spec.ts
+++ b/apps/core/test/src/processors/helper/helper.translation.service.spec.ts
@@ -11,6 +11,7 @@ import {
   applyArticleTranslationInPlace,
   applyTranslationEntriesInPlace,
   buildArticleTranslationMeta,
+  buildTagGlossary,
   TranslationService,
 } from '~/processors/helper/helper.translation.service'
 
@@ -152,7 +153,7 @@ describe('TranslationService', () => {
         text: 'Translated Content',
         subtitle: 'Translated Subtitle',
         summary: 'Translated Summary',
-        tags: ['translated-tag'],
+        tags: ['tag1', 'tag2'],
         isTranslated: true,
         sourceLang: 'zh',
         translationMeta: {
@@ -410,7 +411,7 @@ describe('TranslationService', () => {
       expect(translated.text).toBe('Translated Text 1')
       expect((translated as any).subtitle).toBe('Translated Subtitle 1')
       expect(translated.summary).toBe('Translated Summary 1')
-      expect(translated.tags).toEqual(['translated-a'])
+      expect(translated.tags).toBeUndefined()
       expect(translated.translationMeta).toEqual({
         sourceLang: 'zh',
         targetLang: 'en',
@@ -450,7 +451,7 @@ describe('TranslationService', () => {
       const translated = result.get('1')!
       expect((translated as any).subtitle).toBe('Subtitle 1')
       expect(translated.summary).toBe('Summary 1')
-      expect(translated.tags).toEqual(['a'])
+      expect(translated.tags).toBeUndefined()
     })
 
     it('should return original data when service throws error', async () => {
@@ -884,7 +885,7 @@ describe('applyArticleTranslationInPlace', () => {
     expect(target.text).toBe('Original Text')
   })
 
-  it('translated result overwrites all seven fields by default', () => {
+  it('translated result overwrites all fields except tags by default', () => {
     const target: any = {
       title: 'O',
       text: 'O',
@@ -901,7 +902,7 @@ describe('applyArticleTranslationInPlace', () => {
     expect(target.text).toBe('Translated Text')
     expect(target.subtitle).toBe('Translated Subtitle')
     expect(target.summary).toBe('Translated Summary')
-    expect(target.tags).toEqual(['tag-en'])
+    expect(target.tags).toEqual(['orig'])
     expect(target.content).toBe('Translated Content')
     expect(target.contentFormat).toBe('markdown')
   })
@@ -1053,5 +1054,25 @@ describe('applyTranslationEntriesInPlace', () => {
 
     expect(target.topic.name).toBe('NewName')
     expect(target.mood).toBe('Fröhlich')
+  })
+})
+
+describe('buildTagGlossary', () => {
+  it('returns source/translated pairs from the post.tag dictionary map', () => {
+    const maps = {
+      entityMaps: new Map(),
+      dictMaps: new Map([
+        ['post.tag' as const, new Map([['机器学习', 'Machine Learning']])],
+      ]),
+    }
+    expect(buildTagGlossary(maps)).toEqual([
+      { source: '机器学习', translated: 'Machine Learning' },
+    ])
+  })
+
+  it('returns an empty list when no post.tag map is present', () => {
+    expect(
+      buildTagGlossary({ entityMaps: new Map(), dictMaps: new Map() }),
+    ).toEqual([])
   })
 })

--- a/docs/superpowers/specs/2026-09-02-tag-glossary-and-image-caption-translation-design.md
+++ b/docs/superpowers/specs/2026-09-02-tag-glossary-and-image-caption-translation-design.md
@@ -1,0 +1,95 @@
+# Tag glossary translation + Lexical image caption translation
+
+Issue: mx-space/core#2815 (Linear MXD-242). Two independent gaps in the AI translation subsystem:
+
+1. Post tags are translated per article (`ai_translations.tags`), so the same tag gets different translations across posts, tag pages and the tag cloud stay untranslated, and the frontend links a translated tag name back to a source-name route and breaks.
+2. Lexical `image` / `gallery` captions are never translated because the whole node type sits in `LEXICAL_CONTEXT_SKIP_BLOCKS`.
+
+## Part 1 — Tags move into the translation-entry glossary
+
+### Model
+
+- New `TranslationEntryKeyPath`: `post.tag`, `keyType: 'dict'`, `lookupKey = hashSourceText(tag)`, same shape as `note.mood`.
+- Add `post.tag` to `validKeyPaths` in `translation-entry.schema.ts` so admin generate/query/update endpoints accept it.
+- No DB migration: `translation_entries` already stores arbitrary `keyPath` strings.
+
+### Collection (when entries get generated)
+
+- `AiTranslationEventHandlerService`: subscribe `POST_CREATE`, `POST_UPDATE`, `POST_REPUBLISH`. Payload is `{ id }`; load the post, map `tags[]` to dict values, call `generateForValues`. Gated by `isAutoEntryEnabled()` like notes. `generateForValues` already skips existing entries, so re-saving a post costs zero AI calls for known tags.
+- `collectSourceValues()` (admin full regeneration): add distinct tags via the existing `unnest(posts.tags)` query in `post.repository.ts`.
+- No new task type and no publish-job coupling. The publish job's `aiResources: ['translation']` stays article-only.
+
+### Per-article translation stops translating tags
+
+- Remove `tags` from the article translation prompt segments. `ArticleContent` hashing keeps `tags` so existing translations are not all marked stale. The `ai_translations.tags` column stays and now receives the source tags; it is never read at serving time. A follow-up contract migration can drop it.
+- `helper.translation.service.ts`: drop `'tags'` from `ALL_TRANSLATABLE_FIELDS` and the in-place apply paths so `data.tags` is always the source string array.
+
+### Serving
+
+`data.tags` is never overwritten. Translations ride in a new top-level meta field, a sibling of `translation` / `interaction`:
+
+```ts
+GlossaryMetaSchema = z.object({
+  tags: z.array(z.object({ source: z.string(), translated: z.string() })).optional(),
+}).strict()
+
+BaseResponseMetaSchema += { glossary: GlossaryMetaSchema.optional() }
+```
+
+Array of pairs, not a keyed map: source tags are free text, and the response case transform would mangle them as object keys (`MachineLearning` -> `machine_learning`). Pairs need no `@BypassCaseTransform` and no change to the case-transform pipeline. Only tags that have an entry for the requested lang appear; the frontend falls back to the source name.
+
+`MetaObjectBuilder.glossary(value: GlossaryMeta)` sets `meta.glossary`. Works the same for detail responses (`meta.translation` is an object) and list responses (`meta.translation` is a per-id map) because it never touches `translation`.
+
+Producers (all already inject `TranslationEntryService` and take `@Lang()`):
+
+- `post.controller.ts`: list, detail, latest, by-id/slug. Collect the union of `tags` across the returned posts, one `getTranslationsBatch` call with `dictLookups: [{ keyPath: 'post.tag', sourceTexts }]`, emit one shared `meta.glossary.tags` for the whole response.
+- `category.controller.ts` `?tag=true` route: same for the returned posts plus the queried tag.
+- Category list with `type=tag`, category detail (`tagsSum` + children), and the `?tag=true` route.
+- Not wired: `/aggregate` titled items and `/search` (neither renders tags on the frontend today, and search returns a legacy `{ data, pagination }` object without a meta envelope). Add when a consumer needs them.
+
+`buildTagGlossary(entryMaps)` in `helper.translation.service.ts` turns the `post.tag` dict map into pairs; each controller adds `post.tag` to the `getTranslationsBatch` call it already makes.
+
+### Frontend (Yohaku, separate PR)
+
+- `PostMetaBar`, `TagDetailModal`, `posts/tag/[name]` header, mobile taxonomy rows: build a `Map` from `meta.glossary.tags`, display `map.get(tag) ?? tag`, link and fetch with the source `tag`.
+- api-client: add optional `glossary` to the base meta type.
+
+### Cache
+
+Dict entries are Redis-cached 7 days per `(keyPath, lang)`; `post.tag` reuses that. Entry update/delete via admin already invalidates.
+
+## Part 2 — Image and gallery caption translation
+
+### Parser change
+
+`image` and `gallery` join `COMPLEX_NODE_EXTRACTORS` in `lexical-translation-parser.ts`, the same registry `poll` uses. The extractor runs before the blacklist skip, so the node still never descends into children, and the whitelist util is untouched.
+
+| nodeType | segments emitted |
+| --- | --- |
+| `image` | `caption`, `altText` (each a string prop on the node) |
+| `gallery` | `images[i].alt` (gallery items carry `alt`, no `caption`) |
+
+Property segments point `node` at the holder object (the image node, or the gallery item), so `restoreLexicalTranslation` writes back with no new branch. Empty strings are skipped. `altText` is included because it is user-visible via screen readers and the `alt` attribute.
+
+### Staleness
+
+Block fingerprints come from `extractBlockText` in `helper.lexical.service.ts`, which only reads known text-bearing fields. Image `caption` / `altText` and gallery `alt` are added there so a caption edit marks the block stale.
+
+### Prompt
+
+`translation-chunk-base.system.md` already handles property segments generically (details summary, ruby reading). Add one line: `image.caption` / `image.altText` / `gallery.alts` segments are short figure captions; translate as captions, keep filenames and product names.
+
+## Testing
+
+- `translation-entry.service.spec`: `post.tag` values dedupe by hash, skip existing, generate for configured langs.
+- `ai-translation-event-handler.spec`: POST_CREATE with tags calls `generateForValues` with `post.tag` dict values; disabled flag → no call.
+- `post.controller` e2e: `?lang=en` returns `data.tags` unchanged and `meta.glossary.tags` pairs; missing entries omitted; no `lang` -> no `glossary`.
+- `lexical-translation-parser.spec`: image with caption+altText yields two property segments and no child segments; gallery yields per-index alt segments; restore round-trips; image inside `SKIP_BLOCKS` still does not emit text segments from children.
+- Existing article translation specs updated for `tags` removal from the prompt payload and hash.
+
+## Out of scope
+
+- Making tags first-class entities.
+- Dropping `ai_translations.tags` column (contract step, later migration).
+- Video / link-card / embed titles.
+- Backfilling `post.tag` entries automatically on deploy; the owner runs the existing admin "generate entries" action once.

--- a/packages/api-client/models/base.ts
+++ b/packages/api-client/models/base.ts
@@ -103,12 +103,22 @@ export interface TtsMeta {
   updatedAt?: string | null
 }
 
+export interface TagGlossaryPair {
+  source: string
+  translated: string
+}
+
+export interface GlossaryMeta {
+  tags?: TagGlossaryPair[]
+}
+
 export interface BaseResponseMeta {
   pagination?: PaginationMeta
   view?: string
   translation?: EntryTranslation | Record<string, EntryTranslation>
   interaction?: InteractionMeta | Record<string, InteractionMeta>
   enrichments?: Record<string, EnrichmentResult>
+  glossary?: GlossaryMeta
 }
 
 export interface PostResponseMeta extends BaseResponseMeta {


### PR DESCRIPTION
## Summary

Fixes #2815.

- **Tags via glossary**: new `post.tag` dict keyPath in translation entries. Auto-collected on `POST_CREATE/UPDATE/REPUBLISH` (gated by `enableAutoGenerateTranslation`), full backfill through the existing admin "generate entries" action. Per-article AI translation no longer translates tags; `data.tags` always carries the source names.
- **Delivery**: new `meta.glossary.tags: [{ source, translated }]` on post list/detail, category tag list, category detail (`tagsSum` + children) and the `?tag=true` route. Pairs instead of a keyed map so free-text tag names survive the response case transform. `api-client` base meta type updated.
- **Image captions**: `image` (`caption`, `altText`) and `gallery` (`images[].alt`) join `COMPLEX_NODE_EXTRACTORS` in the Lexical translation parser, and block fingerprints include them so caption edits mark the block stale.

Design: `docs/superpowers/specs/2026-09-02-tag-glossary-and-image-caption-translation-design.md`.

Not wired: `/aggregate` titled items and `/search` (no consumer renders tags there). `ai_translations.tags` column is kept, now holding source tags; can be dropped in a later contract migration.

## Test plan

- [x] `lexical-translation-parser.spec`: image/gallery segments, round-trip restore
- [x] `helper.lexical.service.spec`: caption/alt change fingerprint
- [x] `translation-entry.service.spec`, new `ai-translation-event-handler.service.spec`, `helper.translation.service.spec` (`buildTagGlossary`, tags untouched by article translation)
- [x] `tsc --noEmit`, eslint on changed files
- [ ] Frontend PR (Yohaku) reads `meta.glossary.tags`

https://claude.ai/code/session_01EMxdDyw65qUBDpRERXqp3y
